### PR TITLE
Add env subcommand for environment variable validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,9 @@ preflight/
 - Use table-driven tests where appropriate
 - Mock external dependencies (exec, filesystem, env)
 - Aim for high coverage on pkg/* code
+
+## Pull Requests
+
+- Do NOT add "Test plan" sections to PR descriptions
+- Run tests yourself before opening PR
+- If manual testing is needed, tell the user how to test

--- a/README.md
+++ b/README.md
@@ -98,9 +98,37 @@ preflight cmd java --version-cmd "-version"     # runs: java -version
 - `--match` - Regex pattern to match against version output
 - `--version-cmd` - Override the default `--version` argument
 
+### `preflight env`
+
+Validates environment variables exist and match requirements. By default, the variable must exist and be non-empty.
+
+```sh
+# Check if DATABASE_URL exists and is non-empty (default)
+preflight env DATABASE_URL
+
+# Allow empty values (just check if defined)
+preflight env DATABASE_URL --required
+
+# Match against regex pattern
+preflight env DATABASE_URL --match '^postgres://'
+
+# Require exact value
+preflight env NODE_ENV --exact production
+
+# Hide sensitive values in output
+preflight env API_KEY --hide-value              # shows: [hidden]
+preflight env API_KEY --mask-value              # shows: sk-•••xyz
+```
+
+**Flags:**
+- `--required` - Fail if not set (allows empty values)
+- `--match` - Regex pattern to match against value
+- `--exact` - Exact value required
+- `--hide-value` - Don't show value in output
+- `--mask-value` - Show first/last 3 chars only
+
 ### Coming Soon
 
-- `preflight env` - Validate environment variables
 - `preflight file` - Check files and directories
 
 ## Development

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/vertti/preflight/pkg/check"
 	"github.com/vertti/preflight/pkg/cmdcheck"
+	"github.com/vertti/preflight/pkg/envcheck"
 	"github.com/vertti/preflight/pkg/version"
 )
 
@@ -31,21 +32,45 @@ var cmdCmd = &cobra.Command{
 	RunE:  runCmdCheck,
 }
 
+var envCmd = &cobra.Command{
+	Use:   "env <variable>",
+	Short: "Check that an environment variable is set",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runEnvCheck,
+}
+
 var (
+	// cmd flags
 	minVersion   string
 	maxVersion   string
 	exactVersion string
 	matchPattern string
 	versionCmd   string
+
+	// env flags
+	envRequired  bool
+	envMatch     string
+	envExact     string
+	envHideValue bool
+	envMaskValue bool
 )
 
 func init() {
+	// cmd subcommand
 	cmdCmd.Flags().StringVar(&minVersion, "min", "", "minimum version required (inclusive)")
 	cmdCmd.Flags().StringVar(&maxVersion, "max", "", "maximum version allowed (exclusive)")
 	cmdCmd.Flags().StringVar(&exactVersion, "exact", "", "exact version required")
 	cmdCmd.Flags().StringVar(&matchPattern, "match", "", "regex pattern to match against version output")
 	cmdCmd.Flags().StringVar(&versionCmd, "version-cmd", "--version", "command to get version")
 	rootCmd.AddCommand(cmdCmd)
+
+	// env subcommand
+	envCmd.Flags().BoolVar(&envRequired, "required", false, "fail if not set (allows empty)")
+	envCmd.Flags().StringVar(&envMatch, "match", "", "regex pattern to match value")
+	envCmd.Flags().StringVar(&envExact, "exact", "", "exact value required")
+	envCmd.Flags().BoolVar(&envHideValue, "hide-value", false, "don't show value in output")
+	envCmd.Flags().BoolVar(&envMaskValue, "mask-value", false, "show masked value (first/last 3 chars)")
+	rootCmd.AddCommand(envCmd)
 }
 
 func runCmdCheck(cmd *cobra.Command, args []string) error {
@@ -93,6 +118,28 @@ func runCmdCheck(cmd *cobra.Command, args []string) error {
 
 func parseVersionArgs(s string) []string {
 	return strings.Fields(s)
+}
+
+func runEnvCheck(cmd *cobra.Command, args []string) error {
+	varName := args[0]
+
+	c := &envcheck.Check{
+		Name:      varName,
+		Required:  envRequired,
+		Match:     envMatch,
+		Exact:     envExact,
+		HideValue: envHideValue,
+		MaskValue: envMaskValue,
+		Getter:    &envcheck.RealEnvGetter{},
+	}
+
+	result := c.Run()
+	printResult(result)
+
+	if !result.OK() {
+		os.Exit(1)
+	}
+	return nil
 }
 
 func printResult(r check.Result) {

--- a/pkg/envcheck/check_test.go
+++ b/pkg/envcheck/check_test.go
@@ -1,0 +1,204 @@
+package envcheck
+
+import (
+	"testing"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+func TestEnvCheck_Default_Undefined(t *testing.T) {
+	c := &Check{
+		Name:   "MISSING_VAR",
+		Getter: &MockEnvGetter{Vars: map[string]string{}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusFail {
+		t.Errorf("Status = %v, want %v", result.Status, check.StatusFail)
+	}
+}
+
+func TestEnvCheck_Default_Empty(t *testing.T) {
+	c := &Check{
+		Name:   "EMPTY_VAR",
+		Getter: &MockEnvGetter{Vars: map[string]string{"EMPTY_VAR": ""}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusFail {
+		t.Errorf("Status = %v, want %v", result.Status, check.StatusFail)
+	}
+}
+
+func TestEnvCheck_Default_NonEmpty(t *testing.T) {
+	c := &Check{
+		Name:   "MY_VAR",
+		Getter: &MockEnvGetter{Vars: map[string]string{"MY_VAR": "some_value"}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusOK {
+		t.Errorf("Status = %v, want %v", result.Status, check.StatusOK)
+	}
+}
+
+func TestEnvCheck_Required_Empty(t *testing.T) {
+	c := &Check{
+		Name:     "EMPTY_VAR",
+		Required: true,
+		Getter:   &MockEnvGetter{Vars: map[string]string{"EMPTY_VAR": ""}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusOK {
+		t.Errorf("Status = %v, want %v (--required allows empty)", result.Status, check.StatusOK)
+	}
+}
+
+func TestEnvCheck_Required_Undefined(t *testing.T) {
+	c := &Check{
+		Name:     "MISSING_VAR",
+		Required: true,
+		Getter:   &MockEnvGetter{Vars: map[string]string{}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusFail {
+		t.Errorf("Status = %v, want %v", result.Status, check.StatusFail)
+	}
+}
+
+func TestEnvCheck_Match_Pass(t *testing.T) {
+	c := &Check{
+		Name:   "DATABASE_URL",
+		Match:  `^postgres://`,
+		Getter: &MockEnvGetter{Vars: map[string]string{"DATABASE_URL": "postgres://localhost:5432/db"}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusOK {
+		t.Errorf("Status = %v, want %v", result.Status, check.StatusOK)
+	}
+}
+
+func TestEnvCheck_Match_Fail(t *testing.T) {
+	c := &Check{
+		Name:   "DATABASE_URL",
+		Match:  `^postgres://`,
+		Getter: &MockEnvGetter{Vars: map[string]string{"DATABASE_URL": "mysql://localhost:3306/db"}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusFail {
+		t.Errorf("Status = %v, want %v", result.Status, check.StatusFail)
+	}
+}
+
+func TestEnvCheck_Exact_Pass(t *testing.T) {
+	c := &Check{
+		Name:   "NODE_ENV",
+		Exact:  "production",
+		Getter: &MockEnvGetter{Vars: map[string]string{"NODE_ENV": "production"}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusOK {
+		t.Errorf("Status = %v, want %v", result.Status, check.StatusOK)
+	}
+}
+
+func TestEnvCheck_Exact_Fail(t *testing.T) {
+	c := &Check{
+		Name:   "NODE_ENV",
+		Exact:  "production",
+		Getter: &MockEnvGetter{Vars: map[string]string{"NODE_ENV": "development"}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusFail {
+		t.Errorf("Status = %v, want %v", result.Status, check.StatusFail)
+	}
+}
+
+func TestEnvCheck_MaskValue(t *testing.T) {
+	c := &Check{
+		Name:      "API_KEY",
+		MaskValue: true,
+		Getter:    &MockEnvGetter{Vars: map[string]string{"API_KEY": "sk-secret-key-xyz"}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusOK {
+		t.Errorf("Status = %v, want %v", result.Status, check.StatusOK)
+	}
+
+	// Check that value is masked in details
+	found := false
+	for _, d := range result.Details {
+		if d == "value: sk-•••xyz" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected masked value in details, got: %v", result.Details)
+	}
+}
+
+func TestEnvCheck_HideValue(t *testing.T) {
+	c := &Check{
+		Name:      "SECRET",
+		HideValue: true,
+		Getter:    &MockEnvGetter{Vars: map[string]string{"SECRET": "super-secret"}},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusOK {
+		t.Errorf("Status = %v, want %v", result.Status, check.StatusOK)
+	}
+
+	// Check that value is hidden in details
+	found := false
+	for _, d := range result.Details {
+		if d == "value: [hidden]" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected hidden value in details, got: %v", result.Details)
+	}
+}
+
+func TestEnvCheck_MaskValue_Short(t *testing.T) {
+	c := &Check{
+		Name:      "SHORT",
+		MaskValue: true,
+		Getter:    &MockEnvGetter{Vars: map[string]string{"SHORT": "abc"}},
+	}
+
+	result := c.Run()
+
+	// Short values should be fully masked
+	found := false
+	for _, d := range result.Details {
+		if d == "value: •••" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Expected fully masked short value, got: %v", result.Details)
+	}
+}

--- a/pkg/envcheck/env.go
+++ b/pkg/envcheck/env.go
@@ -1,0 +1,25 @@
+package envcheck
+
+import "os"
+
+// EnvGetter abstracts environment variable access for testability.
+type EnvGetter interface {
+	LookupEnv(key string) (string, bool)
+}
+
+// RealEnvGetter implements EnvGetter using the actual environment.
+type RealEnvGetter struct{}
+
+func (r *RealEnvGetter) LookupEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
+// MockEnvGetter is a test double for EnvGetter.
+type MockEnvGetter struct {
+	Vars map[string]string
+}
+
+func (m *MockEnvGetter) LookupEnv(key string) (string, bool) {
+	val, ok := m.Vars[key]
+	return val, ok
+}


### PR DESCRIPTION
## Summary

- Add `preflight env` subcommand to validate environment variables
- Default behavior: env var must exist AND be non-empty
- Supports regex matching, exact value matching
- Output options: hide or mask sensitive values

## Features

- `--required` - Fail if not set (allows empty values)
- `--match` - Regex pattern to match against value
- `--exact` - Exact value required
- `--hide-value` - Don't show value in output
- `--mask-value` - Show first/last 3 chars only

## Examples

```sh
preflight env DATABASE_URL
preflight env DATABASE_URL --match '^postgres://'
preflight env API_KEY --mask-value
```