### PR TITLE
Fix code quality issues

### DIFF
--- a/cmd/preflight/cmd_env.go
+++ b/cmd/preflight/cmd_env.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	envRequired   bool
+	envAllowEmpty bool
 	envMatch      string
 	envExact      string
 	envOneOf      []string
@@ -32,7 +32,7 @@ var envCmd = &cobra.Command{
 }
 
 func init() {
-	envCmd.Flags().BoolVar(&envRequired, "required", false, "fail if not set (allows empty)")
+	envCmd.Flags().BoolVar(&envAllowEmpty, "allow-empty", false, "pass if defined but empty")
 	envCmd.Flags().StringVar(&envMatch, "match", "", "regex pattern to match value")
 	envCmd.Flags().StringVar(&envExact, "exact", "", "exact value required")
 	envCmd.Flags().StringSliceVar(&envOneOf, "one-of", nil, "value must be one of these (comma-separated)")
@@ -52,7 +52,7 @@ func runEnvCheck(cmd *cobra.Command, args []string) error {
 
 	c := &envcheck.Check{
 		Name:       varName,
-		Required:   envRequired,
+		AllowEmpty: envAllowEmpty,
 		Match:      envMatch,
 		Exact:      envExact,
 		OneOf:      envOneOf,

--- a/pkg/check/helpers.go
+++ b/pkg/check/helpers.go
@@ -3,15 +3,15 @@ package check
 import "fmt"
 
 // Fail sets the result to failed status with a detail message.
-func (r *Result) Fail(detail string, err error) *Result {
+func (r *Result) Fail(detail string, err error) Result {
 	r.Status = StatusFail
 	r.Details = append(r.Details, detail)
 	r.Err = err
-	return r
+	return *r
 }
 
 // Failf sets the result to failed status with a formatted detail message.
-func (r *Result) Failf(format string, args ...interface{}) *Result {
+func (r *Result) Failf(format string, args ...interface{}) Result {
 	return r.Fail(fmt.Sprintf(format, args...), fmt.Errorf(format, args...))
 }
 

--- a/pkg/check/helpers_test.go
+++ b/pkg/check/helpers_test.go
@@ -20,9 +20,6 @@ func TestResult_Fail(t *testing.T) {
 	if result.Err != err {
 		t.Errorf("Err = %v, want %v", result.Err, err)
 	}
-	if result != r {
-		t.Error("Fail should return the same Result pointer")
-	}
 }
 
 func TestResult_Failf(t *testing.T) {

--- a/pkg/cmdcheck/check.go
+++ b/pkg/cmdcheck/check.go
@@ -27,7 +27,7 @@ func (c *Check) Run() check.Result {
 
 	path, err := c.Runner.LookPath(c.Name)
 	if err != nil {
-		return *result.Failf("not found in PATH: %v", err)
+		return result.Failf("not found in PATH: %v", err)
 	}
 
 	result.AddDetailf("path: %s", path)

--- a/pkg/cmdcheck/check_test.go
+++ b/pkg/cmdcheck/check_test.go
@@ -20,7 +20,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			name: "command not found",
 			check: Check{
 				Name: "nonexistent",
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "", errors.New("executable file not found in $PATH")
 					},
@@ -33,7 +33,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			name: "version command fails",
 			check: Check{
 				Name: "broken",
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/broken", nil
 					},
@@ -48,7 +48,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			name: "command found and runs",
 			check: Check{
 				Name: "node",
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -67,7 +67,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "node",
 				MinVersion: &version.Version{Major: 18, Minor: 0, Patch: 0},
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -83,7 +83,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "node",
 				MinVersion: &version.Version{Major: 18, Minor: 0, Patch: 0},
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -101,7 +101,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "node",
 				MaxVersion: &version.Version{Major: 22, Minor: 0, Patch: 0},
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -117,7 +117,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "node",
 				MaxVersion: &version.Version{Major: 22, Minor: 0, Patch: 0},
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -135,7 +135,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:         "node",
 				ExactVersion: &version.Version{Major: 18, Minor: 17, Patch: 0},
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -151,7 +151,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:         "node",
 				ExactVersion: &version.Version{Major: 18, Minor: 17, Patch: 0},
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -169,7 +169,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:         "node",
 				MatchPattern: `^v18\.`,
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -185,7 +185,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:         "node",
 				MatchPattern: `^v18\.`,
-				Runner: &MockRunner{
+				Runner: &mockRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},

--- a/pkg/cmdcheck/runner.go
+++ b/pkg/cmdcheck/runner.go
@@ -29,18 +29,18 @@ func (r *RealRunner) RunCommand(name string, args ...string) (stdout, stderr str
 	return outBuf.String(), errBuf.String(), err
 }
 
-// MockRunner is a test double for Runner.
-type MockRunner struct {
+// mockRunner is a test double for Runner.
+type mockRunner struct {
 	LookPathFunc   func(file string) (string, error)
 	RunCommandFunc func(name string, args ...string) (string, string, error)
 }
 
 // LookPath calls the mock function.
-func (m *MockRunner) LookPath(file string) (string, error) {
+func (m *mockRunner) LookPath(file string) (string, error) {
 	return m.LookPathFunc(file)
 }
 
 // RunCommand calls the mock function.
-func (m *MockRunner) RunCommand(name string, args ...string) (stdout, stderr string, err error) {
+func (m *mockRunner) RunCommand(name string, args ...string) (stdout, stderr string, err error) {
 	return m.RunCommandFunc(name, args...)
 }

--- a/pkg/cmdcheck/runner_test.go
+++ b/pkg/cmdcheck/runner_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestMockRunner_LookPath(t *testing.T) {
-	mock := &MockRunner{
+	mock := &mockRunner{
 		LookPathFunc: func(file string) (string, error) {
 			if file == "node" {
 				return "/usr/bin/node", nil
@@ -30,7 +30,7 @@ func TestMockRunner_LookPath(t *testing.T) {
 }
 
 func TestMockRunner_RunCommand(t *testing.T) {
-	mock := &MockRunner{
+	mock := &mockRunner{
 		RunCommandFunc: func(name string, args ...string) (string, string, error) {
 			if name == "node" && len(args) == 1 && args[0] == "--version" {
 				return "v18.17.0", "", nil

--- a/pkg/envcheck/check.go
+++ b/pkg/envcheck/check.go
@@ -12,7 +12,7 @@ import (
 // Check verifies that an environment variable meets requirements.
 type Check struct {
 	Name       string    // env var name
-	Required   bool      // --required: fail if undefined (allows empty)
+	AllowEmpty bool      // --allow-empty: pass if defined but empty
 	Match      string    // --match: regex pattern
 	Exact      string    // --exact: exact value
 	OneOf      []string  // --one-of: value must be one of these
@@ -39,9 +39,9 @@ func (c *Check) Run() check.Result {
 		return result.Fail("not set", fmt.Errorf("environment variable %s is not set", c.Name))
 	}
 
-	// --required flag: allow empty values
+	// --allow-empty flag: pass if defined but empty
 	// Default: require non-empty
-	if !c.Required && value == "" {
+	if !c.AllowEmpty && value == "" {
 		return result.Fail("empty value", fmt.Errorf("environment variable %s is empty", c.Name))
 	}
 

--- a/pkg/envcheck/check.go
+++ b/pkg/envcheck/check.go
@@ -36,29 +36,29 @@ func (c *Check) Run() check.Result {
 	value, exists := c.Getter.LookupEnv(c.Name)
 
 	if !exists {
-		return *result.Fail("not set", fmt.Errorf("environment variable %s is not set", c.Name))
+		return result.Fail("not set", fmt.Errorf("environment variable %s is not set", c.Name))
 	}
 
 	// --required flag: allow empty values
 	// Default: require non-empty
 	if !c.Required && value == "" {
-		return *result.Fail("empty value", fmt.Errorf("environment variable %s is empty", c.Name))
+		return result.Fail("empty value", fmt.Errorf("environment variable %s is empty", c.Name))
 	}
 
 	// --match: regex pattern
 	if c.Match != "" {
 		re, err := regexp.Compile(c.Match)
 		if err != nil {
-			return *result.Failf("invalid regex pattern: %v", err)
+			return result.Failf("invalid regex pattern: %v", err)
 		}
 		if !re.MatchString(value) {
-			return *result.Failf("value does not match pattern %q", c.Match)
+			return result.Failf("value does not match pattern %q", c.Match)
 		}
 	}
 
 	// --exact: exact value match
 	if c.Exact != "" && value != c.Exact {
-		return *result.Failf("value does not equal %q", c.Exact)
+		return result.Failf("value does not equal %q", c.Exact)
 	}
 
 	// --one-of: value must be one of the allowed values
@@ -79,34 +79,34 @@ func (c *Check) Run() check.Result {
 
 	// --starts-with: value must start with prefix
 	if c.StartsWith != "" && !strings.HasPrefix(value, c.StartsWith) {
-		return *result.Failf("value does not start with %q", c.StartsWith)
+		return result.Failf("value does not start with %q", c.StartsWith)
 	}
 
 	// --ends-with: value must end with suffix
 	if c.EndsWith != "" && !strings.HasSuffix(value, c.EndsWith) {
-		return *result.Failf("value does not end with %q", c.EndsWith)
+		return result.Failf("value does not end with %q", c.EndsWith)
 	}
 
 	// --contains: value must contain substring
 	if c.Contains != "" && !strings.Contains(value, c.Contains) {
-		return *result.Failf("value does not contain %q", c.Contains)
+		return result.Failf("value does not contain %q", c.Contains)
 	}
 
 	// --is-numeric: value must be a valid number
 	if c.IsNumeric {
 		if _, err := strconv.ParseFloat(value, 64); err != nil {
-			return *result.Fail("value is not numeric", fmt.Errorf("value is not numeric"))
+			return result.Fail("value is not numeric", fmt.Errorf("value is not numeric"))
 		}
 	}
 
 	// --min-len: minimum string length
 	if c.MinLen > 0 && len(value) < c.MinLen {
-		return *result.Failf("value length %d < minimum %d", len(value), c.MinLen)
+		return result.Failf("value length %d < minimum %d", len(value), c.MinLen)
 	}
 
 	// --max-len: maximum string length
 	if c.MaxLen > 0 && len(value) > c.MaxLen {
-		return *result.Failf("value length %d > maximum %d", len(value), c.MaxLen)
+		return result.Failf("value length %d > maximum %d", len(value), c.MaxLen)
 	}
 
 	result.Status = check.StatusOK

--- a/pkg/envcheck/check_test.go
+++ b/pkg/envcheck/check_test.go
@@ -42,22 +42,22 @@ func TestEnvCheck_Run(t *testing.T) {
 			wantDetail: "value: some_value",
 		},
 
-		// --required flag tests
+		// --allow-empty flag tests
 		{
-			name: "required allows empty value",
+			name: "allow-empty allows empty value",
 			check: Check{
-				Name:     "EMPTY_VAR",
-				Required: true,
-				Getter:   &MockEnvGetter{Vars: map[string]string{"EMPTY_VAR": ""}},
+				Name:       "EMPTY_VAR",
+				AllowEmpty: true,
+				Getter:     &MockEnvGetter{Vars: map[string]string{"EMPTY_VAR": ""}},
 			},
 			wantStatus: check.StatusOK,
 		},
 		{
-			name: "required still fails if undefined",
+			name: "allow-empty still fails if undefined",
 			check: Check{
-				Name:     "MISSING_VAR",
-				Required: true,
-				Getter:   &MockEnvGetter{Vars: map[string]string{}},
+				Name:       "MISSING_VAR",
+				AllowEmpty: true,
+				Getter:     &MockEnvGetter{Vars: map[string]string{}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: "not set",

--- a/pkg/envcheck/check_test.go
+++ b/pkg/envcheck/check_test.go
@@ -18,7 +18,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			name: "undefined variable fails",
 			check: Check{
 				Name:   "MISSING_VAR",
-				Getter: &MockEnvGetter{Vars: map[string]string{}},
+				Getter: &mockEnvGetter{Vars: map[string]string{}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: "not set",
@@ -27,7 +27,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			name: "empty variable fails by default",
 			check: Check{
 				Name:   "EMPTY_VAR",
-				Getter: &MockEnvGetter{Vars: map[string]string{"EMPTY_VAR": ""}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"EMPTY_VAR": ""}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: "empty value",
@@ -36,7 +36,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			name: "non-empty variable passes",
 			check: Check{
 				Name:   "MY_VAR",
-				Getter: &MockEnvGetter{Vars: map[string]string{"MY_VAR": "some_value"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"MY_VAR": "some_value"}},
 			},
 			wantStatus: check.StatusOK,
 			wantDetail: "value: some_value",
@@ -48,7 +48,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "EMPTY_VAR",
 				AllowEmpty: true,
-				Getter:     &MockEnvGetter{Vars: map[string]string{"EMPTY_VAR": ""}},
+				Getter:     &mockEnvGetter{Vars: map[string]string{"EMPTY_VAR": ""}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -57,7 +57,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "MISSING_VAR",
 				AllowEmpty: true,
-				Getter:     &MockEnvGetter{Vars: map[string]string{}},
+				Getter:     &mockEnvGetter{Vars: map[string]string{}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: "not set",
@@ -69,7 +69,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:   "DATABASE_URL",
 				Match:  `^postgres://`,
-				Getter: &MockEnvGetter{Vars: map[string]string{"DATABASE_URL": "postgres://localhost:5432/db"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"DATABASE_URL": "postgres://localhost:5432/db"}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -78,7 +78,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:   "DATABASE_URL",
 				Match:  `^postgres://`,
-				Getter: &MockEnvGetter{Vars: map[string]string{"DATABASE_URL": "mysql://localhost:3306/db"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"DATABASE_URL": "mysql://localhost:3306/db"}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: `value does not match pattern "^postgres://"`,
@@ -90,7 +90,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:   "NODE_ENV",
 				Exact:  "production",
-				Getter: &MockEnvGetter{Vars: map[string]string{"NODE_ENV": "production"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"NODE_ENV": "production"}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -99,7 +99,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:   "NODE_ENV",
 				Exact:  "production",
-				Getter: &MockEnvGetter{Vars: map[string]string{"NODE_ENV": "development"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"NODE_ENV": "development"}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: `value does not equal "production"`,
@@ -111,7 +111,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:   "NODE_ENV",
 				OneOf:  []string{"dev", "staging", "production"},
-				Getter: &MockEnvGetter{Vars: map[string]string{"NODE_ENV": "production"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"NODE_ENV": "production"}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -120,7 +120,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:   "NODE_ENV",
 				OneOf:  []string{"dev", "staging", "production"},
-				Getter: &MockEnvGetter{Vars: map[string]string{"NODE_ENV": "test"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"NODE_ENV": "test"}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: `value "test" not in allowed list [dev staging production]`,
@@ -131,7 +131,7 @@ func TestEnvCheck_Run(t *testing.T) {
 				Name:      "SECRET_ENV",
 				OneOf:     []string{"a", "b", "c"},
 				HideValue: true,
-				Getter:    &MockEnvGetter{Vars: map[string]string{"SECRET_ENV": "x"}},
+				Getter:    &mockEnvGetter{Vars: map[string]string{"SECRET_ENV": "x"}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: `value "[hidden]" not in allowed list [a b c]`,
@@ -143,7 +143,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:      "SECRET",
 				HideValue: true,
-				Getter:    &MockEnvGetter{Vars: map[string]string{"SECRET": "super-secret"}},
+				Getter:    &mockEnvGetter{Vars: map[string]string{"SECRET": "super-secret"}},
 			},
 			wantStatus: check.StatusOK,
 			wantDetail: "value: [hidden]",
@@ -155,7 +155,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:      "API_KEY",
 				MaskValue: true,
-				Getter:    &MockEnvGetter{Vars: map[string]string{"API_KEY": "sk-secret-key-xyz"}},
+				Getter:    &mockEnvGetter{Vars: map[string]string{"API_KEY": "sk-secret-key-xyz"}},
 			},
 			wantStatus: check.StatusOK,
 			wantDetail: "value: sk-•••xyz",
@@ -165,7 +165,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:      "SHORT",
 				MaskValue: true,
-				Getter:    &MockEnvGetter{Vars: map[string]string{"SHORT": "abc"}},
+				Getter:    &mockEnvGetter{Vars: map[string]string{"SHORT": "abc"}},
 			},
 			wantStatus: check.StatusOK,
 			wantDetail: "value: •••",
@@ -177,7 +177,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "PATH",
 				StartsWith: "/usr",
-				Getter:     &MockEnvGetter{Vars: map[string]string{"PATH": "/usr/local/bin"}},
+				Getter:     &mockEnvGetter{Vars: map[string]string{"PATH": "/usr/local/bin"}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -186,7 +186,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "PATH",
 				StartsWith: "/usr",
-				Getter:     &MockEnvGetter{Vars: map[string]string{"PATH": "/opt/bin"}},
+				Getter:     &mockEnvGetter{Vars: map[string]string{"PATH": "/opt/bin"}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: `value does not start with "/usr"`,
@@ -198,7 +198,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:     "CONFIG",
 				EndsWith: ".yaml",
-				Getter:   &MockEnvGetter{Vars: map[string]string{"CONFIG": "/app/config.yaml"}},
+				Getter:   &mockEnvGetter{Vars: map[string]string{"CONFIG": "/app/config.yaml"}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -207,7 +207,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:     "CONFIG",
 				EndsWith: ".yaml",
-				Getter:   &MockEnvGetter{Vars: map[string]string{"CONFIG": "/app/config.json"}},
+				Getter:   &mockEnvGetter{Vars: map[string]string{"CONFIG": "/app/config.json"}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: `value does not end with ".yaml"`,
@@ -219,7 +219,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:     "URL",
 				Contains: "example",
-				Getter:   &MockEnvGetter{Vars: map[string]string{"URL": "https://example.com/api"}},
+				Getter:   &mockEnvGetter{Vars: map[string]string{"URL": "https://example.com/api"}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -228,7 +228,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:     "URL",
 				Contains: "example",
-				Getter:   &MockEnvGetter{Vars: map[string]string{"URL": "https://other.com/api"}},
+				Getter:   &mockEnvGetter{Vars: map[string]string{"URL": "https://other.com/api"}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: `value does not contain "example"`,
@@ -240,7 +240,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:      "PORT",
 				IsNumeric: true,
-				Getter:    &MockEnvGetter{Vars: map[string]string{"PORT": "8080"}},
+				Getter:    &mockEnvGetter{Vars: map[string]string{"PORT": "8080"}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -249,7 +249,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:      "RATE",
 				IsNumeric: true,
-				Getter:    &MockEnvGetter{Vars: map[string]string{"RATE": "3.14"}},
+				Getter:    &mockEnvGetter{Vars: map[string]string{"RATE": "3.14"}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -258,7 +258,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:      "PORT",
 				IsNumeric: true,
-				Getter:    &MockEnvGetter{Vars: map[string]string{"PORT": "not-a-number"}},
+				Getter:    &mockEnvGetter{Vars: map[string]string{"PORT": "not-a-number"}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: "value is not numeric",
@@ -270,7 +270,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:   "API_KEY",
 				MinLen: 10,
-				Getter: &MockEnvGetter{Vars: map[string]string{"API_KEY": "abcdefghijk"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"API_KEY": "abcdefghijk"}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -279,7 +279,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:   "API_KEY",
 				MinLen: 10,
-				Getter: &MockEnvGetter{Vars: map[string]string{"API_KEY": "short"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"API_KEY": "short"}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: "value length 5 < minimum 10",
@@ -291,7 +291,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:   "CODE",
 				MaxLen: 10,
-				Getter: &MockEnvGetter{Vars: map[string]string{"CODE": "abc"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"CODE": "abc"}},
 			},
 			wantStatus: check.StatusOK,
 		},
@@ -300,7 +300,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			check: Check{
 				Name:   "CODE",
 				MaxLen: 5,
-				Getter: &MockEnvGetter{Vars: map[string]string{"CODE": "toolongvalue"}},
+				Getter: &mockEnvGetter{Vars: map[string]string{"CODE": "toolongvalue"}},
 			},
 			wantStatus: check.StatusFail,
 			wantDetail: "value length 12 > maximum 5",

--- a/pkg/envcheck/env.go
+++ b/pkg/envcheck/env.go
@@ -14,12 +14,12 @@ func (r *RealEnvGetter) LookupEnv(key string) (string, bool) {
 	return os.LookupEnv(key)
 }
 
-// MockEnvGetter is a test double for EnvGetter.
-type MockEnvGetter struct {
+// mockEnvGetter is a test double for EnvGetter.
+type mockEnvGetter struct {
 	Vars map[string]string
 }
 
-func (m *MockEnvGetter) LookupEnv(key string) (string, bool) {
+func (m *mockEnvGetter) LookupEnv(key string) (string, bool) {
 	val, ok := m.Vars[key]
 	return val, ok
 }

--- a/pkg/filecheck/check.go
+++ b/pkg/filecheck/check.go
@@ -37,18 +37,18 @@ func (c *Check) Run() check.Result {
 	if err != nil {
 		switch {
 		case os.IsNotExist(err):
-			return *result.Fail("not found", err)
+			return result.Fail("not found", err)
 		case os.IsPermission(err):
-			return *result.Fail("permission denied", err)
+			return result.Fail("permission denied", err)
 		default:
-			return *result.Failf("stat failed: %v", err)
+			return result.Failf("stat failed: %v", err)
 		}
 	}
 
 	// Type check: --dir flag
 	if c.ExpectDir {
 		if !info.IsDir() {
-			return *result.Fail("expected directory, got file", fmt.Errorf("expected directory, got file"))
+			return result.Fail("expected directory, got file", fmt.Errorf("expected directory, got file"))
 		}
 		result.AddDetail("type: directory")
 	} else {
@@ -65,19 +65,19 @@ func (c *Check) Run() check.Result {
 
 		// --not-empty
 		if c.NotEmpty && info.Size() == 0 {
-			return *result.Fail("file is empty", fmt.Errorf("file is empty"))
+			return result.Fail("file is empty", fmt.Errorf("file is empty"))
 		}
 
 		// --min-size
 		if c.MinSize > 0 && info.Size() < c.MinSize {
-			return *result.Fail(
+			return result.Fail(
 				fmt.Sprintf("size %d < minimum %d", info.Size(), c.MinSize),
 				fmt.Errorf("file size %d below minimum %d", info.Size(), c.MinSize))
 		}
 
 		// --max-size
 		if c.MaxSize > 0 && info.Size() > c.MaxSize {
-			return *result.Fail(
+			return result.Fail(
 				fmt.Sprintf("size %d > maximum %d", info.Size(), c.MaxSize),
 				fmt.Errorf("file size %d above maximum %d", info.Size(), c.MaxSize))
 		}
@@ -103,14 +103,14 @@ func (c *Check) Run() check.Result {
 	// --writable
 	if c.Writable {
 		if !isWritable(info.Mode()) {
-			return *result.Fail("not writable", fmt.Errorf("file is not writable"))
+			return result.Fail("not writable", fmt.Errorf("file is not writable"))
 		}
 	}
 
 	// --executable
 	if c.Executable {
 		if !isExecutable(info.Mode()) {
-			return *result.Fail("not executable", fmt.Errorf("file is not executable"))
+			return result.Fail("not executable", fmt.Errorf("file is not executable"))
 		}
 	}
 

--- a/pkg/filecheck/check_test.go
+++ b/pkg/filecheck/check_test.go
@@ -21,9 +21,9 @@ func TestCheck_Run(t *testing.T) {
 			name: "file exists",
 			check: Check{
 				Path: "/etc/config",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "config",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -38,7 +38,7 @@ func TestCheck_Run(t *testing.T) {
 			name: "file not found",
 			check: Check{
 				Path: "/missing",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
 						return nil, os.ErrNotExist
 					},
@@ -51,7 +51,7 @@ func TestCheck_Run(t *testing.T) {
 			name: "permission denied",
 			check: Check{
 				Path: "/secret",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
 						return nil, os.ErrPermission
 					},
@@ -67,9 +67,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:      "/var/log",
 				ExpectDir: true,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue:  "log",
 							IsDirValue: true,
 							ModeValue:  0o755 | fs.ModeDir,
@@ -85,9 +85,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:      "/etc/config",
 				ExpectDir: true,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "config",
 							ModeValue: 0o644,
 						}, nil
@@ -104,9 +104,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:     "/data.json",
 				NotEmpty: true,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "data.json",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -121,9 +121,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:     "/empty.txt",
 				NotEmpty: true,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "empty.txt",
 							SizeValue: 0,
 							ModeValue: 0o644,
@@ -139,9 +139,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:    "/data.json",
 				MinSize: 50,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "data.json",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -156,9 +156,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:    "/data.json",
 				MinSize: 200,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "data.json",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -174,9 +174,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:    "/data.json",
 				MaxSize: 200,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "data.json",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -191,9 +191,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:    "/data.json",
 				MaxSize: 50,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "data.json",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -211,9 +211,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:     "/data.json",
 				Writable: true,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "data.json",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -228,9 +228,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:     "/readonly.txt",
 				Writable: true,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "readonly.txt",
 							SizeValue: 100,
 							ModeValue: 0o444,
@@ -246,9 +246,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:       "/script.sh",
 				Executable: true,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "script.sh",
 							SizeValue: 100,
 							ModeValue: 0o755,
@@ -263,9 +263,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:       "/data.txt",
 				Executable: true,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "data.txt",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -283,9 +283,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path: "/key.pem",
 				Mode: "0600",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "key.pem",
 							SizeValue: 100,
 							ModeValue: 0o600,
@@ -300,9 +300,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path: "/key.pem",
 				Mode: "0600",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "key.pem",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -317,9 +317,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path: "/key.pem",
 				Mode: "0644",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "key.pem",
 							SizeValue: 100,
 							ModeValue: 0o600,
@@ -335,9 +335,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:      "/key.pem",
 				ModeExact: "0600",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "key.pem",
 							SizeValue: 100,
 							ModeValue: 0o600,
@@ -352,9 +352,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:      "/key.pem",
 				ModeExact: "0600",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "key.pem",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -372,9 +372,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:     "/config.txt",
 				Contains: "database",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "config.txt",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -392,9 +392,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:     "/config.txt",
 				Contains: "redis",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "config.txt",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -413,9 +413,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:  "/hosts",
 				Match: "^127\\.0\\.0\\.1",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "hosts",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -433,9 +433,9 @@ func TestCheck_Run(t *testing.T) {
 			check: Check{
 				Path:  "/hosts",
 				Match: "^192\\.168",
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "hosts",
 							SizeValue: 100,
 							ModeValue: 0o644,
@@ -455,9 +455,9 @@ func TestCheck_Run(t *testing.T) {
 				Path:     "/large.log",
 				Contains: "ERROR",
 				Head:     1024,
-				FS: &MockFileSystem{
+				FS: &mockFileSystem{
 					StatFunc: func(name string) (fs.FileInfo, error) {
-						return &MockFileInfo{
+						return &mockFileInfo{
 							NameValue: "large.log",
 							SizeValue: 10000,
 							ModeValue: 0o644,

--- a/pkg/filecheck/fs.go
+++ b/pkg/filecheck/fs.go
@@ -37,24 +37,24 @@ func (r *RealFileSystem) ReadFile(name string, limit int64) ([]byte, error) {
 	return io.ReadAll(io.LimitReader(f, limit))
 }
 
-// MockFileSystem is a test double for FileSystem.
-type MockFileSystem struct {
+// mockFileSystem is a test double for FileSystem.
+type mockFileSystem struct {
 	StatFunc     func(name string) (fs.FileInfo, error)
 	ReadFileFunc func(name string, limit int64) ([]byte, error)
 }
 
 // Stat calls the mock function.
-func (m *MockFileSystem) Stat(name string) (fs.FileInfo, error) {
+func (m *mockFileSystem) Stat(name string) (fs.FileInfo, error) {
 	return m.StatFunc(name)
 }
 
 // ReadFile calls the mock function.
-func (m *MockFileSystem) ReadFile(name string, limit int64) ([]byte, error) {
+func (m *mockFileSystem) ReadFile(name string, limit int64) ([]byte, error) {
 	return m.ReadFileFunc(name, limit)
 }
 
-// MockFileInfo is a test double for fs.FileInfo.
-type MockFileInfo struct {
+// mockFileInfo is a test double for fs.FileInfo.
+type mockFileInfo struct {
 	NameValue    string
 	SizeValue    int64
 	ModeValue    fs.FileMode
@@ -62,9 +62,9 @@ type MockFileInfo struct {
 	ModTimeValue int64
 }
 
-func (m *MockFileInfo) Name() string       { return m.NameValue }
-func (m *MockFileInfo) Size() int64        { return m.SizeValue }
-func (m *MockFileInfo) Mode() fs.FileMode  { return m.ModeValue }
-func (m *MockFileInfo) IsDir() bool        { return m.IsDirValue }
-func (m *MockFileInfo) Sys() interface{}   { return nil }
-func (m *MockFileInfo) ModTime() time.Time { return time.Unix(m.ModTimeValue, 0) }
+func (m *mockFileInfo) Name() string       { return m.NameValue }
+func (m *mockFileInfo) Size() int64        { return m.SizeValue }
+func (m *mockFileInfo) Mode() fs.FileMode  { return m.ModeValue }
+func (m *mockFileInfo) IsDir() bool        { return m.IsDirValue }
+func (m *mockFileInfo) Sys() interface{}   { return nil }
+func (m *mockFileInfo) ModTime() time.Time { return time.Unix(m.ModTimeValue, 0) }

--- a/pkg/tcpcheck/check.go
+++ b/pkg/tcpcheck/check.go
@@ -41,7 +41,7 @@ func (c *Check) Run() check.Result {
 
 	conn, err := c.Dialer.DialTimeout("tcp", c.Address, timeout)
 	if err != nil {
-		return *result.Failf("connection failed: %v", err)
+		return result.Failf("connection failed: %v", err)
 	}
 	defer func() { _ = conn.Close() }()
 

--- a/pkg/tcpcheck/check_test.go
+++ b/pkg/tcpcheck/check_test.go
@@ -9,26 +9,26 @@ import (
 	"github.com/vertti/preflight/pkg/check"
 )
 
-// MockDialer is a mock implementation of Dialer for testing.
-type MockDialer struct {
+// mockDialer is a mock implementation of Dialer for testing.
+type mockDialer struct {
 	DialFunc func(network, address string, timeout time.Duration) (net.Conn, error)
 }
 
-func (m *MockDialer) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
+func (m *mockDialer) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
 	return m.DialFunc(network, address, timeout)
 }
 
-// MockConn is a minimal net.Conn implementation for testing.
-type MockConn struct{}
+// mockConn is a minimal net.Conn implementation for testing.
+type mockConn struct{}
 
-func (m *MockConn) Read(b []byte) (n int, err error)   { return 0, nil }
-func (m *MockConn) Write(b []byte) (n int, err error)  { return len(b), nil }
-func (m *MockConn) Close() error                       { return nil }
-func (m *MockConn) LocalAddr() net.Addr                { return nil }
-func (m *MockConn) RemoteAddr() net.Addr               { return nil }
-func (m *MockConn) SetDeadline(t time.Time) error      { return nil }
-func (m *MockConn) SetReadDeadline(t time.Time) error  { return nil }
-func (m *MockConn) SetWriteDeadline(t time.Time) error { return nil }
+func (m *mockConn) Read(b []byte) (n int, err error)   { return 0, nil }
+func (m *mockConn) Write(b []byte) (n int, err error)  { return len(b), nil }
+func (m *mockConn) Close() error                       { return nil }
+func (m *mockConn) LocalAddr() net.Addr                { return nil }
+func (m *mockConn) RemoteAddr() net.Addr               { return nil }
+func (m *mockConn) SetDeadline(t time.Time) error      { return nil }
+func (m *mockConn) SetReadDeadline(t time.Time) error  { return nil }
+func (m *mockConn) SetWriteDeadline(t time.Time) error { return nil }
 
 func TestTCPCheck(t *testing.T) {
 	tests := []struct {
@@ -43,7 +43,7 @@ func TestTCPCheck(t *testing.T) {
 			name:    "successful connection",
 			address: "localhost:5432",
 			dialFunc: func(network, address string, timeout time.Duration) (net.Conn, error) {
-				return &MockConn{}, nil
+				return &mockConn{}, nil
 			},
 			wantStatus: check.StatusOK,
 			wantName:   "tcp: localhost:5432",
@@ -84,7 +84,7 @@ func TestTCPCheck(t *testing.T) {
 				if timeout != 10*time.Second {
 					t.Errorf("expected timeout 10s, got %v", timeout)
 				}
-				return &MockConn{}, nil
+				return &mockConn{}, nil
 			},
 			wantStatus: check.StatusOK,
 			wantName:   "tcp: localhost:8080",
@@ -97,7 +97,7 @@ func TestTCPCheck(t *testing.T) {
 				if timeout != 5*time.Second {
 					t.Errorf("expected default timeout 5s, got %v", timeout)
 				}
-				return &MockConn{}, nil
+				return &mockConn{}, nil
 			},
 			wantStatus: check.StatusOK,
 			wantName:   "tcp: localhost:3000",
@@ -109,7 +109,7 @@ func TestTCPCheck(t *testing.T) {
 			c := &Check{
 				Address: tt.address,
 				Timeout: tt.timeout,
-				Dialer: &MockDialer{
+				Dialer: &mockDialer{
 					DialFunc: tt.dialFunc,
 				},
 			}

--- a/pkg/usercheck/check.go
+++ b/pkg/usercheck/check.go
@@ -37,7 +37,7 @@ func (c *Check) Run() check.Result {
 
 	u, err := c.Lookup.Lookup(c.Username)
 	if err != nil {
-		return *result.Failf("user not found: %v", err)
+		return result.Failf("user not found: %v", err)
 	}
 
 	result.AddDetailf("uid: %s", u.Uid)
@@ -56,7 +56,7 @@ func (c *Check) Run() check.Result {
 
 	for _, chk := range checks {
 		if chk.expected != "" && chk.actual != chk.expected {
-			return *result.Fail(
+			return result.Fail(
 				fmt.Sprintf("%s mismatch: expected %s, got %s", chk.name, chk.expected, chk.actual),
 				fmt.Errorf("%s mismatch", chk.name))
 		}

--- a/pkg/usercheck/check_test.go
+++ b/pkg/usercheck/check_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/vertti/preflight/pkg/check"
 )
 
-// MockUserLookup is a mock implementation of UserLookup for testing.
-type MockUserLookup struct {
+// mockUserLookup is a mock implementation of UserLookup for testing.
+type mockUserLookup struct {
 	LookupFunc func(username string) (*user.User, error)
 }
 
-func (m *MockUserLookup) Lookup(username string) (*user.User, error) {
+func (m *mockUserLookup) Lookup(username string) (*user.User, error) {
 	return m.LookupFunc(username)
 }
 
@@ -159,7 +159,7 @@ func TestUserCheck(t *testing.T) {
 				UID:      tt.uid,
 				GID:      tt.gid,
 				Home:     tt.home,
-				Lookup: &MockUserLookup{
+				Lookup: &mockUserLookup{
 					LookupFunc: tt.lookupFunc,
 				},
 			}


### PR DESCRIPTION
## Summary
- Fix Result helper return types to return values instead of pointers (removes awkward `*result.Failf(...)` pattern)
- Rename `Required` to `AllowEmpty` in envcheck (fixes confusing inverted semantics)
- Unexport mock types to clean up public API (`MockRunner` → `mockRunner`, etc.)