### PR TITLE
Add file subcommand for file/directory checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ COPY --from=ghcr.io/vertti/preflight:latest /preflight /usr/local/bin/preflight
 
 RUN preflight cmd node --min 18
 RUN preflight env DATABASE_URL --match '^postgres://'
+RUN preflight file /etc/nginx/nginx.conf --contains "worker_processes"
 ```
 
 ## Install
@@ -57,6 +58,15 @@ preflight env DATABASE_URL                       # exists and non-empty
 preflight env DATABASE_URL --match '^postgres://' # matches pattern
 preflight env NODE_ENV --exact production        # exact value
 preflight env API_KEY --mask-value               # hide in output
+```
+
+### Check files and directories
+
+```sh
+preflight file /etc/nginx/nginx.conf             # exists and readable
+preflight file /var/log/app --dir --writable     # directory is writable
+preflight file /app/config.json --not-empty      # file has content
+preflight file /etc/hosts --contains "localhost" # content check
 ```
 
 ### Output

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,6 +30,7 @@ preflight/
     check/           # Core types (Result, Status)
     cmdcheck/        # Command/binary checks
     envcheck/        # Environment variable checks
+    filecheck/       # File and directory checks
     version/         # Version parsing and comparison
 ```
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,6 +79,59 @@ preflight env API_KEY --mask-value   # shows: sk-•••xyz
 
 ---
 
+## `preflight file`
+
+Checks that a file or directory exists and meets requirements. By default, the path must exist and be readable.
+
+```sh
+preflight file <path> [flags]
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--dir` | Expect a directory (fail if it's a file) |
+| `--writable` | Check write permission |
+| `--executable` | Check execute permission |
+| `--not-empty` | File must have size > 0 |
+| `--min-size <bytes>` | Minimum file size |
+| `--max-size <bytes>` | Maximum file size |
+| `--match <pattern>` | Regex pattern to match against content |
+| `--contains <string>` | Literal string to search in content |
+| `--head <bytes>` | Limit content read to first N bytes |
+| `--mode <perms>` | Minimum permissions (e.g., `0644` passes for `0666`) |
+| `--mode-exact <perms>` | Exact permissions required |
+
+### Examples
+
+```sh
+# Basic check - exists and readable
+preflight file /etc/nginx/nginx.conf
+
+# Directory checks
+preflight file /var/log/app --dir --writable
+
+# Permission checks (minimum - file has at least these perms)
+preflight file /etc/ssl/private/key.pem --mode 0600
+
+# Permission checks (exact)
+preflight file /etc/ssl/private/key.pem --mode-exact 0600
+
+# Content checks (reads full file)
+preflight file /etc/nginx/nginx.conf --contains "worker_processes"
+preflight file /etc/hosts --match "127\.0\.0\.1"
+
+# Content checks (limited to first 1KB)
+preflight file /var/log/huge.log --contains "ERROR" --head 1024
+
+# Size constraints
+preflight file /app/data.json --not-empty
+preflight file /var/log/app.log --max-size 10485760  # 10MB
+```
+
+---
+
 ## Output Format
 
 ### Success
@@ -103,6 +156,12 @@ preflight env API_KEY --mask-value   # shows: sk-•••xyz
 
 [FAIL] env:DATABASE_URL
       value does not match pattern "^postgres://"
+
+[FAIL] file:/var/log/app
+      not writable
+
+[FAIL] file:/missing/path
+      not found
 ```
 
 ---

