### PR TITLE
Add Darwin binaries to UPX compression

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,9 +45,9 @@ jobs:
             done
           done
 
-      - name: Compress Linux and Windows binaries with UPX
+      - name: Compress binaries with UPX
         run: |
-          upx --best dist/preflight-linux-* dist/preflight-windows-*
+          upx --best dist/preflight-*
           ls -lh dist/
 
       - name: Create Release


### PR DESCRIPTION
## Summary
- Extend UPX compression to include Darwin/macOS binaries
- Simplifies glob to `dist/preflight-*` to compress all platforms

If UPX fails on Darwin in CI, we can revert to explicit platform list.