### PR TITLE
Speed up UPX install by downloading directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,8 @@ jobs:
           go-version: "1.25"
 
       - name: Install UPX
-        run: sudo apt-get update && sudo apt-get install -y upx
+        run: |
+          curl -sL https://github.com/upx/upx/releases/download/v4.2.4/upx-4.2.4-amd64_linux.tar.xz | tar -xJ --strip-components=1 -C /usr/local/bin upx-4.2.4-amd64_linux/upx
 
       - name: Build and compress binaries
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install UPX
         run: |
-          sudo apt-get update && sudo apt-get install -y upx
+          curl -sL https://github.com/upx/upx/releases/download/v4.2.4/upx-4.2.4-amd64_linux.tar.xz | tar -xJ --strip-components=1 -C /usr/local/bin upx-4.2.4-amd64_linux/upx
 
       - name: Extract version tag
         id: version


### PR DESCRIPTION
Download UPX binary directly from GitHub releases instead of using apt-get. Should be faster than apt-get update + install (~14s).