--- a/pkg/filecheck/check.go
+++ b/pkg/filecheck/check.go
@@ -1,0 +1,241 @@
+package filecheck
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+// Check verifies that a file or directory meets requirements.
+type Check struct {
+	Path       string     // path to check
+	ExpectDir  bool       // --dir: expect a directory
+	Writable   bool       // --writable: check write permission
+	Executable bool       // --executable: check execute permission
+	NotEmpty   bool       // --not-empty: file must have size > 0
+	MinSize    int64      // --min-size: minimum file size in bytes
+	MaxSize    int64      // --max-size: maximum file size in bytes (0 = no limit)
+	Match      string     // --match: regex pattern for content
+	Contains   string     // --contains: literal string to search
+	Head       int64      // --head: limit content read to first N bytes
+	Mode       string     // --mode: minimum permissions (octal, e.g., "0644")
+	ModeExact  string     // --mode-exact: exact permissions required
+	FS         FileSystem // injected for testing
+}
+
+// Run executes the file check.
+func (c *Check) Run() check.Result {
+	result := check.Result{
+		Name: fmt.Sprintf("file:%s", c.Path),
+	}
+
+	info, err := c.FS.Stat(c.Path)
+	if err != nil {
+		result.Status = check.StatusFail
+		switch {
+		case os.IsNotExist(err):
+			result.Details = append(result.Details, "not found")
+		case os.IsPermission(err):
+			result.Details = append(result.Details, "permission denied")
+		default:
+			result.Details = append(result.Details, fmt.Sprintf("stat failed: %v", err))
+		}
+		result.Err = err
+		return result
+	}
+
+	// Type check: --dir flag
+	if c.ExpectDir {
+		if !info.IsDir() {
+			result.Status = check.StatusFail
+			result.Details = append(result.Details, "expected directory, got file")
+			result.Err = fmt.Errorf("expected directory, got file")
+			return result
+		}
+		result.Details = append(result.Details, "type: directory")
+	} else {
+		if info.IsDir() {
+			result.Details = append(result.Details, "type: directory")
+		} else {
+			result.Details = append(result.Details, "type: file")
+		}
+	}
+
+	// Size details and checks (only for files)
+	if !info.IsDir() {
+		result.Details = append(result.Details, fmt.Sprintf("size: %d", info.Size()))
+
+		// --not-empty
+		if c.NotEmpty && info.Size() == 0 {
+			result.Status = check.StatusFail
+			result.Details = append(result.Details, "file is empty")
+			result.Err = fmt.Errorf("file is empty")
+			return result
+		}
+
+		// --min-size
+		if c.MinSize > 0 && info.Size() < c.MinSize {
+			result.Status = check.StatusFail
+			result.Details = append(result.Details, fmt.Sprintf("size %d < minimum %d", info.Size(), c.MinSize))
+			result.Err = fmt.Errorf("file size %d below minimum %d", info.Size(), c.MinSize)
+			return result
+		}
+
+		// --max-size
+		if c.MaxSize > 0 && info.Size() > c.MaxSize {
+			result.Status = check.StatusFail
+			result.Details = append(result.Details, fmt.Sprintf("size %d > maximum %d", info.Size(), c.MaxSize))
+			result.Err = fmt.Errorf("file size %d above maximum %d", info.Size(), c.MaxSize)
+			return result
+		}
+	}
+
+	// Permission details
+	result.Details = append(result.Details, fmt.Sprintf("permissions: %s", info.Mode().Perm()))
+
+	// --mode: minimum permissions check
+	if c.Mode != "" {
+		if err := c.checkModeMinimum(info.Mode(), &result); err != nil {
+			return result
+		}
+	}
+
+	// --mode-exact: exact permissions check
+	if c.ModeExact != "" {
+		if err := c.checkModeExact(info.Mode(), &result); err != nil {
+			return result
+		}
+	}
+
+	// --writable
+	if c.Writable {
+		if !isWritable(info.Mode()) {
+			result.Status = check.StatusFail
+			result.Details = append(result.Details, "not writable")
+			result.Err = fmt.Errorf("file is not writable")
+			return result
+		}
+	}
+
+	// --executable
+	if c.Executable {
+		if !isExecutable(info.Mode()) {
+			result.Status = check.StatusFail
+			result.Details = append(result.Details, "not executable")
+			result.Err = fmt.Errorf("file is not executable")
+			return result
+		}
+	}
+
+	// Content checks (only for files, not directories)
+	if !info.IsDir() && (c.Contains != "" || c.Match != "") {
+		if err := c.checkContent(&result); err != nil {
+			return result
+		}
+	}
+
+	result.Status = check.StatusOK
+	return result
+}
+
+func (c *Check) checkModeMinimum(mode fs.FileMode, result *check.Result) error {
+	required, err := parseOctalMode(c.Mode)
+	if err != nil {
+		result.Status = check.StatusFail
+		result.Details = append(result.Details, fmt.Sprintf("invalid mode: %v", err))
+		result.Err = err
+		return err
+	}
+
+	actual := mode.Perm()
+	// Check if actual permissions include at least the required permissions
+	if actual&required != required {
+		result.Status = check.StatusFail
+		result.Details = append(result.Details, fmt.Sprintf("permissions %s do not include minimum %s", actual, required))
+		result.Err = fmt.Errorf("permissions %s do not include minimum %s", actual, required)
+		return result.Err
+	}
+	return nil
+}
+
+func (c *Check) checkModeExact(mode fs.FileMode, result *check.Result) error {
+	required, err := parseOctalMode(c.ModeExact)
+	if err != nil {
+		result.Status = check.StatusFail
+		result.Details = append(result.Details, fmt.Sprintf("invalid mode: %v", err))
+		result.Err = err
+		return err
+	}
+
+	actual := mode.Perm()
+	if actual != required {
+		result.Status = check.StatusFail
+		result.Details = append(result.Details, fmt.Sprintf("permissions %s != required %s", actual, required))
+		result.Err = fmt.Errorf("permissions %s do not match required %s", actual, required)
+		return result.Err
+	}
+	return nil
+}
+
+func (c *Check) checkContent(result *check.Result) error {
+	content, err := c.FS.ReadFile(c.Path, c.Head)
+	if err != nil {
+		result.Status = check.StatusFail
+		result.Details = append(result.Details, fmt.Sprintf("failed to read file: %v", err))
+		result.Err = err
+		return err
+	}
+
+	// --contains: literal string search
+	if c.Contains != "" {
+		if !strings.Contains(string(content), c.Contains) {
+			result.Status = check.StatusFail
+			result.Details = append(result.Details, fmt.Sprintf("content does not contain %q", c.Contains))
+			result.Err = fmt.Errorf("content does not contain %q", c.Contains)
+			return result.Err
+		}
+	}
+
+	// --match: regex pattern
+	if c.Match != "" {
+		re, err := regexp.Compile(c.Match)
+		if err != nil {
+			result.Status = check.StatusFail
+			result.Details = append(result.Details, fmt.Sprintf("invalid regex pattern: %v", err))
+			result.Err = err
+			return err
+		}
+		if !re.Match(content) {
+			result.Status = check.StatusFail
+			result.Details = append(result.Details, fmt.Sprintf("content does not match pattern %q", c.Match))
+			result.Err = fmt.Errorf("content does not match pattern %q", c.Match)
+			return result.Err
+		}
+	}
+
+	return nil
+}
+
+// parseOctalMode parses an octal permission string like "0644" or "644"
+func parseOctalMode(s string) (fs.FileMode, error) {
+	var mode uint32
+	_, err := fmt.Sscanf(s, "%o", &mode)
+	if err != nil {
+		return 0, fmt.Errorf("invalid octal mode %q: %w", s, err)
+	}
+	return fs.FileMode(mode), nil
+}
+
+// isWritable checks if the mode has any write bit set (owner, group, or other)
+func isWritable(mode fs.FileMode) bool {
+	return mode&0o222 != 0
+}
+
+// isExecutable checks if the mode has any execute bit set (owner, group, or other)
+func isExecutable(mode fs.FileMode) bool {
+	return mode&0o111 != 0
+}

