### PR TITLE
Add preflight user command for user existence checks

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -211,6 +211,56 @@ healthcheck:
 
 ---
 
+## `preflight user`
+
+Checks that a user exists on the system and optionally validates uid, gid, and home directory. Useful for verifying non-root container configurations.
+
+```sh
+preflight user <username> [flags]
+```
+
+### Flags
+
+| Flag            | Description               |
+| --------------- | ------------------------- |
+| `--uid <id>`    | Expected user ID          |
+| `--gid <id>`    | Expected primary group ID |
+| `--home <path>` | Expected home directory   |
+
+### Examples
+
+```sh
+# Check user exists
+preflight user appuser
+
+# Verify specific uid/gid (common for non-root containers)
+preflight user appuser --uid 1000 --gid 1000
+
+# Verify home directory
+preflight user appuser --home /app
+
+# All constraints
+preflight user appuser --uid 1000 --gid 1000 --home /app
+```
+
+### Use Cases
+
+**Non-root container validation:**
+
+```dockerfile
+RUN preflight user appuser --uid 1000 --gid 1000
+USER appuser
+```
+
+**Kubernetes security context verification:**
+
+```sh
+# Verify container runs as expected user
+preflight user nobody --uid 65534
+```
+
+---
+
 ## CI & Container Verification
 
 Preflight can verify container images in CI pipelines, replacing ad-hoc shell scripts. These examples assume preflight is installed in the container image.
@@ -282,6 +332,14 @@ docker run myapp:latest sh -c '
 
 [FAIL] tcp:localhost:9999
       connection failed: dial tcp [::1]:9999: connect: connection refused
