### PR TITLE
Move mocks from production files to test files

### DIFF
--- a/pkg/cmdcheck/runner.go
+++ b/pkg/cmdcheck/runner.go
@@ -5,21 +5,17 @@ import (
 	"os/exec"
 )
 
-// Runner abstracts command execution for testability.
 type Runner interface {
 	LookPath(file string) (string, error)
 	RunCommand(name string, args ...string) (stdout, stderr string, err error)
 }
 
-// RealRunner implements Runner using actual OS commands.
 type RealRunner struct{}
 
-// LookPath searches for an executable in PATH.
 func (r *RealRunner) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
 
-// RunCommand executes a command and returns its output.
 func (r *RealRunner) RunCommand(name string, args ...string) (stdout, stderr string, err error) {
 	cmd := exec.Command(name, args...)
 	var outBuf, errBuf bytes.Buffer
@@ -27,20 +23,4 @@ func (r *RealRunner) RunCommand(name string, args ...string) (stdout, stderr str
 	cmd.Stderr = &errBuf
 	err = cmd.Run()
 	return outBuf.String(), errBuf.String(), err
-}
-
-// mockRunner is a test double for Runner.
-type mockRunner struct {
-	LookPathFunc   func(file string) (string, error)
-	RunCommandFunc func(name string, args ...string) (string, string, error)
-}
-
-// LookPath calls the mock function.
-func (m *mockRunner) LookPath(file string) (string, error) {
-	return m.LookPathFunc(file)
-}
-
-// RunCommand calls the mock function.
-func (m *mockRunner) RunCommand(name string, args ...string) (stdout, stderr string, err error) {
-	return m.RunCommandFunc(name, args...)
 }

--- a/pkg/cmdcheck/runner_test.go
+++ b/pkg/cmdcheck/runner_test.go
@@ -5,6 +5,19 @@ import (
 	"testing"
 )
 
+type mockRunner struct {
+	LookPathFunc   func(file string) (string, error)
+	RunCommandFunc func(name string, args ...string) (string, string, error)
+}
+
+func (m *mockRunner) LookPath(file string) (string, error) {
+	return m.LookPathFunc(file)
+}
+
+func (m *mockRunner) RunCommand(name string, args ...string) (stdout, stderr string, err error) {
+	return m.RunCommandFunc(name, args...)
+}
+
 func TestMockRunner_LookPath(t *testing.T) {
 	mock := &mockRunner{
 		LookPathFunc: func(file string) (string, error) {

--- a/pkg/envcheck/check_test.go
+++ b/pkg/envcheck/check_test.go
@@ -6,6 +6,15 @@ import (
 	"github.com/vertti/preflight/pkg/check"
 )
 
+type mockEnvGetter struct {
+	Vars map[string]string
+}
+
+func (m *mockEnvGetter) LookupEnv(key string) (string, bool) {
+	val, ok := m.Vars[key]
+	return val, ok
+}
+
 func TestEnvCheck_Run(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/envcheck/env.go
+++ b/pkg/envcheck/env.go
@@ -2,24 +2,12 @@ package envcheck
 
 import "os"
 
-// EnvGetter abstracts environment variable access for testability.
 type EnvGetter interface {
 	LookupEnv(key string) (string, bool)
 }
 
-// RealEnvGetter implements EnvGetter using the actual environment.
 type RealEnvGetter struct{}
 
 func (r *RealEnvGetter) LookupEnv(key string) (string, bool) {
 	return os.LookupEnv(key)
-}
-
-// mockEnvGetter is a test double for EnvGetter.
-type mockEnvGetter struct {
-	Vars map[string]string
-}
-
-func (m *mockEnvGetter) LookupEnv(key string) (string, bool) {
-	val, ok := m.Vars[key]
-	return val, ok
 }

--- a/pkg/filecheck/check_test.go
+++ b/pkg/filecheck/check_test.go
@@ -5,9 +5,38 @@ import (
 	"io/fs"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/vertti/preflight/pkg/check"
 )
+
+type mockFileSystem struct {
+	StatFunc     func(name string) (fs.FileInfo, error)
+	ReadFileFunc func(name string, limit int64) ([]byte, error)
+}
+
+func (m *mockFileSystem) Stat(name string) (fs.FileInfo, error) {
+	return m.StatFunc(name)
+}
+
+func (m *mockFileSystem) ReadFile(name string, limit int64) ([]byte, error) {
+	return m.ReadFileFunc(name, limit)
+}
+
+type mockFileInfo struct {
+	NameValue    string
+	SizeValue    int64
+	ModeValue    fs.FileMode
+	IsDirValue   bool
+	ModTimeValue int64
+}
+
+func (m *mockFileInfo) Name() string       { return m.NameValue }
+func (m *mockFileInfo) Size() int64        { return m.SizeValue }
+func (m *mockFileInfo) Mode() fs.FileMode  { return m.ModeValue }
+func (m *mockFileInfo) IsDir() bool        { return m.IsDirValue }
+func (m *mockFileInfo) Sys() interface{}   { return nil }
+func (m *mockFileInfo) ModTime() time.Time { return time.Unix(m.ModTimeValue, 0) }
 
 func TestCheck_Run(t *testing.T) {
 	tests := []struct {

--- a/pkg/filecheck/fs.go
+++ b/pkg/filecheck/fs.go
@@ -4,25 +4,20 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"time"
 )
 
-// FileSystem abstracts file system operations for testability.
 type FileSystem interface {
 	Stat(name string) (fs.FileInfo, error)
 	ReadFile(name string, limit int64) ([]byte, error)
 }
 
-// RealFileSystem implements FileSystem using the actual file system.
 type RealFileSystem struct{}
 
-// Stat returns file info for the given path.
 func (r *RealFileSystem) Stat(name string) (fs.FileInfo, error) {
 	return os.Stat(name)
 }
 
-// ReadFile reads a file's contents, optionally limited to the first `limit` bytes.
-// If limit is 0 or negative, reads the entire file.
+// ReadFile reads up to limit bytes. If limit <= 0, reads entire file.
 func (r *RealFileSystem) ReadFile(name string, limit int64) ([]byte, error) {
 	if limit <= 0 {
 		return os.ReadFile(name)
@@ -36,35 +31,3 @@ func (r *RealFileSystem) ReadFile(name string, limit int64) ([]byte, error) {
 
 	return io.ReadAll(io.LimitReader(f, limit))
 }
-
-// mockFileSystem is a test double for FileSystem.
-type mockFileSystem struct {
-	StatFunc     func(name string) (fs.FileInfo, error)
-	ReadFileFunc func(name string, limit int64) ([]byte, error)
-}
-
-// Stat calls the mock function.
-func (m *mockFileSystem) Stat(name string) (fs.FileInfo, error) {
-	return m.StatFunc(name)
-}
-
-// ReadFile calls the mock function.
-func (m *mockFileSystem) ReadFile(name string, limit int64) ([]byte, error) {
-	return m.ReadFileFunc(name, limit)
-}
-
-// mockFileInfo is a test double for fs.FileInfo.
-type mockFileInfo struct {
-	NameValue    string
-	SizeValue    int64
-	ModeValue    fs.FileMode
-	IsDirValue   bool
-	ModTimeValue int64
-}
-
-func (m *mockFileInfo) Name() string       { return m.NameValue }
-func (m *mockFileInfo) Size() int64        { return m.SizeValue }
-func (m *mockFileInfo) Mode() fs.FileMode  { return m.ModeValue }
-func (m *mockFileInfo) IsDir() bool        { return m.IsDirValue }
-func (m *mockFileInfo) Sys() interface{}   { return nil }
-func (m *mockFileInfo) ModTime() time.Time { return time.Unix(m.ModTimeValue, 0) }


### PR DESCRIPTION
## Summary
- Move mock types from production files to `_test.go` files where they belong
- Remove obvious self-documenting comments (e.g., "// Stat calls the mock function.")
- Production files now contain only interfaces and real implementations

## Changes
- `pkg/cmdcheck/runner.go` → `runner_test.go`
- `pkg/envcheck/env.go` → `check_test.go`  
- `pkg/filecheck/fs.go` → `check_test.go`

Net result: 52 insertions, 70 deletions (-18 lines)