### PR TITLE
Refactor: Split main.go and add Result helpers

### DIFF
--- a/cmd/preflight/cmd_cmd.go
+++ b/cmd/preflight/cmd_cmd.go
@@ -46,28 +46,15 @@ func runCmdCheck(cmd *cobra.Command, args []string) error {
 		Runner:       &cmdcheck.RealRunner{},
 	}
 
-	if minVersion != "" {
-		v, err := version.Parse(minVersion)
-		if err != nil {
-			return fmt.Errorf("invalid --min version: %w", err)
-		}
-		c.MinVersion = &v
+	var err error
+	if c.MinVersion, err = version.ParseOptional(minVersion); err != nil {
+		return fmt.Errorf("invalid --min version: %w", err)
 	}
-
-	if maxVersion != "" {
-		v, err := version.Parse(maxVersion)
-		if err != nil {
-			return fmt.Errorf("invalid --max version: %w", err)
-		}
-		c.MaxVersion = &v
+	if c.MaxVersion, err = version.ParseOptional(maxVersion); err != nil {
+		return fmt.Errorf("invalid --max version: %w", err)
 	}
-
-	if exactVersion != "" {
-		v, err := version.Parse(exactVersion)
-		if err != nil {
-			return fmt.Errorf("invalid --exact version: %w", err)
-		}
-		c.ExactVersion = &v
+	if c.ExactVersion, err = version.ParseOptional(exactVersion); err != nil {
+		return fmt.Errorf("invalid --exact version: %w", err)
 	}
 
 	result := c.Run()

--- a/cmd/preflight/cmd_cmd.go
+++ b/cmd/preflight/cmd_cmd.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vertti/preflight/pkg/cmdcheck"
+	"github.com/vertti/preflight/pkg/output"
+	"github.com/vertti/preflight/pkg/version"
+)
+
+var (
+	minVersion   string
+	maxVersion   string
+	exactVersion string
+	matchPattern string
+	versionCmd   string
+)
+
+var cmdCmd = &cobra.Command{
+	Use:   "cmd <command>",
+	Short: "Check that a command exists and can run",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runCmdCheck,
+}
+
+func init() {
+	cmdCmd.Flags().StringVar(&minVersion, "min", "", "minimum version required (inclusive)")
+	cmdCmd.Flags().StringVar(&maxVersion, "max", "", "maximum version allowed (exclusive)")
+	cmdCmd.Flags().StringVar(&exactVersion, "exact", "", "exact version required")
+	cmdCmd.Flags().StringVar(&matchPattern, "match", "", "regex pattern to match against version output")
+	cmdCmd.Flags().StringVar(&versionCmd, "version-cmd", "--version", "command to get version")
+	rootCmd.AddCommand(cmdCmd)
+}
+
+func runCmdCheck(cmd *cobra.Command, args []string) error {
+	commandName := args[0]
+
+	c := &cmdcheck.Check{
+		Name:         commandName,
+		VersionArgs:  parseVersionArgs(versionCmd),
+		MatchPattern: matchPattern,
+		Runner:       &cmdcheck.RealRunner{},
+	}
+
+	if minVersion != "" {
+		v, err := version.Parse(minVersion)
+		if err != nil {
+			return fmt.Errorf("invalid --min version: %w", err)
+		}
+		c.MinVersion = &v
+	}
+
+	if maxVersion != "" {
+		v, err := version.Parse(maxVersion)
+		if err != nil {
+			return fmt.Errorf("invalid --max version: %w", err)
+		}
+		c.MaxVersion = &v
+	}
+
+	if exactVersion != "" {
+		v, err := version.Parse(exactVersion)
+		if err != nil {
+			return fmt.Errorf("invalid --exact version: %w", err)
+		}
+		c.ExactVersion = &v
+	}
+
+	result := c.Run()
+	output.PrintResult(result)
+
+	if !result.OK() {
+		os.Exit(1)
+	}
+	return nil
+}
+
+func parseVersionArgs(s string) []string {
+	return strings.Fields(s)
+}

--- a/cmd/preflight/cmd_env.go
+++ b/cmd/preflight/cmd_env.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vertti/preflight/pkg/envcheck"
+	"github.com/vertti/preflight/pkg/output"
+)
+
+var (
+	envRequired   bool
+	envMatch      string
+	envExact      string
+	envOneOf      []string
+	envHideValue  bool
+	envMaskValue  bool
+	envStartsWith string
+	envEndsWith   string
+	envContains   string
+	envIsNumeric  bool
+	envMinLen     int
+	envMaxLen     int
+)
+
+var envCmd = &cobra.Command{
+	Use:   "env <variable>",
+	Short: "Check that an environment variable is set",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runEnvCheck,
+}
+
+func init() {
+	envCmd.Flags().BoolVar(&envRequired, "required", false, "fail if not set (allows empty)")
+	envCmd.Flags().StringVar(&envMatch, "match", "", "regex pattern to match value")
+	envCmd.Flags().StringVar(&envExact, "exact", "", "exact value required")
+	envCmd.Flags().StringSliceVar(&envOneOf, "one-of", nil, "value must be one of these (comma-separated)")
+	envCmd.Flags().BoolVar(&envHideValue, "hide-value", false, "don't show value in output")
+	envCmd.Flags().BoolVar(&envMaskValue, "mask-value", false, "show masked value (first/last 3 chars)")
+	envCmd.Flags().StringVar(&envStartsWith, "starts-with", "", "value must start with this string")
+	envCmd.Flags().StringVar(&envEndsWith, "ends-with", "", "value must end with this string")
+	envCmd.Flags().StringVar(&envContains, "contains", "", "value must contain this string")
+	envCmd.Flags().BoolVar(&envIsNumeric, "is-numeric", false, "value must be a valid number")
+	envCmd.Flags().IntVar(&envMinLen, "min-len", 0, "minimum string length")
+	envCmd.Flags().IntVar(&envMaxLen, "max-len", 0, "maximum string length")
+	rootCmd.AddCommand(envCmd)
+}
+
+func runEnvCheck(cmd *cobra.Command, args []string) error {
+	varName := args[0]
+
+	c := &envcheck.Check{
+		Name:       varName,
+		Required:   envRequired,
+		Match:      envMatch,
+		Exact:      envExact,
+		OneOf:      envOneOf,
+		HideValue:  envHideValue,
+		MaskValue:  envMaskValue,
+		StartsWith: envStartsWith,
+		EndsWith:   envEndsWith,
+		Contains:   envContains,
+		IsNumeric:  envIsNumeric,
+		MinLen:     envMinLen,
+		MaxLen:     envMaxLen,
+		Getter:     &envcheck.RealEnvGetter{},
+	}
+
+	result := c.Run()
+	output.PrintResult(result)
+
+	if !result.OK() {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/cmd/preflight/cmd_file.go
+++ b/cmd/preflight/cmd_file.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vertti/preflight/pkg/filecheck"
+	"github.com/vertti/preflight/pkg/output"
+)
+
+var (
+	fileDir        bool
+	fileWritable   bool
+	fileExecutable bool
+	fileNotEmpty   bool
+	fileMinSize    int64
+	fileMaxSize    int64
+	fileMatch      string
+	fileContains   string
+	fileHead       int64
+	fileMode       string
+	fileModeExact  string
+)
+
+var fileCmd = &cobra.Command{
+	Use:   "file <path>",
+	Short: "Check that a file or directory exists and meets requirements",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runFileCheck,
+}
+
+func init() {
+	fileCmd.Flags().BoolVar(&fileDir, "dir", false, "expect a directory")
+	fileCmd.Flags().BoolVar(&fileWritable, "writable", false, "check write permission")
+	fileCmd.Flags().BoolVar(&fileExecutable, "executable", false, "check execute permission")
+	fileCmd.Flags().BoolVar(&fileNotEmpty, "not-empty", false, "file must have size > 0")
+	fileCmd.Flags().Int64Var(&fileMinSize, "min-size", 0, "minimum file size in bytes")
+	fileCmd.Flags().Int64Var(&fileMaxSize, "max-size", 0, "maximum file size in bytes")
+	fileCmd.Flags().StringVar(&fileMatch, "match", "", "regex pattern to match content")
+	fileCmd.Flags().StringVar(&fileContains, "contains", "", "literal string to search in content")
+	fileCmd.Flags().Int64Var(&fileHead, "head", 0, "limit content read to first N bytes")
+	fileCmd.Flags().StringVar(&fileMode, "mode", "", "minimum permissions (e.g., 0644)")
+	fileCmd.Flags().StringVar(&fileModeExact, "mode-exact", "", "exact permissions required")
+	rootCmd.AddCommand(fileCmd)
+}
+
+func runFileCheck(cmd *cobra.Command, args []string) error {
+	path := args[0]
+
+	c := &filecheck.Check{
+		Path:       path,
+		ExpectDir:  fileDir,
+		Writable:   fileWritable,
+		Executable: fileExecutable,
+		NotEmpty:   fileNotEmpty,
+		MinSize:    fileMinSize,
+		MaxSize:    fileMaxSize,
+		Match:      fileMatch,
+		Contains:   fileContains,
+		Head:       fileHead,
+		Mode:       fileMode,
+		ModeExact:  fileModeExact,
+		FS:         &filecheck.RealFileSystem{},
+	}
+
+	result := c.Run()
+	output.PrintResult(result)
+
+	if !result.OK() {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/cmd/preflight/cmd_run.go
+++ b/cmd/preflight/cmd_run.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vertti/preflight/pkg/preflightfile"
+)
+
+var runFile string
+
+var runCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run checks from a .preflight file",
+	Args:  cobra.NoArgs,
+	RunE:  runRun,
+}
+
+func init() {
+	runCmd.Flags().StringVar(&runFile, "file", "", "path to .preflight file (default: search up from current directory)")
+	rootCmd.AddCommand(runCmd)
+}
+
+func runRun(cmd *cobra.Command, args []string) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	preflightPath, err := preflightfile.FindFile(wd, runFile)
+	if err != nil {
+		return err
+	}
+
+	commands, err := preflightfile.ParseFile(preflightPath)
+	if err != nil {
+		return err
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %w", err)
+	}
+
+	for _, command := range commands {
+		parts := strings.Fields(command)
+		if len(parts) == 0 {
+			continue
+		}
+
+		if parts[0] == "preflight" {
+			parts[0] = executable
+		}
+
+		execCmd := exec.Command(parts[0], parts[1:]...)
+		execCmd.Stdout = os.Stdout
+		execCmd.Stderr = os.Stderr
+		execCmd.Stdin = os.Stdin
+
+		if err := execCmd.Run(); err != nil {
+			if exitError, ok := err.(*exec.ExitError); ok {
+				os.Exit(exitError.ExitCode())
+			}
+			return fmt.Errorf("failed to execute command %q: %w", command, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/preflight/cmd_tcp.go
+++ b/cmd/preflight/cmd_tcp.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vertti/preflight/pkg/output"
+	"github.com/vertti/preflight/pkg/tcpcheck"
+)
+
+var tcpTimeout time.Duration
+
+var tcpCmd = &cobra.Command{
+	Use:   "tcp <host:port>",
+	Short: "Check TCP connectivity to a host:port",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTCPCheck,
+}
+
+func init() {
+	tcpCmd.Flags().DurationVar(&tcpTimeout, "timeout", 5*time.Second, "connection timeout")
+	rootCmd.AddCommand(tcpCmd)
+}
+
+func runTCPCheck(cmd *cobra.Command, args []string) error {
+	address := args[0]
+
+	c := &tcpcheck.Check{
+		Address: address,
+		Timeout: tcpTimeout,
+		Dialer:  &tcpcheck.RealDialer{},
+	}
+
+	result := c.Run()
+	output.PrintResult(result)
+
+	if !result.OK() {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/cmd/preflight/cmd_user.go
+++ b/cmd/preflight/cmd_user.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vertti/preflight/pkg/output"
+	"github.com/vertti/preflight/pkg/usercheck"
+)
+
+var (
+	userUID  string
+	userGID  string
+	userHome string
+)
+
+var userCmd = &cobra.Command{
+	Use:   "user <username>",
+	Short: "Check that a user exists and meets requirements",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runUserCheck,
+}
+
+func init() {
+	userCmd.Flags().StringVar(&userUID, "uid", "", "expected user ID")
+	userCmd.Flags().StringVar(&userGID, "gid", "", "expected primary group ID")
+	userCmd.Flags().StringVar(&userHome, "home", "", "expected home directory")
+	rootCmd.AddCommand(userCmd)
+}
+
+func runUserCheck(cmd *cobra.Command, args []string) error {
+	username := args[0]
+
+	c := &usercheck.Check{
+		Username: username,
+		UID:      userUID,
+		GID:      userGID,
+		Home:     userHome,
+		Lookup:   &usercheck.RealUserLookup{},
+	}
+
+	result := c.Run()
+	output.PrintResult(result)
+
+	if !result.OK() {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/vertti/preflight/pkg/envcheck"
 	"github.com/vertti/preflight/pkg/filecheck"
 	"github.com/vertti/preflight/pkg/output"
 	"github.com/vertti/preflight/pkg/preflightfile"
@@ -55,13 +54,6 @@ var rootCmd = &cobra.Command{
 	Version: Version,
 }
 
-var envCmd = &cobra.Command{
-	Use:   "env <variable>",
-	Short: "Check that an environment variable is set",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runEnvCheck,
-}
-
 var fileCmd = &cobra.Command{
 	Use:   "file <path>",
 	Short: "Check that a file or directory exists and meets requirements",
@@ -91,20 +83,6 @@ var runCmd = &cobra.Command{
 }
 
 var (
-	// env flags
-	envRequired   bool
-	envMatch      string
-	envExact      string
-	envOneOf      []string
-	envHideValue  bool
-	envMaskValue  bool
-	envStartsWith string
-	envEndsWith   string
-	envContains   string
-	envIsNumeric  bool
-	envMinLen     int
-	envMaxLen     int
-
 	// file flags
 	fileDir        bool
 	fileWritable   bool
@@ -131,21 +109,6 @@ var (
 )
 
 func init() {
-	// env subcommand
-	envCmd.Flags().BoolVar(&envRequired, "required", false, "fail if not set (allows empty)")
-	envCmd.Flags().StringVar(&envMatch, "match", "", "regex pattern to match value")
-	envCmd.Flags().StringVar(&envExact, "exact", "", "exact value required")
-	envCmd.Flags().StringSliceVar(&envOneOf, "one-of", nil, "value must be one of these (comma-separated)")
-	envCmd.Flags().BoolVar(&envHideValue, "hide-value", false, "don't show value in output")
-	envCmd.Flags().BoolVar(&envMaskValue, "mask-value", false, "show masked value (first/last 3 chars)")
-	envCmd.Flags().StringVar(&envStartsWith, "starts-with", "", "value must start with this string")
-	envCmd.Flags().StringVar(&envEndsWith, "ends-with", "", "value must end with this string")
-	envCmd.Flags().StringVar(&envContains, "contains", "", "value must contain this string")
-	envCmd.Flags().BoolVar(&envIsNumeric, "is-numeric", false, "value must be a valid number")
-	envCmd.Flags().IntVar(&envMinLen, "min-len", 0, "minimum string length")
-	envCmd.Flags().IntVar(&envMaxLen, "max-len", 0, "maximum string length")
-	rootCmd.AddCommand(envCmd)
-
 	// file subcommand
 	fileCmd.Flags().BoolVar(&fileDir, "dir", false, "expect a directory")
 	fileCmd.Flags().BoolVar(&fileWritable, "writable", false, "check write permission")
@@ -173,35 +136,6 @@ func init() {
 	// run subcommand
 	runCmd.Flags().StringVar(&runFile, "file", "", "path to .preflight file (default: search up from current directory)")
 	rootCmd.AddCommand(runCmd)
-}
-
-func runEnvCheck(cmd *cobra.Command, args []string) error {
-	varName := args[0]
-
-	c := &envcheck.Check{
-		Name:       varName,
-		Required:   envRequired,
-		Match:      envMatch,
-		Exact:      envExact,
-		OneOf:      envOneOf,
-		HideValue:  envHideValue,
-		MaskValue:  envMaskValue,
-		StartsWith: envStartsWith,
-		EndsWith:   envEndsWith,
-		Contains:   envContains,
-		IsNumeric:  envIsNumeric,
-		MinLen:     envMinLen,
-		MaxLen:     envMaxLen,
-		Getter:     &envcheck.RealEnvGetter{},
-	}
-
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
 }
 
 func runFileCheck(cmd *cobra.Command, args []string) error {

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -1,14 +1,10 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
-
-	"github.com/vertti/preflight/pkg/preflightfile"
 )
 
 // Version is set at build time via ldflags
@@ -47,65 +43,4 @@ var rootCmd = &cobra.Command{
 	Short:   "Docker preflight checks for your runtime environment",
 	Long:    "Preflight is a CLI tool for running sanity checks on container and CI environments.",
 	Version: Version,
-}
-
-var runCmd = &cobra.Command{
-	Use:   "run",
-	Short: "Run checks from a .preflight file",
-	Args:  cobra.NoArgs,
-	RunE:  runRun,
-}
-
-var runFile string
-
-func init() {
-	runCmd.Flags().StringVar(&runFile, "file", "", "path to .preflight file (default: search up from current directory)")
-	rootCmd.AddCommand(runCmd)
-}
-
-func runRun(cmd *cobra.Command, args []string) error {
-	wd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get working directory: %w", err)
-	}
-
-	preflightPath, err := preflightfile.FindFile(wd, runFile)
-	if err != nil {
-		return err
-	}
-
-	commands, err := preflightfile.ParseFile(preflightPath)
-	if err != nil {
-		return err
-	}
-
-	executable, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("failed to get executable path: %w", err)
-	}
-
-	for _, command := range commands {
-		parts := strings.Fields(command)
-		if len(parts) == 0 {
-			continue
-		}
-
-		if parts[0] == "preflight" {
-			parts[0] = executable
-		}
-
-		execCmd := exec.Command(parts[0], parts[1:]...)
-		execCmd.Stdout = os.Stdout
-		execCmd.Stderr = os.Stderr
-		execCmd.Stdin = os.Stdin
-
-		if err := execCmd.Run(); err != nil {
-			if exitError, ok := err.(*exec.ExitError); ok {
-				os.Exit(exitError.ExitCode())
-			}
-			return fmt.Errorf("failed to execute command %q: %w", command, err)
-		}
-	}
-
-	return nil
 }

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -5,14 +5,10 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
-	"github.com/vertti/preflight/pkg/output"
 	"github.com/vertti/preflight/pkg/preflightfile"
-	"github.com/vertti/preflight/pkg/tcpcheck"
-	"github.com/vertti/preflight/pkg/usercheck"
 )
 
 // Version is set at build time via ldflags
@@ -53,20 +49,6 @@ var rootCmd = &cobra.Command{
 	Version: Version,
 }
 
-var tcpCmd = &cobra.Command{
-	Use:   "tcp <host:port>",
-	Short: "Check TCP connectivity to a host:port",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runTCPCheck,
-}
-
-var userCmd = &cobra.Command{
-	Use:   "user <username>",
-	Short: "Check that a user exists and meets requirements",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runUserCheck,
-}
-
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run checks from a .preflight file",
@@ -74,71 +56,11 @@ var runCmd = &cobra.Command{
 	RunE:  runRun,
 }
 
-var (
-	// tcp flags
-	tcpTimeout time.Duration
-
-	// user flags
-	userUID  string
-	userGID  string
-	userHome string
-
-	// run flags
-	runFile string
-)
+var runFile string
 
 func init() {
-	// tcp subcommand
-	tcpCmd.Flags().DurationVar(&tcpTimeout, "timeout", 5*time.Second, "connection timeout")
-	rootCmd.AddCommand(tcpCmd)
-
-	// user subcommand
-	userCmd.Flags().StringVar(&userUID, "uid", "", "expected user ID")
-	userCmd.Flags().StringVar(&userGID, "gid", "", "expected primary group ID")
-	userCmd.Flags().StringVar(&userHome, "home", "", "expected home directory")
-	rootCmd.AddCommand(userCmd)
-
-	// run subcommand
 	runCmd.Flags().StringVar(&runFile, "file", "", "path to .preflight file (default: search up from current directory)")
 	rootCmd.AddCommand(runCmd)
-}
-
-func runTCPCheck(cmd *cobra.Command, args []string) error {
-	address := args[0]
-
-	c := &tcpcheck.Check{
-		Address: address,
-		Timeout: tcpTimeout,
-		Dialer:  &tcpcheck.RealDialer{},
-	}
-
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
-}
-
-func runUserCheck(cmd *cobra.Command, args []string) error {
-	username := args[0]
-
-	c := &usercheck.Check{
-		Username: username,
-		UID:      userUID,
-		GID:      userGID,
-		Home:     userHome,
-		Lookup:   &usercheck.RealUserLookup{},
-	}
-
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
 }
 
 func runRun(cmd *cobra.Command, args []string) error {

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/vertti/preflight/pkg/filecheck"
 	"github.com/vertti/preflight/pkg/output"
 	"github.com/vertti/preflight/pkg/preflightfile"
 	"github.com/vertti/preflight/pkg/tcpcheck"
@@ -54,13 +53,6 @@ var rootCmd = &cobra.Command{
 	Version: Version,
 }
 
-var fileCmd = &cobra.Command{
-	Use:   "file <path>",
-	Short: "Check that a file or directory exists and meets requirements",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runFileCheck,
-}
-
 var tcpCmd = &cobra.Command{
 	Use:   "tcp <host:port>",
 	Short: "Check TCP connectivity to a host:port",
@@ -83,19 +75,6 @@ var runCmd = &cobra.Command{
 }
 
 var (
-	// file flags
-	fileDir        bool
-	fileWritable   bool
-	fileExecutable bool
-	fileNotEmpty   bool
-	fileMinSize    int64
-	fileMaxSize    int64
-	fileMatch      string
-	fileContains   string
-	fileHead       int64
-	fileMode       string
-	fileModeExact  string
-
 	// tcp flags
 	tcpTimeout time.Duration
 
@@ -109,20 +88,6 @@ var (
 )
 
 func init() {
-	// file subcommand
-	fileCmd.Flags().BoolVar(&fileDir, "dir", false, "expect a directory")
-	fileCmd.Flags().BoolVar(&fileWritable, "writable", false, "check write permission")
-	fileCmd.Flags().BoolVar(&fileExecutable, "executable", false, "check execute permission")
-	fileCmd.Flags().BoolVar(&fileNotEmpty, "not-empty", false, "file must have size > 0")
-	fileCmd.Flags().Int64Var(&fileMinSize, "min-size", 0, "minimum file size in bytes")
-	fileCmd.Flags().Int64Var(&fileMaxSize, "max-size", 0, "maximum file size in bytes")
-	fileCmd.Flags().StringVar(&fileMatch, "match", "", "regex pattern to match content")
-	fileCmd.Flags().StringVar(&fileContains, "contains", "", "literal string to search in content")
-	fileCmd.Flags().Int64Var(&fileHead, "head", 0, "limit content read to first N bytes")
-	fileCmd.Flags().StringVar(&fileMode, "mode", "", "minimum permissions (e.g., 0644)")
-	fileCmd.Flags().StringVar(&fileModeExact, "mode-exact", "", "exact permissions required")
-	rootCmd.AddCommand(fileCmd)
-
 	// tcp subcommand
 	tcpCmd.Flags().DurationVar(&tcpTimeout, "timeout", 5*time.Second, "connection timeout")
 	rootCmd.AddCommand(tcpCmd)
@@ -136,34 +101,6 @@ func init() {
 	// run subcommand
 	runCmd.Flags().StringVar(&runFile, "file", "", "path to .preflight file (default: search up from current directory)")
 	rootCmd.AddCommand(runCmd)
-}
-
-func runFileCheck(cmd *cobra.Command, args []string) error {
-	path := args[0]
-
-	c := &filecheck.Check{
-		Path:       path,
-		ExpectDir:  fileDir,
-		Writable:   fileWritable,
-		Executable: fileExecutable,
-		NotEmpty:   fileNotEmpty,
-		MinSize:    fileMinSize,
-		MaxSize:    fileMaxSize,
-		Match:      fileMatch,
-		Contains:   fileContains,
-		Head:       fileHead,
-		Mode:       fileMode,
-		ModeExact:  fileModeExact,
-		FS:         &filecheck.RealFileSystem{},
-	}
-
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
 }
 
 func runTCPCheck(cmd *cobra.Command, args []string) error {

--- a/pkg/check/checker.go
+++ b/pkg/check/checker.go
@@ -1,0 +1,15 @@
+package check
+
+// Checker is implemented by all check types.
+// Each check validates a specific aspect of the environment
+// and returns a Result indicating success or failure.
+//
+// Implementations:
+//   - cmdcheck.Check: verifies command existence and version
+//   - envcheck.Check: validates environment variables
+//   - filecheck.Check: checks file/directory properties
+//   - tcpcheck.Check: tests TCP connectivity
+//   - usercheck.Check: verifies user existence and properties
+type Checker interface {
+	Run() Result
+}

--- a/pkg/check/helpers.go
+++ b/pkg/check/helpers.go
@@ -1,0 +1,27 @@
+package check
+
+import "fmt"
+
+// Fail sets the result to failed status with a detail message.
+func (r *Result) Fail(detail string, err error) *Result {
+	r.Status = StatusFail
+	r.Details = append(r.Details, detail)
+	r.Err = err
+	return r
+}
+
+// Failf sets the result to failed status with a formatted detail message.
+func (r *Result) Failf(format string, args ...interface{}) *Result {
+	return r.Fail(fmt.Sprintf(format, args...), fmt.Errorf(format, args...))
+}
+
+// AddDetail appends a detail line to the result.
+func (r *Result) AddDetail(detail string) *Result {
+	r.Details = append(r.Details, detail)
+	return r
+}
+
+// AddDetailf appends a formatted detail line to the result.
+func (r *Result) AddDetailf(format string, args ...interface{}) *Result {
+	return r.AddDetail(fmt.Sprintf(format, args...))
+}

--- a/pkg/check/helpers_test.go
+++ b/pkg/check/helpers_test.go
@@ -1,0 +1,68 @@
+package check
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestResult_Fail(t *testing.T) {
+	r := &Result{Name: "test"}
+	err := errors.New("test error")
+
+	result := r.Fail("something failed", err)
+
+	if result.Status != StatusFail {
+		t.Errorf("Status = %v, want %v", result.Status, StatusFail)
+	}
+	if len(result.Details) != 1 || result.Details[0] != "something failed" {
+		t.Errorf("Details = %v, want [something failed]", result.Details)
+	}
+	if result.Err != err {
+		t.Errorf("Err = %v, want %v", result.Err, err)
+	}
+	if result != r {
+		t.Error("Fail should return the same Result pointer")
+	}
+}
+
+func TestResult_Failf(t *testing.T) {
+	r := &Result{Name: "test"}
+
+	result := r.Failf("value %d is invalid", 42)
+
+	if result.Status != StatusFail {
+		t.Errorf("Status = %v, want %v", result.Status, StatusFail)
+	}
+	if len(result.Details) != 1 || result.Details[0] != "value 42 is invalid" {
+		t.Errorf("Details = %v, want [value 42 is invalid]", result.Details)
+	}
+	if result.Err == nil || result.Err.Error() != "value 42 is invalid" {
+		t.Errorf("Err = %v, want error with message 'value 42 is invalid'", result.Err)
+	}
+}
+
+func TestResult_AddDetail(t *testing.T) {
+	r := &Result{Name: "test"}
+
+	result := r.AddDetail("first detail").AddDetail("second detail")
+
+	if len(result.Details) != 2 {
+		t.Errorf("len(Details) = %d, want 2", len(result.Details))
+	}
+	if result.Details[0] != "first detail" || result.Details[1] != "second detail" {
+		t.Errorf("Details = %v, want [first detail, second detail]", result.Details)
+	}
+	if result != r {
+		t.Error("AddDetail should return the same Result pointer")
+	}
+}
+
+func TestResult_AddDetailf(t *testing.T) {
+	r := &Result{Name: "test"}
+
+	result := r.AddDetailf("path: %s", "/usr/bin/go")
+
+	if len(result.Details) != 1 || result.Details[0] != "path: /usr/bin/go" {
+		t.Errorf("Details = %v, want [path: /usr/bin/go]", result.Details)
+	}
+}

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -1,0 +1,157 @@
+package output
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+func TestFormatLabel(t *testing.T) {
+	// Save and restore color codes
+	oldDim, oldReset := dim, reset
+	defer func() { dim, reset = oldDim, oldReset }()
+
+	// Test without colors
+	dim, reset = "", ""
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"cmd: go", "cmd: go"},
+		{"path: /usr/bin", "path: /usr/bin"},
+		{"no colon here", "no colon here"},
+		{"multiple: colons: here", "multiple: colons: here"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		got := formatLabel(tt.input)
+		if got != tt.want {
+			t.Errorf("formatLabel(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFormatLabelWithColors(t *testing.T) {
+	// Save and restore color codes
+	oldDim, oldReset := dim, reset
+	defer func() { dim, reset = oldDim, oldReset }()
+
+	// Set test colors
+	dim, reset = "[DIM]", "[RESET]"
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"cmd: go", "[DIM]cmd:[RESET] go"},
+		{"path: /usr/bin", "[DIM]path:[RESET] /usr/bin"},
+		{"no colon here", "no colon here"},
+	}
+
+	for _, tt := range tests {
+		got := formatLabel(tt.input)
+		if got != tt.want {
+			t.Errorf("formatLabel(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestPrintResultOK(t *testing.T) {
+	// Capture stdout
+	output := captureOutput(func() {
+		// Save and restore color codes
+		oldGreen, oldReset, oldDim := green, reset, dim
+		green, reset, dim = "", "", ""
+		defer func() { green, reset, dim = oldGreen, oldReset, oldDim }()
+
+		PrintResult(check.Result{
+			Name:    "cmd: go",
+			Status:  check.StatusOK,
+			Details: []string{"path: /usr/bin/go", "version: 1.21"},
+		})
+	})
+
+	expected := "[OK] cmd: go\n     path: /usr/bin/go\n     version: 1.21\n"
+	if output != expected {
+		t.Errorf("PrintResult output = %q, want %q", output, expected)
+	}
+}
+
+func TestPrintResultFail(t *testing.T) {
+	// Capture stdout
+	output := captureOutput(func() {
+		// Save and restore color codes
+		oldRed, oldReset, oldDim := red, reset, dim
+		red, reset, dim = "", "", ""
+		defer func() { red, reset, dim = oldRed, oldReset, oldDim }()
+
+		PrintResult(check.Result{
+			Name:    "file: /missing",
+			Status:  check.StatusFail,
+			Details: []string{"not found"},
+		})
+	})
+
+	expected := "[FAIL] file: /missing\n       not found\n"
+	if output != expected {
+		t.Errorf("PrintResult output = %q, want %q", output, expected)
+	}
+}
+
+func TestPrintResultIndentation(t *testing.T) {
+	// Test that OK and FAIL have correct indentation for alignment
+	okOutput := captureOutput(func() {
+		oldGreen, oldReset, oldDim := green, reset, dim
+		green, reset, dim = "", "", ""
+		defer func() { green, reset, dim = oldGreen, oldReset, oldDim }()
+
+		PrintResult(check.Result{
+			Name:    "test",
+			Status:  check.StatusOK,
+			Details: []string{"detail"},
+		})
+	})
+
+	failOutput := captureOutput(func() {
+		oldRed, oldReset, oldDim := red, reset, dim
+		red, reset, dim = "", "", ""
+		defer func() { red, reset, dim = oldRed, oldReset, oldDim }()
+
+		PrintResult(check.Result{
+			Name:    "test",
+			Status:  check.StatusFail,
+			Details: []string{"detail"},
+		})
+	})
+
+	// OK: "[OK] " is 5 chars, so detail should have 5 space indent
+	if !strings.Contains(okOutput, "\n     detail\n") {
+		t.Errorf("OK output should have 5-space indent for details, got: %q", okOutput)
+	}
+
+	// FAIL: "[FAIL] " is 7 chars, so detail should have 7 space indent
+	if !strings.Contains(failOutput, "\n       detail\n") {
+		t.Errorf("FAIL output should have 7-space indent for details, got: %q", failOutput)
+	}
+}
+
+func captureOutput(f func()) string {
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	f()
+
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}

--- a/pkg/tcpcheck/check.go
+++ b/pkg/tcpcheck/check.go
@@ -41,14 +41,11 @@ func (c *Check) Run() check.Result {
 
 	conn, err := c.Dialer.DialTimeout("tcp", c.Address, timeout)
 	if err != nil {
-		result.Status = check.StatusFail
-		result.Details = append(result.Details, fmt.Sprintf("connection failed: %v", err))
-		result.Err = err
-		return result
+		return *result.Failf("connection failed: %v", err)
 	}
 	defer func() { _ = conn.Close() }()
 
 	result.Status = check.StatusOK
-	result.Details = append(result.Details, fmt.Sprintf("connected to %s", c.Address))
+	result.AddDetailf("connected to %s", c.Address)
 	return result
 }

--- a/pkg/usercheck/check.go
+++ b/pkg/usercheck/check.go
@@ -37,17 +37,12 @@ func (c *Check) Run() check.Result {
 
 	u, err := c.Lookup.Lookup(c.Username)
 	if err != nil {
-		result.Status = check.StatusFail
-		result.Details = append(result.Details, fmt.Sprintf("user not found: %v", err))
-		result.Err = err
-		return result
+		return *result.Failf("user not found: %v", err)
 	}
 
-	result.Details = append(result.Details,
-		fmt.Sprintf("uid: %s", u.Uid),
-		fmt.Sprintf("gid: %s", u.Gid),
-		fmt.Sprintf("home: %s", u.HomeDir),
-	)
+	result.AddDetailf("uid: %s", u.Uid)
+	result.AddDetailf("gid: %s", u.Gid)
+	result.AddDetailf("home: %s", u.HomeDir)
 
 	checks := []struct {
 		name     string
@@ -61,10 +56,9 @@ func (c *Check) Run() check.Result {
 
 	for _, chk := range checks {
 		if chk.expected != "" && chk.actual != chk.expected {
-			result.Status = check.StatusFail
-			result.Details = append(result.Details, fmt.Sprintf("%s mismatch: expected %s, got %s", chk.name, chk.expected, chk.actual))
-			result.Err = fmt.Errorf("%s mismatch", chk.name)
-			return result
+			return *result.Fail(
+				fmt.Sprintf("%s mismatch: expected %s, got %s", chk.name, chk.expected, chk.actual),
+				fmt.Errorf("%s mismatch", chk.name))
 		}
 	}
 

--- a/pkg/version/parse.go
+++ b/pkg/version/parse.go
@@ -41,6 +41,20 @@ func Parse(s string) (Version, error) {
 	return parseMatches(matches), nil
 }
 
+// ParseOptional parses a version string if non-empty.
+// Returns nil, nil for empty strings.
+func ParseOptional(s string) (*Version, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, nil
+	}
+	v, err := Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
 // Extract finds and parses the first version number in a string.
 func Extract(s string) (Version, error) {
 	matches := versionRegex.FindStringSubmatch(s)

--- a/pkg/version/parse_test.go
+++ b/pkg/version/parse_test.go
@@ -33,6 +33,36 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestParseOptional(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    *Version
+		wantErr bool
+	}{
+		{"", nil, false},
+		{"   ", nil, false},
+		{"1.2.3", &Version{1, 2, 3}, false},
+		{"v1.2", &Version{1, 2, 0}, false},
+		{"abc", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseOptional(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseOptional(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if tt.want == nil && got != nil {
+				t.Errorf("ParseOptional(%q) = %v, want nil", tt.input, got)
+			}
+			if tt.want != nil && (got == nil || *got != *tt.want) {
+				t.Errorf("ParseOptional(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestExtract(t *testing.T) {
 	tests := []struct {
 		input   string


### PR DESCRIPTION
## Summary

- Reduce main.go from 389 to 46 lines by extracting subcommands to separate files
- Add Result helper methods (`Fail`, `Failf`, `AddDetail`, `AddDetailf`) for cleaner error handling
- Add output package tests
- Document the Checker interface

## New structure

```
cmd/preflight/
├── main.go          # 46 lines: root command + file shorthand
├── cmd_cmd.go       # cmd subcommand
├── cmd_env.go       # env subcommand  
├── cmd_file.go      # file subcommand
├── cmd_tcp.go       # tcp subcommand
├── cmd_user.go      # user subcommand
└── cmd_run.go       # run subcommand
```

Adding a new check type now requires:
1. Create `pkg/newcheck/check.go` with a Check struct implementing `Run() check.Result`
2. Create `cmd/preflight/cmd_new.go` with flags, command, and run function