### PR TITLE
Use mise-action for Go and golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,27 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
+      - uses: jdx/mise-action@v2
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.6.2
+        run: golangci-lint run
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
+      - uses: jdx/mise-action@v2
 
       - name: Run tests
         run: go test -race -coverprofile=coverage.out ./...
@@ -52,11 +42,7 @@ jobs:
         goarch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
+      - uses: jdx/mise-action@v2
 
       - name: Build
         env:
@@ -69,11 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
+      - uses: jdx/mise-action@v2
 
       - name: Install UPX
         run: |
@@ -111,11 +93,7 @@ jobs:
             cmd: python
     steps:
       - uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
+      - uses: jdx/mise-action@v2
 
       - name: Build static binary
         run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o preflight ./cmd/preflight

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: '1.25'
+      - uses: jdx/mise-action@v2
 
       - name: Install UPX
         run: |


### PR DESCRIPTION
Keeps CI in sync with local dev environment by using mise-action instead of separate setup actions.