### PR TITLE
Add Windows binaries to UPX compression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,9 @@ jobs:
             done
           done
 
-      - name: Compress Linux binaries with UPX
+      - name: Compress Linux and Windows binaries with UPX
         run: |
-          upx --best dist/preflight-linux-*
+          upx --best dist/preflight-linux-* dist/preflight-windows-*
           ls -lh dist/
 
       - name: Create Release


### PR DESCRIPTION
## Summary
- Extend UPX compression in release workflow to include Windows executables
- Reduces download size for Windows users

## Changes
- Updated `.github/workflows/release.yml` to compress both Linux and Windows binaries with UPX

## Notes
- macOS/Darwin binaries not included due to unclear UPX support status