+
+[OK] user:appuser
+      uid: 1000
+      gid: 1000
+      home: /app
+
+[FAIL] user:nonexistent
+      user not found: user: unknown user nonexistent
 ```
 
 ---

--- a/pkg/usercheck/check.go
+++ b/pkg/usercheck/check.go
@@ -1,0 +1,73 @@
+package usercheck
+
+import (
+	"fmt"
+	"os/user"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+// UserLookup abstracts user lookup for testability.
+type UserLookup interface {
+	Lookup(username string) (*user.User, error)
+}
+
+// RealUserLookup uses the real os/user package.
+type RealUserLookup struct{}
+
+// Lookup looks up a user by username.
+func (r *RealUserLookup) Lookup(username string) (*user.User, error) {
+	return user.Lookup(username)
+}
+
+// Check verifies a user exists and optionally validates uid/gid/home.
+type Check struct {
+	Username string     // username to check
+	UID      string     // expected uid (empty = don't check)
+	GID      string     // expected gid (empty = don't check)
+	Home     string     // expected home directory (empty = don't check)
+	Lookup   UserLookup // injected for testing
+}
+
+// Run executes the user check.
+func (c *Check) Run() check.Result {
+	result := check.Result{
+		Name: fmt.Sprintf("user:%s", c.Username),
+	}
+
+	u, err := c.Lookup.Lookup(c.Username)
+	if err != nil {
+		result.Status = check.StatusFail
+		result.Details = append(result.Details, fmt.Sprintf("user not found: %v", err))
+		result.Err = err
+		return result
+	}
+
+	result.Details = append(result.Details,
+		fmt.Sprintf("uid: %s", u.Uid),
+		fmt.Sprintf("gid: %s", u.Gid),
+		fmt.Sprintf("home: %s", u.HomeDir),
+	)
+
+	checks := []struct {
+		name     string
+		expected string
+		actual   string
+	}{
+		{"uid", c.UID, u.Uid},
+		{"gid", c.GID, u.Gid},
+		{"home", c.Home, u.HomeDir},
+	}
+
+	for _, chk := range checks {
+		if chk.expected != "" && chk.actual != chk.expected {
+			result.Status = check.StatusFail
+			result.Details = append(result.Details, fmt.Sprintf("%s mismatch: expected %s, got %s", chk.name, chk.expected, chk.actual))
+			result.Err = fmt.Errorf("%s mismatch", chk.name)
+			return result
+		}
+	}
+
+	result.Status = check.StatusOK
+	return result
+}

--- a/pkg/usercheck/check_test.go
+++ b/pkg/usercheck/check_test.go
@@ -1,0 +1,180 @@
+package usercheck
+
+import (
+	"errors"
+	"os/user"
+	"testing"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+// MockUserLookup is a mock implementation of UserLookup for testing.
+type MockUserLookup struct {
+	LookupFunc func(username string) (*user.User, error)
+}
+
+func (m *MockUserLookup) Lookup(username string) (*user.User, error) {
+	return m.LookupFunc(username)
+}
+
+func TestUserCheck(t *testing.T) {
+	tests := []struct {
+		name       string
+		username   string
+		uid        string
+		gid        string
+		home       string
+		lookupFunc func(username string) (*user.User, error)
+		wantStatus check.Status
+		wantName   string
+	}{
+		{
+			name:     "user exists",
+			username: "appuser",
+			lookupFunc: func(username string) (*user.User, error) {
+				return &user.User{
+					Uid:     "1000",
+					Gid:     "1000",
+					HomeDir: "/home/appuser",
+				}, nil
+			},
+			wantStatus: check.StatusOK,
+			wantName:   "user:appuser",
+		},
+		{
+			name:     "user not found",
+			username: "nonexistent",
+			lookupFunc: func(username string) (*user.User, error) {
+				return nil, errors.New("user: unknown user nonexistent")
+			},
+			wantStatus: check.StatusFail,
+			wantName:   "user:nonexistent",
+		},
+		{
+			name:     "uid matches",
+			username: "appuser",
+			uid:      "1000",
+			lookupFunc: func(username string) (*user.User, error) {
+				return &user.User{
+					Uid:     "1000",
+					Gid:     "1000",
+					HomeDir: "/home/appuser",
+				}, nil
+			},
+			wantStatus: check.StatusOK,
+			wantName:   "user:appuser",
+		},
+		{
+			name:     "uid mismatch",
+			username: "appuser",
+			uid:      "1001",
+			lookupFunc: func(username string) (*user.User, error) {
+				return &user.User{
+					Uid:     "1000",
+					Gid:     "1000",
+					HomeDir: "/home/appuser",
+				}, nil
+			},
+			wantStatus: check.StatusFail,
+			wantName:   "user:appuser",
+		},
+		{
+			name:     "gid matches",
+			username: "appuser",
+			gid:      "1000",
+			lookupFunc: func(username string) (*user.User, error) {
+				return &user.User{
+					Uid:     "1000",
+					Gid:     "1000",
+					HomeDir: "/home/appuser",
+				}, nil
+			},
+			wantStatus: check.StatusOK,
+			wantName:   "user:appuser",
+		},
+		{
+			name:     "gid mismatch",
+			username: "appuser",
+			gid:      "1001",
+			lookupFunc: func(username string) (*user.User, error) {
+				return &user.User{
+					Uid:     "1000",
+					Gid:     "1000",
+					HomeDir: "/home/appuser",
+				}, nil
+			},
+			wantStatus: check.StatusFail,
+			wantName:   "user:appuser",
+		},
+		{
+			name:     "home matches",
+			username: "appuser",
+			home:     "/app",
+			lookupFunc: func(username string) (*user.User, error) {
+				return &user.User{
+					Uid:     "1000",
+					Gid:     "1000",
+					HomeDir: "/app",
+				}, nil
+			},
+			wantStatus: check.StatusOK,
+			wantName:   "user:appuser",
+		},
+		{
+			name:     "home mismatch",
+			username: "appuser",
+			home:     "/app",
+			lookupFunc: func(username string) (*user.User, error) {
+				return &user.User{
+					Uid:     "1000",
+					Gid:     "1000",
+					HomeDir: "/home/appuser",
+				}, nil
+			},
+			wantStatus: check.StatusFail,
+			wantName:   "user:appuser",
+		},
+		{
+			name:     "all constraints match",
+			username: "appuser",
+			uid:      "1000",
+			gid:      "1000",
+			home:     "/app",
+			lookupFunc: func(username string) (*user.User, error) {
+				return &user.User{
+					Uid:     "1000",
+					Gid:     "1000",
+					HomeDir: "/app",
+				}, nil
+			},
+			wantStatus: check.StatusOK,
+			wantName:   "user:appuser",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Check{
+				Username: tt.username,
+				UID:      tt.uid,
+				GID:      tt.gid,
+				Home:     tt.home,
+				Lookup: &MockUserLookup{
+					LookupFunc: tt.lookupFunc,
+				},
+			}
+
+			result := c.Run()
+
+			if result.Status != tt.wantStatus {
+				t.Errorf("Status = %v, want %v", result.Status, tt.wantStatus)
+			}
+			if result.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", result.Name, tt.wantName)
+			}
+			if tt.wantStatus == check.StatusFail && result.Err == nil {
+				t.Error("expected Err to be set on failure")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `preflight user <username>` command to verify a user exists and optionally validate:
- `--uid` - expected user ID
- `--gid` - expected primary group ID  
- `--home` - expected home directory

## Examples

```sh
preflight user appuser
preflight user appuser --uid 1000 --gid 1000
preflight user appuser --home /app
```

## Use Cases

- Verify non-root container configurations
- Validate user setup before switching to non-root user
- Check Kubernetes security context expectations