--- a/pkg/filecheck/check_test.go
+++ b/pkg/filecheck/check_test.go
@@ -1,0 +1,526 @@
+package filecheck
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+func TestCheck_Run(t *testing.T) {
+	tests := []struct {
+		name       string
+		check      Check
+		wantStatus check.Status
+		wantDetail string
+	}{
+		// Basic existence tests
+		{
+			name: "file exists",
+			check: Check{
+				Path: "/etc/config",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "config",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+			wantDetail: "type: file",
+		},
+		{
+			name: "file not found",
+			check: Check{
+				Path: "/missing",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return nil, os.ErrNotExist
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "not found",
+		},
+		{
+			name: "permission denied",
+			check: Check{
+				Path: "/secret",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return nil, os.ErrPermission
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "permission denied",
+		},
+
+		// Directory tests
+		{
+			name: "directory exists",
+			check: Check{
+				Path:      "/var/log",
+				ExpectDir: true,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue:  "log",
+							IsDirValue: true,
+							ModeValue:  0o755 | fs.ModeDir,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+			wantDetail: "type: directory",
+		},
+		{
+			name: "expected directory got file",
+			check: Check{
+				Path:      "/etc/config",
+				ExpectDir: true,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "config",
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "expected directory, got file",
+		},
+
+		// Size tests
+		{
+			name: "not empty - passes",
+			check: Check{
+				Path:     "/data.json",
+				NotEmpty: true,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "data.json",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "not empty - fails",
+			check: Check{
+				Path:     "/empty.txt",
+				NotEmpty: true,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "empty.txt",
+							SizeValue: 0,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "file is empty",
+		},
+		{
+			name: "min size - passes",
+			check: Check{
+				Path:    "/data.json",
+				MinSize: 50,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "data.json",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "min size - fails",
+			check: Check{
+				Path:    "/data.json",
+				MinSize: 200,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "data.json",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "size 100 < minimum 200",
+		},
+		{
+			name: "max size - passes",
+			check: Check{
+				Path:    "/data.json",
+				MaxSize: 200,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "data.json",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "max size - fails",
+			check: Check{
+				Path:    "/data.json",
+				MaxSize: 50,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "data.json",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "size 100 > maximum 50",
+		},
+
+		// Permission tests
+		{
+			name: "writable - passes",
+			check: Check{
+				Path:     "/data.json",
+				Writable: true,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "data.json",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "writable - fails",
+			check: Check{
+				Path:     "/readonly.txt",
+				Writable: true,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "readonly.txt",
+							SizeValue: 100,
+							ModeValue: 0o444,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "not writable",
+		},
+		{
+			name: "executable - passes",
+			check: Check{
+				Path:       "/script.sh",
+				Executable: true,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "script.sh",
+							SizeValue: 100,
+							ModeValue: 0o755,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "executable - fails",
+			check: Check{
+				Path:       "/data.txt",
+				Executable: true,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "data.txt",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "not executable",
+		},
+
+		// Mode tests
+		{
+			name: "mode minimum - passes (exact match)",
+			check: Check{
+				Path: "/key.pem",
+				Mode: "0600",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "key.pem",
+							SizeValue: 100,
+							ModeValue: 0o600,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "mode minimum - passes (more permissive)",
+			check: Check{
+				Path: "/key.pem",
+				Mode: "0600",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "key.pem",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "mode minimum - fails",
+			check: Check{
+				Path: "/key.pem",
+				Mode: "0644",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "key.pem",
+							SizeValue: 100,
+							ModeValue: 0o600,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "permissions -rw------- do not include minimum -rw-r--r--",
+		},
+		{
+			name: "mode exact - passes",
+			check: Check{
+				Path:      "/key.pem",
+				ModeExact: "0600",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "key.pem",
+							SizeValue: 100,
+							ModeValue: 0o600,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "mode exact - fails",
+			check: Check{
+				Path:      "/key.pem",
+				ModeExact: "0600",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "key.pem",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "permissions -rw-r--r-- != required -rw-------",
+		},
+
+		// Content tests
+		{
+			name: "contains - passes",
+			check: Check{
+				Path:     "/config.txt",
+				Contains: "database",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "config.txt",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+					ReadFileFunc: func(name string, limit int64) ([]byte, error) {
+						return []byte("database_url=postgres://localhost"), nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "contains - fails",
+			check: Check{
+				Path:     "/config.txt",
+				Contains: "redis",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "config.txt",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+					ReadFileFunc: func(name string, limit int64) ([]byte, error) {
+						return []byte("database_url=postgres://localhost"), nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "content does not contain \"redis\"",
+		},
+		{
+			name: "match regex - passes",
+			check: Check{
+				Path:  "/hosts",
+				Match: "^127\\.0\\.0\\.1",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "hosts",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+					ReadFileFunc: func(name string, limit int64) ([]byte, error) {
+						return []byte("127.0.0.1 localhost"), nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "match regex - fails",
+			check: Check{
+				Path:  "/hosts",
+				Match: "^192\\.168",
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "hosts",
+							SizeValue: 100,
+							ModeValue: 0o644,
+						}, nil
+					},
+					ReadFileFunc: func(name string, limit int64) ([]byte, error) {
+						return []byte("127.0.0.1 localhost"), nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "content does not match pattern \"^192\\\\.168\"",
+		},
+		{
+			name: "head limit is passed to ReadFile",
+			check: Check{
+				Path:     "/large.log",
+				Contains: "ERROR",
+				Head:     1024,
+				FS: &MockFileSystem{
+					StatFunc: func(name string) (fs.FileInfo, error) {
+						return &MockFileInfo{
+							NameValue: "large.log",
+							SizeValue: 10000,
+							ModeValue: 0o644,
+						}, nil
+					},
+					ReadFileFunc: func(name string, limit int64) ([]byte, error) {
+						if limit != 1024 {
+							return nil, errors.New("expected limit 1024")
+						}
+						return []byte("ERROR: something failed"), nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.check.Run()
+
+			if result.Status != tt.wantStatus {
+				t.Errorf("status = %v, want %v", result.Status, tt.wantStatus)
+			}
+
+			if tt.wantDetail != "" {
+				found := false
+				for _, d := range result.Details {
+					if d == tt.wantDetail {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("expected detail %q not found in %v", tt.wantDetail, result.Details)
+				}
+			}
+		})
+	}
+}
+
+func TestParseOctalMode(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    fs.FileMode
+		wantErr bool
+	}{
+		{"0644", 0o644, false},
+		{"644", 0o644, false},
+		{"0755", 0o755, false},
+		{"0600", 0o600, false},
+		{"invalid", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseOctalMode(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseOctalMode(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("parseOctalMode(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/filecheck/fs.go
+++ b/pkg/filecheck/fs.go
@@ -1,0 +1,70 @@
+package filecheck
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"time"
+)
+
+// FileSystem abstracts file system operations for testability.
+type FileSystem interface {
+	Stat(name string) (fs.FileInfo, error)
+	ReadFile(name string, limit int64) ([]byte, error)
+}
+
+// RealFileSystem implements FileSystem using the actual file system.
+type RealFileSystem struct{}
+
+// Stat returns file info for the given path.
+func (r *RealFileSystem) Stat(name string) (fs.FileInfo, error) {
+	return os.Stat(name)
+}
+
+// ReadFile reads a file's contents, optionally limited to the first `limit` bytes.
+// If limit is 0 or negative, reads the entire file.
+func (r *RealFileSystem) ReadFile(name string, limit int64) ([]byte, error) {
+	if limit <= 0 {
+		return os.ReadFile(name)
+	}
+
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+
+	return io.ReadAll(io.LimitReader(f, limit))
+}
+
+// MockFileSystem is a test double for FileSystem.
+type MockFileSystem struct {
+	StatFunc     func(name string) (fs.FileInfo, error)
+	ReadFileFunc func(name string, limit int64) ([]byte, error)
+}
+
+// Stat calls the mock function.
+func (m *MockFileSystem) Stat(name string) (fs.FileInfo, error) {
+	return m.StatFunc(name)
+}
+
+// ReadFile calls the mock function.
+func (m *MockFileSystem) ReadFile(name string, limit int64) ([]byte, error) {
+	return m.ReadFileFunc(name, limit)
+}
+
+// MockFileInfo is a test double for fs.FileInfo.
+type MockFileInfo struct {
+	NameValue    string
+	SizeValue    int64
+	ModeValue    fs.FileMode
+	IsDirValue   bool
+	ModTimeValue int64
+}
+
+func (m *MockFileInfo) Name() string       { return m.NameValue }
+func (m *MockFileInfo) Size() int64        { return m.SizeValue }
+func (m *MockFileInfo) Mode() fs.FileMode  { return m.ModeValue }
+func (m *MockFileInfo) IsDir() bool        { return m.IsDirValue }
+func (m *MockFileInfo) Sys() interface{}   { return nil }
+func (m *MockFileInfo) ModTime() time.Time { return time.Unix(m.ModTimeValue, 0) }


### PR DESCRIPTION
## Summary
- Adds `preflight file <path>` command for checking files and directories
- 11 flags: `--dir`, `--writable`, `--executable`, `--not-empty`, `--min-size`, `--max-size`, `--match`, `--contains`, `--head`, `--mode`, `--mode-exact`
- Default behavior: path must exist and be readable
- Full test coverage with table-driven tests