### PR TITLE
Add --version flag with build-time injection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,14 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y upx
 
+      - name: Extract version tag
+        id: version
+        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
       - name: Build binaries
         run: |
           mkdir -p dist
+          VERSION="${{ steps.version.outputs.tag }}"
           for GOOS in linux darwin windows; do
             for GOARCH in amd64 arm64; do
               output="preflight-${GOOS}-${GOARCH}"
@@ -34,9 +39,9 @@ jobs:
                 output="${output}.exe"
               fi
               echo "Building ${output}..."
-              # CGO_ENABLED=0 produces fully static binaries (works on Alpine/musl)
-              # -trimpath removes file paths from binary
-              CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build -ldflags="-s -w" -trimpath -o "dist/${output}" ./cmd/preflight
+              CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH go build \
+                -ldflags="-s -w -X main.Version=${VERSION}" \
+                -trimpath -o "dist/${output}" ./cmd/preflight
             done
           done
 
@@ -60,10 +65,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract version tag
-        id: version
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Build and push multi-arch image
         uses: docker/build-push-action@v6

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -13,6 +13,9 @@ import (
 	"github.com/vertti/preflight/pkg/version"
 )
 
+// Version is set at build time via ldflags
+var Version = "dev"
+
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
@@ -20,9 +23,10 @@ func main() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "preflight",
-	Short: "Docker preflight checks for your runtime environment",
-	Long:  "Preflight is a CLI tool for running sanity checks on container and CI environments.",
+	Use:     "preflight",
+	Short:   "Docker preflight checks for your runtime environment",
+	Long:    "Preflight is a CLI tool for running sanity checks on container and CI environments.",
+	Version: Version,
 }
 
 var cmdCmd = &cobra.Command{


### PR DESCRIPTION
## Summary

Add `--version` flag to preflight CLI.

- Local/dev builds show `dev`
- Release builds inject the git tag via ldflags

```sh
$ preflight --version
preflight version v0.1.0
```