### PR TITLE
Add colored output for OK/FAIL status

### DIFF
--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -9,10 +9,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/vertti/preflight/pkg/check"
 	"github.com/vertti/preflight/pkg/cmdcheck"
 	"github.com/vertti/preflight/pkg/envcheck"
 	"github.com/vertti/preflight/pkg/filecheck"
+	"github.com/vertti/preflight/pkg/output"
 	"github.com/vertti/preflight/pkg/preflightfile"
 	"github.com/vertti/preflight/pkg/tcpcheck"
 	"github.com/vertti/preflight/pkg/usercheck"
@@ -234,7 +234,7 @@ func runCmdCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	result := c.Run()
-	printResult(result)
+	output.PrintResult(result)
 
 	if !result.OK() {
 		os.Exit(1)
@@ -267,7 +267,7 @@ func runEnvCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	result := c.Run()
-	printResult(result)
+	output.PrintResult(result)
 
 	if !result.OK() {
 		os.Exit(1)
@@ -295,7 +295,7 @@ func runFileCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	result := c.Run()
-	printResult(result)
+	output.PrintResult(result)
 
 	if !result.OK() {
 		os.Exit(1)
@@ -313,7 +313,7 @@ func runTCPCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	result := c.Run()
-	printResult(result)
+	output.PrintResult(result)
 
 	if !result.OK() {
 		os.Exit(1)
@@ -333,7 +333,7 @@ func runUserCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	result := c.Run()
-	printResult(result)
+	output.PrintResult(result)
 
 	if !result.OK() {
 		os.Exit(1)
@@ -386,15 +386,4 @@ func runRun(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func printResult(r check.Result) {
-	if r.OK() {
-		fmt.Printf("[OK] %s\n", r.Name)
-	} else {
-		fmt.Printf("[FAIL] %s\n", r.Name)
-	}
-	for _, d := range r.Details {
-		fmt.Printf("      %s\n", d)
-	}
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -376,14 +376,33 @@ Preflight outputs colored status indicators:
 - `[OK]` in green
 - `[FAIL]` in red
 
-Colors are automatically enabled in terminals and CI environments (GitHub Actions, GitLab CI, etc.).
+### Where Colors Work Automatically
+
+- **Terminals** - colors are detected automatically
+- **GitHub Actions** - colors are enabled automatically
+- **GitLab CI** - colors are enabled automatically
+- **Other CI systems** - most are detected automatically
+
+### Docker Builds
+
+Docker builds don't allocate a TTY, so colors are disabled by default. To enable colors in your Dockerfile, set `PREFLIGHT_COLOR=1`:
+
+```dockerfile
+FROM alpine
+
+ENV PREFLIGHT_COLOR=1
+
+RUN preflight cmd myapp
+RUN preflight env MODEL_PATH
+RUN preflight file /app/config.yaml
+```
 
 ### Environment Variables
 
-| Variable      | Description                                |
-| ------------- | ------------------------------------------ |
-| `NO_COLOR=1`  | Disable colored output                     |
-| `FORCE_COLOR` | Force colors (useful when piping to `cat`) |
+| Variable           | Description                      |
+| ------------------ | -------------------------------- |
+| `PREFLIGHT_COLOR=1`| Enable colors (for Docker builds)|
+| `NO_COLOR=1`       | Disable colors                   |
 
 ### Examples
 
@@ -391,6 +410,6 @@ Colors are automatically enabled in terminals and CI environments (GitHub Action
 # Disable colors
 NO_COLOR=1 preflight cmd myapp
 
-# Force colors when piping
-FORCE_COLOR=1 preflight cmd myapp | tee output.log
+# Enable colors in scripts/Docker
+PREFLIGHT_COLOR=1 preflight cmd myapp
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -366,3 +366,31 @@ docker run myapp:latest sh -c '
 | ---- | ------------------------- |
 | `0`  | All checks passed         |
 | `1`  | One or more checks failed |
+
+---
+
+## Colored Output
+
+Preflight outputs colored status indicators:
+
+- `[OK]` in green
+- `[FAIL]` in red
+
+Colors are automatically enabled in terminals and CI environments (GitHub Actions, GitLab CI, etc.).
+
+### Environment Variables
+
+| Variable      | Description                                |
+| ------------- | ------------------------------------------ |
+| `NO_COLOR=1`  | Disable colored output                     |
+| `FORCE_COLOR` | Force colors (useful when piping to `cat`) |
+
+### Examples
+
+```sh
+# Disable colors
+NO_COLOR=1 preflight cmd myapp
+
+# Force colors when piping
+FORCE_COLOR=1 preflight cmd myapp | tee output.log
+```

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,8 @@ require github.com/spf13/cobra v1.10.1
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jwalton/go-supportscolor v1.2.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 // indirect
+	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,17 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jwalton/go-supportscolor v1.2.0 h1:g6Ha4u7Vm3LIsQ5wmeBpS4gazu0UP1DRDE8y6bre4H8=
+github.com/jwalton/go-supportscolor v1.2.0/go.mod h1:hFVUAZV2cWg+WFFC4v8pT2X/S2qUUBYMioBD9AINXGs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
 github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43 h1:SgQ6LNaYJU0JIuEHv9+s6EbhSCwYeAf5Yvj6lpYlqAE=
+golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d h1:SZxvLBoTP5yHO3Frd4z4vrF+DBX9vMVanchswa69toE=
+golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/cmdcheck/check.go
+++ b/pkg/cmdcheck/check.go
@@ -22,7 +22,7 @@ type Check struct {
 // Run executes the command check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("cmd:%s", c.Name),
+		Name: fmt.Sprintf("cmd: %s", c.Name),
 	}
 
 	path, err := c.Runner.LookPath(c.Name)

--- a/pkg/cmdcheck/check_test.go
+++ b/pkg/cmdcheck/check_test.go
@@ -27,7 +27,7 @@ func TestCommandCheck_Run(t *testing.T) {
 				},
 			},
 			wantStatus: check.StatusFail,
-			wantName:   "cmd:nonexistent",
+			wantName:   "cmd: nonexistent",
 		},
 		{
 			name: "version command fails",
@@ -58,7 +58,7 @@ func TestCommandCheck_Run(t *testing.T) {
 				},
 			},
 			wantStatus: check.StatusOK,
-			wantName:   "cmd:node",
+			wantName:   "cmd: node",
 		},
 
 		// --min version tests

--- a/pkg/envcheck/check.go
+++ b/pkg/envcheck/check.go
@@ -30,7 +30,7 @@ type Check struct {
 // Run executes the environment variable check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("env:%s", c.Name),
+		Name: fmt.Sprintf("env: %s", c.Name),
 	}
 
 	value, exists := c.Getter.LookupEnv(c.Name)

--- a/pkg/filecheck/check.go
+++ b/pkg/filecheck/check.go
@@ -30,7 +30,7 @@ type Check struct {
 // Run executes the file check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("file:%s", c.Path),
+		Name: fmt.Sprintf("file: %s", c.Path),
 	}
 
 	info, err := c.FS.Stat(c.Path)

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/jwalton/go-supportscolor"
 
@@ -15,7 +16,14 @@ var (
 )
 
 func init() {
-	if !supportscolor.Stdout().SupportsColor {
+	colorEnabled := supportscolor.Stdout().SupportsColor
+
+	// PREFLIGHT_COLOR=1 forces colors (useful for Docker builds)
+	if os.Getenv("PREFLIGHT_COLOR") == "1" {
+		colorEnabled = true
+	}
+
+	if !colorEnabled {
 		green, red, reset = "", "", ""
 	}
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,0 +1,33 @@
+package output
+
+import (
+	"fmt"
+
+	"github.com/jwalton/go-supportscolor"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+var (
+	green = "\033[32m"
+	red   = "\033[31m"
+	reset = "\033[0m"
+)
+
+func init() {
+	if !supportscolor.Stdout().SupportsColor {
+		green, red, reset = "", "", ""
+	}
+}
+
+// PrintResult outputs a check result with colored status.
+func PrintResult(r check.Result) {
+	if r.OK() {
+		fmt.Printf("%s[OK]%s %s\n", green, reset, r.Name)
+	} else {
+		fmt.Printf("%s[FAIL]%s %s\n", red, reset, r.Name)
+	}
+	for _, d := range r.Details {
+		fmt.Printf("      %s\n", d)
+	}
+}

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jwalton/go-supportscolor"
 
@@ -12,6 +13,7 @@ import (
 var (
 	green = "\033[32m"
 	red   = "\033[31m"
+	dim   = "\033[90m"
 	reset = "\033[0m"
 )
 
@@ -24,18 +26,29 @@ func init() {
 	}
 
 	if !colorEnabled {
-		green, red, reset = "", "", ""
+		green, red, dim, reset = "", "", "", ""
 	}
 }
 
 // PrintResult outputs a check result with colored status.
 func PrintResult(r check.Result) {
+	var indent string
 	if r.OK() {
-		fmt.Printf("%s[OK]%s %s\n", green, reset, r.Name)
+		fmt.Printf("%s[OK]%s %s\n", green, reset, formatLabel(r.Name))
+		indent = "     " // align with content after "[OK] "
 	} else {
-		fmt.Printf("%s[FAIL]%s %s\n", red, reset, r.Name)
+		fmt.Printf("%s[FAIL]%s %s\n", red, reset, formatLabel(r.Name))
+		indent = "       " // align with content after "[FAIL] "
 	}
 	for _, d := range r.Details {
-		fmt.Printf("      %s\n", d)
+		fmt.Printf("%s%s\n", indent, formatLabel(d))
 	}
+}
+
+// formatLabel colors the label part (before colon) in dim.
+func formatLabel(s string) string {
+	if idx := strings.Index(s, ":"); idx != -1 {
+		return dim + s[:idx+1] + reset + s[idx+1:]
+	}
+	return s
 }

--- a/pkg/tcpcheck/check.go
+++ b/pkg/tcpcheck/check.go
@@ -31,7 +31,7 @@ type Check struct {
 // Run executes the TCP connectivity check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("tcp:%s", c.Address),
+		Name: fmt.Sprintf("tcp: %s", c.Address),
 	}
 
 	timeout := c.Timeout

--- a/pkg/tcpcheck/check_test.go
+++ b/pkg/tcpcheck/check_test.go
@@ -46,7 +46,7 @@ func TestTCPCheck(t *testing.T) {
 				return &MockConn{}, nil
 			},
 			wantStatus: check.StatusOK,
-			wantName:   "tcp:localhost:5432",
+			wantName:   "tcp: localhost:5432",
 		},
 		{
 			name:    "connection refused",
@@ -55,7 +55,7 @@ func TestTCPCheck(t *testing.T) {
 				return nil, errors.New("connection refused")
 			},
 			wantStatus: check.StatusFail,
-			wantName:   "tcp:localhost:9999",
+			wantName:   "tcp: localhost:9999",
 		},
 		{
 			name:    "timeout",
@@ -65,7 +65,7 @@ func TestTCPCheck(t *testing.T) {
 				return nil, errors.New("i/o timeout")
 			},
 			wantStatus: check.StatusFail,
-			wantName:   "tcp:10.255.255.1:80",
+			wantName:   "tcp: 10.255.255.1:80",
 		},
 		{
 			name:    "dns resolution failure",
@@ -74,7 +74,7 @@ func TestTCPCheck(t *testing.T) {
 				return nil, errors.New("no such host")
 			},
 			wantStatus: check.StatusFail,
-			wantName:   "tcp:nonexistent.invalid:80",
+			wantName:   "tcp: nonexistent.invalid:80",
 		},
 		{
 			name:    "custom timeout used",
@@ -87,7 +87,7 @@ func TestTCPCheck(t *testing.T) {
 				return &MockConn{}, nil
 			},
 			wantStatus: check.StatusOK,
-			wantName:   "tcp:localhost:8080",
+			wantName:   "tcp: localhost:8080",
 		},
 		{
 			name:    "default timeout when zero",
@@ -100,7 +100,7 @@ func TestTCPCheck(t *testing.T) {
 				return &MockConn{}, nil
 			},
 			wantStatus: check.StatusOK,
-			wantName:   "tcp:localhost:3000",
+			wantName:   "tcp: localhost:3000",
 		},
 	}
 

--- a/pkg/usercheck/check.go
+++ b/pkg/usercheck/check.go
@@ -32,7 +32,7 @@ type Check struct {
 // Run executes the user check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("user:%s", c.Username),
+		Name: fmt.Sprintf("user: %s", c.Username),
 	}
 
 	u, err := c.Lookup.Lookup(c.Username)

--- a/pkg/usercheck/check_test.go
+++ b/pkg/usercheck/check_test.go
@@ -39,16 +39,16 @@ func TestUserCheck(t *testing.T) {
 				}, nil
 			},
 			wantStatus: check.StatusOK,
-			wantName:   "user:appuser",
+			wantName:   "user: appuser",
 		},
 		{
 			name:     "user not found",
 			username: "nonexistent",
 			lookupFunc: func(username string) (*user.User, error) {
-				return nil, errors.New("user: unknown user nonexistent")
+				return nil, errors.New("user:  unknown user nonexistent")
 			},
 			wantStatus: check.StatusFail,
-			wantName:   "user:nonexistent",
+			wantName:   "user: nonexistent",
 		},
 		{
 			name:     "uid matches",
@@ -62,7 +62,7 @@ func TestUserCheck(t *testing.T) {
 				}, nil
 			},
 			wantStatus: check.StatusOK,
-			wantName:   "user:appuser",
+			wantName:   "user: appuser",
 		},
 		{
 			name:     "uid mismatch",
@@ -76,7 +76,7 @@ func TestUserCheck(t *testing.T) {
 				}, nil
 			},
 			wantStatus: check.StatusFail,
-			wantName:   "user:appuser",
+			wantName:   "user: appuser",
 		},
 		{
 			name:     "gid matches",
@@ -90,7 +90,7 @@ func TestUserCheck(t *testing.T) {
 				}, nil
 			},
 			wantStatus: check.StatusOK,
-			wantName:   "user:appuser",
+			wantName:   "user: appuser",
 		},
 		{
 			name:     "gid mismatch",
@@ -104,7 +104,7 @@ func TestUserCheck(t *testing.T) {
 				}, nil
 			},
 			wantStatus: check.StatusFail,
-			wantName:   "user:appuser",
+			wantName:   "user: appuser",
 		},
 		{
 			name:     "home matches",
@@ -118,7 +118,7 @@ func TestUserCheck(t *testing.T) {
 				}, nil
 			},
 			wantStatus: check.StatusOK,
-			wantName:   "user:appuser",
+			wantName:   "user: appuser",
 		},
 		{
 			name:     "home mismatch",
@@ -132,7 +132,7 @@ func TestUserCheck(t *testing.T) {
 				}, nil
 			},
 			wantStatus: check.StatusFail,
-			wantName:   "user:appuser",
+			wantName:   "user: appuser",
 		},
 		{
 			name:     "all constraints match",
@@ -148,7 +148,7 @@ func TestUserCheck(t *testing.T) {
 				}, nil
 			},
 			wantStatus: check.StatusOK,
-			wantName:   "user:appuser",
+			wantName:   "user: appuser",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Add colored output: green `[OK]`, red `[FAIL]`, dim labels
- Auto-enabled in terminals and CI (GitHub Actions, GitLab CI, etc.)
- `PREFLIGHT_COLOR=1` env var for Docker builds
- Improved formatting: aligned details, spaced colons

### Docker usage

```dockerfile
ENV PREFLIGHT_COLOR=1

RUN preflight cmd myapp
RUN preflight env MODEL_PATH
```