### PR TITLE
Add --one-of flag to env command

### DIFF
--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -63,6 +63,7 @@ var (
 	envRequired  bool
 	envMatch     string
 	envExact     string
+	envOneOf     []string
 	envHideValue bool
 	envMaskValue bool
 
@@ -93,6 +94,7 @@ func init() {
 	envCmd.Flags().BoolVar(&envRequired, "required", false, "fail if not set (allows empty)")
 	envCmd.Flags().StringVar(&envMatch, "match", "", "regex pattern to match value")
 	envCmd.Flags().StringVar(&envExact, "exact", "", "exact value required")
+	envCmd.Flags().StringSliceVar(&envOneOf, "one-of", nil, "value must be one of these (comma-separated)")
 	envCmd.Flags().BoolVar(&envHideValue, "hide-value", false, "don't show value in output")
 	envCmd.Flags().BoolVar(&envMaskValue, "mask-value", false, "show masked value (first/last 3 chars)")
 	rootCmd.AddCommand(envCmd)
@@ -167,6 +169,7 @@ func runEnvCheck(cmd *cobra.Command, args []string) error {
 		Required:  envRequired,
 		Match:     envMatch,
 		Exact:     envExact,
+		OneOf:     envOneOf,
 		HideValue: envHideValue,
 		MaskValue: envMaskValue,
 		Getter:    &envcheck.RealEnvGetter{},

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,6 +54,7 @@ preflight env <variable> [flags]
 | `--required` | Fail if not set (allows empty values) |
 | `--match <pattern>` | Regex pattern to match against value |
 | `--exact <value>` | Exact value required |
+| `--one-of <values>` | Value must be one of these (comma-separated) |
 | `--hide-value` | Don't show value in output |
 | `--mask-value` | Show first/last 3 chars only (e.g., `sk-•••xyz`) |
 
@@ -71,6 +72,9 @@ preflight env DATABASE_URL --match '^postgres://'
 
 # Exact value
 preflight env NODE_ENV --exact production
+
+# Value from allowed list
+preflight env NODE_ENV --one-of dev,staging,production
 
 # Hide sensitive values in logs
 preflight env API_KEY --hide-value   # shows: [hidden]


### PR DESCRIPTION
## Summary
- Adds `--one-of` flag to `preflight env` command
- Validates that environment variable value is one of a set of allowed values
- Example: `preflight env NODE_ENV --one-of dev,staging,production`
