### PR TITLE
Add dprint and hk pre-commit hooks

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,3 +1,6 @@
 [tools]
 go = "1.25"
 golangci-lint = "2.6.2"
+dprint = "0.50.2"
+hk = "1.25.0"
+pkl = "0.30.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ make fmt && make lint && make test
 ## Commit Message Style
 
 Use conventional style:
+
 - `Add X` - new feature or file
 - `Fix X` - bug fix
 - `Update X` - enhancement to existing feature

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test test-coverage lint fmt clean
+.PHONY: all build test test-coverage lint fmt fmt-md check-md clean install-hooks
 
 # Build the preflight binary
 build:
@@ -21,8 +21,20 @@ lint:
 fmt:
 	goimports -w .
 
+# Format markdown files
+fmt-md:
+	dprint fmt
+
+# Check markdown formatting
+check-md:
+	dprint check
+
 # Run all checks (lint, test, build)
 all: lint test build
+
+# Install pre-commit hooks
+install-hooks:
+	hk install --mise
 
 # Clean build artifacts
 clean:

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ RUN preflight file /etc/nginx/nginx.conf --contains "worker_processes"
 ## Install
 
 **Dockerfiles** (recommended):
+
 ```dockerfile
 COPY --from=ghcr.io/vertti/preflight:latest /preflight /usr/local/bin/preflight
 ```
 
 **Shell**:
+
 ```sh
 curl -fsSL https://raw.githubusercontent.com/vertti/preflight/main/install.sh | sh
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,13 +10,13 @@ preflight cmd <command> [flags]
 
 ### Flags
 
-| Flag | Description |
-|------|-------------|
-| `--min <version>` | Minimum version required (inclusive) |
-| `--max <version>` | Maximum version allowed (exclusive) |
-| `--exact <version>` | Exact version required |
-| `--match <pattern>` | Regex pattern to match against version output |
-| `--version-cmd <arg>` | Override the default `--version` argument |
+| Flag                  | Description                                   |
+| --------------------- | --------------------------------------------- |
+| `--min <version>`     | Minimum version required (inclusive)          |
+| `--max <version>`     | Maximum version allowed (exclusive)           |
+| `--exact <version>`   | Exact version required                        |
+| `--match <pattern>`   | Regex pattern to match against version output |
+| `--version-cmd <arg>` | Override the default `--version` argument     |
 
 ### Examples
 
@@ -49,14 +49,14 @@ preflight env <variable> [flags]
 
 ### Flags
 
-| Flag | Description |
-|------|-------------|
-| `--required` | Fail if not set (allows empty values) |
-| `--match <pattern>` | Regex pattern to match against value |
-| `--exact <value>` | Exact value required |
-| `--one-of <values>` | Value must be one of these (comma-separated) |
-| `--hide-value` | Don't show value in output |
-| `--mask-value` | Show first/last 3 chars only (e.g., `sk-•••xyz`) |
+| Flag                | Description                                      |
+| ------------------- | ------------------------------------------------ |
+| `--required`        | Fail if not set (allows empty values)            |
+| `--match <pattern>` | Regex pattern to match against value             |
+| `--exact <value>`   | Exact value required                             |
+| `--one-of <values>` | Value must be one of these (comma-separated)     |
+| `--hide-value`      | Don't show value in output                       |
+| `--mask-value`      | Show first/last 3 chars only (e.g., `sk-•••xyz`) |
 
 ### Examples
 
@@ -93,19 +93,19 @@ preflight file <path> [flags]
 
 ### Flags
 
-| Flag | Description |
-|------|-------------|
-| `--dir` | Expect a directory (fail if it's a file) |
-| `--writable` | Check write permission |
-| `--executable` | Check execute permission |
-| `--not-empty` | File must have size > 0 |
-| `--min-size <bytes>` | Minimum file size |
-| `--max-size <bytes>` | Maximum file size |
-| `--match <pattern>` | Regex pattern to match against content |
-| `--contains <string>` | Literal string to search in content |
-| `--head <bytes>` | Limit content read to first N bytes |
-| `--mode <perms>` | Minimum permissions (e.g., `0644` passes for `0666`) |
-| `--mode-exact <perms>` | Exact permissions required |
+| Flag                   | Description                                          |
+| ---------------------- | ---------------------------------------------------- |
+| `--dir`                | Expect a directory (fail if it's a file)             |
+| `--writable`           | Check write permission                               |
+| `--executable`         | Check execute permission                             |
+| `--not-empty`          | File must have size > 0                              |
+| `--min-size <bytes>`   | Minimum file size                                    |
+| `--max-size <bytes>`   | Maximum file size                                    |
+| `--match <pattern>`    | Regex pattern to match against content               |
+| `--contains <string>`  | Literal string to search in content                  |
+| `--head <bytes>`       | Limit content read to first N bytes                  |
+| `--mode <perms>`       | Minimum permissions (e.g., `0644` passes for `0666`) |
+| `--mode-exact <perms>` | Exact permissions required                           |
 
 ### Examples
 
@@ -207,7 +207,7 @@ docker run myapp:latest sh -c '
 
 ## Exit Codes
 
-| Code | Meaning |
-|------|---------|
-| `0` | All checks passed |
-| `1` | One or more checks failed |
+| Code | Meaning                   |
+| ---- | ------------------------- |
+| `0`  | All checks passed         |
+| `1`  | One or more checks failed |

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "https://plugins.dprint.dev/markdown-0.20.0.wasm"
+  ],
+  "markdown": {},
+  "includes": ["**/*.md"],
+  "excludes": ["**/node_modules"]
+}

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,26 @@
+amends "package://github.com/jdx/hk/releases/download/v1.25.0/hk@1.25.0#/Config.pkl"
+
+local linters = new Mapping<String, Step> {
+    ["gofmt"] {
+        glob = List("*.go")
+        check = "gofmt -l {{files}}"
+        fix = "gofmt -w {{files}}"
+    }
+    ["golangci-lint"] {
+        glob = List("*.go")
+        check = "golangci-lint run"
+    }
+    ["dprint"] {
+        glob = List("*.md")
+        check = "dprint check"
+        fix = "dprint fmt"
+    }
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps = linters
+    }
+}


### PR DESCRIPTION
- Add dprint for markdown formatting
- Add hk for pre-commit hooks (gofmt, golangci-lint, dprint)
- Format existing markdown files with dprint

Run `make install-hooks` to enable the pre-commit hooks.