### PR TITLE
Add string matcher flags to env check

### DIFF
--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -108,12 +108,18 @@ var (
 	versionCmd   string
 
 	// env flags
-	envRequired  bool
-	envMatch     string
-	envExact     string
-	envOneOf     []string
-	envHideValue bool
-	envMaskValue bool
+	envRequired   bool
+	envMatch      string
+	envExact      string
+	envOneOf      []string
+	envHideValue  bool
+	envMaskValue  bool
+	envStartsWith string
+	envEndsWith   string
+	envContains   string
+	envIsNumeric  bool
+	envMinLen     int
+	envMaxLen     int
 
 	// file flags
 	fileDir        bool
@@ -156,6 +162,12 @@ func init() {
 	envCmd.Flags().StringSliceVar(&envOneOf, "one-of", nil, "value must be one of these (comma-separated)")
 	envCmd.Flags().BoolVar(&envHideValue, "hide-value", false, "don't show value in output")
 	envCmd.Flags().BoolVar(&envMaskValue, "mask-value", false, "show masked value (first/last 3 chars)")
+	envCmd.Flags().StringVar(&envStartsWith, "starts-with", "", "value must start with this string")
+	envCmd.Flags().StringVar(&envEndsWith, "ends-with", "", "value must end with this string")
+	envCmd.Flags().StringVar(&envContains, "contains", "", "value must contain this string")
+	envCmd.Flags().BoolVar(&envIsNumeric, "is-numeric", false, "value must be a valid number")
+	envCmd.Flags().IntVar(&envMinLen, "min-len", 0, "minimum string length")
+	envCmd.Flags().IntVar(&envMaxLen, "max-len", 0, "maximum string length")
 	rootCmd.AddCommand(envCmd)
 
 	// file subcommand
@@ -238,14 +250,20 @@ func runEnvCheck(cmd *cobra.Command, args []string) error {
 	varName := args[0]
 
 	c := &envcheck.Check{
-		Name:      varName,
-		Required:  envRequired,
-		Match:     envMatch,
-		Exact:     envExact,
-		OneOf:     envOneOf,
-		HideValue: envHideValue,
-		MaskValue: envMaskValue,
-		Getter:    &envcheck.RealEnvGetter{},
+		Name:       varName,
+		Required:   envRequired,
+		Match:      envMatch,
+		Exact:      envExact,
+		OneOf:      envOneOf,
+		HideValue:  envHideValue,
+		MaskValue:  envMaskValue,
+		StartsWith: envStartsWith,
+		EndsWith:   envEndsWith,
+		Contains:   envContains,
+		IsNumeric:  envIsNumeric,
+		MinLen:     envMinLen,
+		MaxLen:     envMaxLen,
+		Getter:     &envcheck.RealEnvGetter{},
 	}
 
 	result := c.Run()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,14 +59,20 @@ preflight env <variable> [flags]
 
 ### Flags
 
-| Flag                | Description                                      |
-| ------------------- | ------------------------------------------------ |
-| `--required`        | Fail if not set (allows empty values)            |
-| `--match <pattern>` | Regex pattern to match against value             |
-| `--exact <value>`   | Exact value required                             |
-| `--one-of <values>` | Value must be one of these (comma-separated)     |
-| `--hide-value`      | Don't show value in output                       |
-| `--mask-value`      | Show first/last 3 chars only (e.g., `sk-•••xyz`) |
+| Flag                  | Description                                      |
+| --------------------- | ------------------------------------------------ |
+| `--required`          | Fail if not set (allows empty values)            |
+| `--match <pattern>`   | Regex pattern to match against value             |
+| `--exact <value>`     | Exact value required                             |
+| `--one-of <values>`   | Value must be one of these (comma-separated)     |
+| `--starts-with <str>` | Value must start with string                     |
+| `--ends-with <str>`   | Value must end with string                       |
+| `--contains <str>`    | Value must contain substring                     |
+| `--is-numeric`        | Value must be a valid number                     |
+| `--min-len <n>`       | Minimum string length                            |
+| `--max-len <n>`       | Maximum string length                            |
+| `--hide-value`        | Don't show value in output                       |
+| `--mask-value`        | Show first/last 3 chars only (e.g., `sk-•••xyz`) |
 
 ### Examples
 
@@ -86,6 +92,16 @@ preflight env APP_ENV --exact production
 
 # Value from allowed list
 preflight env APP_ENV --one-of dev,staging,production
+
+# String matchers
+preflight env MODEL_PATH --starts-with /models/
+preflight env CONFIG_FILE --ends-with .yaml
+preflight env WEBHOOK_URL --contains example.com
+
+# Numeric and length validation
+preflight env PORT --is-numeric
+preflight env API_KEY --min-len 32
+preflight env CODE --max-len 6
 
 # Hide sensitive values in logs
 preflight env AWS_SECRET_ARN --hide-value   # shows: [hidden]

--- a/pkg/envcheck/check_test.go
+++ b/pkg/envcheck/check_test.go
@@ -170,6 +170,141 @@ func TestEnvCheck_Run(t *testing.T) {
 			wantStatus: check.StatusOK,
 			wantDetail: "value: •••",
 		},
+
+		// --starts-with flag tests
+		{
+			name: "starts-with passes",
+			check: Check{
+				Name:       "PATH",
+				StartsWith: "/usr",
+				Getter:     &MockEnvGetter{Vars: map[string]string{"PATH": "/usr/local/bin"}},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "starts-with fails",
+			check: Check{
+				Name:       "PATH",
+				StartsWith: "/usr",
+				Getter:     &MockEnvGetter{Vars: map[string]string{"PATH": "/opt/bin"}},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: `value does not start with "/usr"`,
+		},
+
+		// --ends-with flag tests
+		{
+			name: "ends-with passes",
+			check: Check{
+				Name:     "CONFIG",
+				EndsWith: ".yaml",
+				Getter:   &MockEnvGetter{Vars: map[string]string{"CONFIG": "/app/config.yaml"}},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "ends-with fails",
+			check: Check{
+				Name:     "CONFIG",
+				EndsWith: ".yaml",
+				Getter:   &MockEnvGetter{Vars: map[string]string{"CONFIG": "/app/config.json"}},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: `value does not end with ".yaml"`,
+		},
+
+		// --contains flag tests
+		{
+			name: "contains passes",
+			check: Check{
+				Name:     "URL",
+				Contains: "example",
+				Getter:   &MockEnvGetter{Vars: map[string]string{"URL": "https://example.com/api"}},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "contains fails",
+			check: Check{
+				Name:     "URL",
+				Contains: "example",
+				Getter:   &MockEnvGetter{Vars: map[string]string{"URL": "https://other.com/api"}},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: `value does not contain "example"`,
+		},
+
+		// --is-numeric flag tests
+		{
+			name: "is-numeric passes with integer",
+			check: Check{
+				Name:      "PORT",
+				IsNumeric: true,
+				Getter:    &MockEnvGetter{Vars: map[string]string{"PORT": "8080"}},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "is-numeric passes with float",
+			check: Check{
+				Name:      "RATE",
+				IsNumeric: true,
+				Getter:    &MockEnvGetter{Vars: map[string]string{"RATE": "3.14"}},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "is-numeric fails",
+			check: Check{
+				Name:      "PORT",
+				IsNumeric: true,
+				Getter:    &MockEnvGetter{Vars: map[string]string{"PORT": "not-a-number"}},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "value is not numeric",
+		},
+
+		// --min-len flag tests
+		{
+			name: "min-len passes",
+			check: Check{
+				Name:   "API_KEY",
+				MinLen: 10,
+				Getter: &MockEnvGetter{Vars: map[string]string{"API_KEY": "abcdefghijk"}},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "min-len fails",
+			check: Check{
+				Name:   "API_KEY",
+				MinLen: 10,
+				Getter: &MockEnvGetter{Vars: map[string]string{"API_KEY": "short"}},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "value length 5 < minimum 10",
+		},
+
+		// --max-len flag tests
+		{
+			name: "max-len passes",
+			check: Check{
+				Name:   "CODE",
+				MaxLen: 10,
+				Getter: &MockEnvGetter{Vars: map[string]string{"CODE": "abc"}},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "max-len fails",
+			check: Check{
+				Name:   "CODE",
+				MaxLen: 5,
+				Getter: &MockEnvGetter{Vars: map[string]string{"CODE": "toolongvalue"}},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "value length 12 > maximum 5",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add convenience flags for common string validation patterns to `preflight env`
- New flags: `--starts-with`, `--ends-with`, `--contains`, `--is-numeric`, `--min-len`, `--max-len`
- Update docs/usage.md with new flags and examples