### PR TITLE
Fix UPX to exclude Darwin, add CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,34 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
         run: go build -o bin/preflight-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/preflight || echo "Build skipped for ${{ matrix.goos }}/${{ matrix.goarch }}"
 
+  upx-test:
+    name: UPX Compression Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+
+      - name: Install UPX
+        run: sudo apt-get update && sudo apt-get install -y upx
+
+      - name: Build and compress binaries
+        run: |
+          mkdir -p dist
+          # Build all UPX-supported targets
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -trimpath -o dist/preflight-linux-amd64 ./cmd/preflight
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -trimpath -o dist/preflight-linux-arm64 ./cmd/preflight
+          CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -trimpath -o dist/preflight-windows-amd64.exe ./cmd/preflight
+          # UPX supports: Linux (amd64, arm64), Windows (amd64 only)
+          upx --best \
+            dist/preflight-linux-amd64 \
+            dist/preflight-linux-arm64 \
+            dist/preflight-windows-amd64.exe
+          ls -lh dist/
+
   container-test:
     name: Container Test
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,12 @@ jobs:
 
       - name: Compress binaries with UPX
         run: |
-          upx --best dist/preflight-*
+          # UPX supports: Linux (amd64, arm64), Windows (amd64 only)
+          # Not supported: Darwin, Windows arm64
+          upx --best \
+            dist/preflight-linux-amd64 \
+            dist/preflight-linux-arm64 \
+            dist/preflight-windows-amd64.exe
           ls -lh dist/
 
       - name: Create Release


### PR DESCRIPTION
## Summary
- Revert UPX to Linux + Windows only (Darwin not supported)
- Add `upx-test` job to CI workflow to catch compression failures before release

Fixes broken v0.5.0 release caused by UPX failing on Darwin binaries.