### PR TITLE
Add git command for repository state verification

### DIFF
--- a/cmd/preflight/cmd_git.go
+++ b/cmd/preflight/cmd_git.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vertti/preflight/pkg/gitcheck"
+	"github.com/vertti/preflight/pkg/output"
+)
+
+var (
+	gitClean         bool
+	gitNoUncommitted bool
+	gitNoUntracked   bool
+	gitBranch        string
+	gitTagMatch      string
+)
+
+var gitCmd = &cobra.Command{
+	Use:   "git",
+	Short: "Check git repository state (clean, branch, tags)",
+	Long: `Check git repository state.
+
+Examples:
+  preflight git --clean                    # No uncommitted or untracked files
+  preflight git --no-uncommitted           # Allow untracked, forbid uncommitted
+  preflight git --branch main              # Must be on 'main' branch
+  preflight git --tag-match "v*"           # HEAD must have tag starting with 'v'
+  preflight git --clean --branch release   # Combined checks`,
+	RunE: runGitCheck,
+}
+
+func init() {
+	gitCmd.Flags().BoolVar(&gitClean, "clean", false,
+		"working directory must be clean (no uncommitted or untracked)")
+	gitCmd.Flags().BoolVar(&gitNoUncommitted, "no-uncommitted", false,
+		"no uncommitted (staged/modified) changes allowed")
+	gitCmd.Flags().BoolVar(&gitNoUntracked, "no-untracked", false,
+		"no untracked files allowed")
+	gitCmd.Flags().StringVar(&gitBranch, "branch", "",
+		"must be on specified branch")
+	gitCmd.Flags().StringVar(&gitTagMatch, "tag-match", "",
+		"HEAD must have tag matching glob pattern (e.g., 'v*')")
+	rootCmd.AddCommand(gitCmd)
+}
+
+func runGitCheck(cmd *cobra.Command, args []string) error {
+	// Require at least one check flag
+	if !gitClean && !gitNoUncommitted && !gitNoUntracked &&
+		gitBranch == "" && gitTagMatch == "" {
+		return fmt.Errorf("at least one check flag required: --clean, --no-uncommitted, --no-untracked, --branch, or --tag-match")
+	}
+
+	c := &gitcheck.Check{
+		Clean:         gitClean,
+		NoUncommitted: gitNoUncommitted,
+		NoUntracked:   gitNoUntracked,
+		Branch:        gitBranch,
+		TagMatch:      gitTagMatch,
+		Runner:        &gitcheck.RealGitRunner{},
+	}
+
+	result := c.Run()
+	output.PrintResult(result)
+
+	if !result.OK() {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/cmd/preflight/cmd_git_test.go
+++ b/cmd/preflight/cmd_git_test.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestRunGitCheck_RequiresFlag(t *testing.T) {
+	// Reset all flags to defaults
+	gitClean = false
+	gitNoUncommitted = false
+	gitNoUntracked = false
+	gitBranch = ""
+	gitTagMatch = ""
+
+	err := runGitCheck(nil, nil)
+	if err == nil {
+		t.Error("expected error when no flags provided")
+	}
+
+	expectedMsg := "at least one check flag required"
+	if err != nil && err.Error()[:len(expectedMsg)] != expectedMsg {
+		t.Errorf("error = %q, want prefix %q", err.Error(), expectedMsg)
+	}
+}

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -11,7 +11,7 @@ import (
 var Version = "dev"
 
 // knownSubcommands lists all valid preflight subcommands
-var knownSubcommands = []string{"cmd", "env", "file", "hash", "http", "sys", "tcp", "user", "run", "version", "help", "--help", "-h"}
+var knownSubcommands = []string{"cmd", "env", "file", "git", "hash", "http", "sys", "tcp", "user", "run", "version", "help", "--help", "-h"}
 
 // fileChecker abstracts file existence checks for testing
 type fileChecker func(path string) (isFile bool)

--- a/pkg/gitcheck/check.go
+++ b/pkg/gitcheck/check.go
@@ -1,0 +1,163 @@
+package gitcheck
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+// Check verifies git repository state.
+type Check struct {
+	Clean         bool   // --clean: no uncommitted or untracked changes
+	NoUncommitted bool   // --no-uncommitted: no staged/modified files
+	NoUntracked   bool   // --no-untracked: no untracked files
+	Branch        string // --branch: must be on this branch
+	TagMatch      string // --tag-match: HEAD must have tag matching glob
+	Runner        GitRunner
+}
+
+// Run executes the git check.
+func (c *Check) Run() check.Result {
+	result := check.Result{
+		Name: "git",
+	}
+
+	// First verify we're in a git repository
+	isRepo, err := c.Runner.IsGitRepo()
+	if err != nil {
+		return result.Failf("failed to check git repository: %v", err)
+	}
+	if !isRepo {
+		return result.Failf("not a git repository")
+	}
+
+	// Expand --clean to its component checks
+	noUncommitted := c.NoUncommitted || c.Clean
+	noUntracked := c.NoUntracked || c.Clean
+
+	// Check for uncommitted/untracked changes
+	if noUncommitted || noUntracked {
+		if err := c.checkStatus(noUncommitted, noUntracked, &result); err != nil {
+			return result
+		}
+	}
+
+	// Check branch
+	if c.Branch != "" {
+		if err := c.checkBranch(&result); err != nil {
+			return result
+		}
+	}
+
+	// Check tag match
+	if c.TagMatch != "" {
+		if err := c.checkTagMatch(&result); err != nil {
+			return result
+		}
+	}
+
+	result.Status = check.StatusOK
+	return result
+}
+
+func (c *Check) checkStatus(noUncommitted, noUntracked bool, result *check.Result) error {
+	status, err := c.Runner.Status()
+	if err != nil {
+		result.Failf("failed to get git status: %v", err)
+		return err
+	}
+
+	if status == "" {
+		result.AddDetail("working directory clean")
+		return nil
+	}
+
+	// Parse porcelain output
+	lines := strings.Split(status, "\n")
+	var uncommitted, untracked []string
+
+	for _, line := range lines {
+		if len(line) < 4 {
+			continue
+		}
+		// Porcelain format: XY PATH
+		// X = index status, Y = worktree status
+		// '??' = untracked, anything else = staged/modified
+		// Path starts after XY, trim leading space(s)
+		if strings.HasPrefix(line, "??") {
+			untracked = append(untracked, strings.TrimSpace(line[2:]))
+		} else {
+			uncommitted = append(uncommitted, strings.TrimSpace(line[2:]))
+		}
+	}
+
+	if noUncommitted && len(uncommitted) > 0 {
+		result.AddDetailf("uncommitted: %d file(s)", len(uncommitted))
+		for _, f := range uncommitted {
+			result.AddDetailf("  %s", f)
+		}
+		result.Failf("found %d uncommitted file(s)", len(uncommitted))
+		return fmt.Errorf("uncommitted files")
+	}
+
+	if noUntracked && len(untracked) > 0 {
+		result.AddDetailf("untracked: %d file(s)", len(untracked))
+		for _, f := range untracked {
+			result.AddDetailf("  %s", f)
+		}
+		result.Failf("found %d untracked file(s)", len(untracked))
+		return fmt.Errorf("untracked files")
+	}
+
+	result.AddDetail("working directory clean")
+	return nil
+}
+
+func (c *Check) checkBranch(result *check.Result) error {
+	branch, err := c.Runner.CurrentBranch()
+	if err != nil {
+		result.Failf("failed to get current branch: %v", err)
+		return err
+	}
+
+	result.AddDetailf("branch: %s", branch)
+
+	if branch != c.Branch {
+		result.Failf("on branch %q, expected %q", branch, c.Branch)
+		return fmt.Errorf("wrong branch")
+	}
+
+	return nil
+}
+
+func (c *Check) checkTagMatch(result *check.Result) error {
+	tags, err := c.Runner.TagsAtHead()
+	if err != nil {
+		result.Failf("failed to get tags: %v", err)
+		return err
+	}
+
+	if len(tags) == 0 {
+		result.Failf("no tags at HEAD, expected match for %q", c.TagMatch)
+		return fmt.Errorf("no tags")
+	}
+
+	// Check if any tag matches the glob pattern
+	for _, tag := range tags {
+		matched, err := path.Match(c.TagMatch, tag)
+		if err != nil {
+			result.Failf("invalid tag pattern %q: %v", c.TagMatch, err)
+			return err
+		}
+		if matched {
+			result.AddDetailf("tag: %s (matches %q)", tag, c.TagMatch)
+			return nil
+		}
+	}
+
+	result.AddDetailf("tags at HEAD: %s", strings.Join(tags, ", "))
+	result.Failf("no tag matches pattern %q", c.TagMatch)
+	return fmt.Errorf("no matching tag")
+}

--- a/pkg/gitcheck/check_test.go
+++ b/pkg/gitcheck/check_test.go
@@ -1,0 +1,418 @@
+package gitcheck
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+func TestGitCheck_Run(t *testing.T) {
+	tests := []struct {
+		name       string
+		check      Check
+		wantStatus check.Status
+	}{
+		// Repository checks
+		{
+			name: "not a git repository",
+			check: Check{
+				Clean: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return false, nil },
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "git repo check fails",
+			check: Check{
+				Clean: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) {
+						return false, errors.New("git not found")
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+
+		// --clean tests
+		{
+			name: "clean passes on clean repo",
+			check: Check{
+				Clean: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc:    func() (string, error) { return "", nil },
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "clean fails with uncommitted changes",
+			check: Check{
+				Clean: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return " M modified.go", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "clean fails with staged changes",
+			check: Check{
+				Clean: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return "A  staged.go", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "clean fails with untracked files",
+			check: Check{
+				Clean: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return "?? newfile.txt", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+
+		// --no-uncommitted tests
+		{
+			name: "no-uncommitted passes with clean repo",
+			check: Check{
+				NoUncommitted: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc:    func() (string, error) { return "", nil },
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "no-uncommitted passes with only untracked",
+			check: Check{
+				NoUncommitted: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return "?? untracked.txt", nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "no-uncommitted fails with staged file",
+			check: Check{
+				NoUncommitted: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return "A  staged.go", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "no-uncommitted fails with modified file",
+			check: Check{
+				NoUncommitted: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return " M modified.go", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+
+		// --no-untracked tests
+		{
+			name: "no-untracked passes with clean repo",
+			check: Check{
+				NoUntracked: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc:    func() (string, error) { return "", nil },
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "no-untracked passes with only uncommitted",
+			check: Check{
+				NoUntracked: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return " M modified.go", nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "no-untracked fails with untracked files",
+			check: Check{
+				NoUntracked: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return "?? newfile.txt", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+
+		// --branch tests
+		{
+			name: "branch passes on correct branch",
+			check: Check{
+				Branch: "main",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc:     func() (bool, error) { return true, nil },
+					CurrentBranchFunc: func() (string, error) { return "main", nil },
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "branch fails on wrong branch",
+			check: Check{
+				Branch: "main",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc:     func() (bool, error) { return true, nil },
+					CurrentBranchFunc: func() (string, error) { return "feature", nil },
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "branch fails in detached HEAD",
+			check: Check{
+				Branch: "main",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc:     func() (bool, error) { return true, nil },
+					CurrentBranchFunc: func() (string, error) { return "HEAD", nil },
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "branch check error",
+			check: Check{
+				Branch: "main",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					CurrentBranchFunc: func() (string, error) {
+						return "", errors.New("git error")
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+
+		// --tag-match tests
+		{
+			name: "tag-match passes with matching tag",
+			check: Check{
+				TagMatch: "v*",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc:  func() (bool, error) { return true, nil },
+					TagsAtHeadFunc: func() ([]string, error) { return []string{"v1.0.0"}, nil },
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "tag-match passes with multiple tags one matching",
+			check: Check{
+				TagMatch: "release-*",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					TagsAtHeadFunc: func() ([]string, error) {
+						return []string{"v1.0.0", "release-2024-01"}, nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "tag-match fails with no tags",
+			check: Check{
+				TagMatch: "v*",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc:  func() (bool, error) { return true, nil },
+					TagsAtHeadFunc: func() ([]string, error) { return nil, nil },
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "tag-match fails with non-matching tag",
+			check: Check{
+				TagMatch: "v*",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc:  func() (bool, error) { return true, nil },
+					TagsAtHeadFunc: func() ([]string, error) { return []string{"release-1.0"}, nil },
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "tag-match invalid pattern",
+			check: Check{
+				TagMatch: "[invalid",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc:  func() (bool, error) { return true, nil },
+					TagsAtHeadFunc: func() ([]string, error) { return []string{"v1.0.0"}, nil },
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "tag-match error getting tags",
+			check: Check{
+				TagMatch: "v*",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					TagsAtHeadFunc: func() ([]string, error) {
+						return nil, errors.New("git error")
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+
+		// Combined flags
+		{
+			name: "clean and branch both pass",
+			check: Check{
+				Clean:  true,
+				Branch: "main",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc:     func() (bool, error) { return true, nil },
+					StatusFunc:        func() (string, error) { return "", nil },
+					CurrentBranchFunc: func() (string, error) { return "main", nil },
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "clean passes but branch fails",
+			check: Check{
+				Clean:  true,
+				Branch: "main",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc:     func() (bool, error) { return true, nil },
+					StatusFunc:        func() (string, error) { return "", nil },
+					CurrentBranchFunc: func() (string, error) { return "develop", nil },
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "branch passes but clean fails",
+			check: Check{
+				Clean:  true,
+				Branch: "main",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return "?? untracked.txt", nil
+					},
+					CurrentBranchFunc: func() (string, error) { return "main", nil },
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "all checks pass together",
+			check: Check{
+				Clean:    true,
+				Branch:   "main",
+				TagMatch: "v*",
+				Runner: &mockGitRunner{
+					IsGitRepoFunc:     func() (bool, error) { return true, nil },
+					StatusFunc:        func() (string, error) { return "", nil },
+					CurrentBranchFunc: func() (string, error) { return "main", nil },
+					TagsAtHeadFunc:    func() ([]string, error) { return []string{"v1.0.0"}, nil },
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+
+		// Status command error
+		{
+			name: "status command fails",
+			check: Check{
+				Clean: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return "", errors.New("git status failed")
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+
+		// Multiple untracked/uncommitted files
+		{
+			name: "clean fails with multiple uncommitted files",
+			check: Check{
+				Clean: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return " M file1.go\n M file2.go\nA  file3.go", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "clean fails with mixed changes",
+			check: Check{
+				Clean: true,
+				Runner: &mockGitRunner{
+					IsGitRepoFunc: func() (bool, error) { return true, nil },
+					StatusFunc: func() (string, error) {
+						return " M modified.go\n?? untracked.txt", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.check.Run()
+
+			if result.Status != tt.wantStatus {
+				t.Errorf("status = %v, want %v (details: %v)", result.Status, tt.wantStatus, result.Details)
+			}
+
+			if result.Name != "git" {
+				t.Errorf("name = %q, want %q", result.Name, "git")
+			}
+		})
+	}
+}

--- a/pkg/gitcheck/runner.go
+++ b/pkg/gitcheck/runner.go
@@ -1,0 +1,74 @@
+package gitcheck
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+)
+
+// GitRunner abstracts git command execution for testability.
+type GitRunner interface {
+	// IsGitRepo returns true if the current directory is inside a git repository.
+	IsGitRepo() (bool, error)
+
+	// Status returns the output of 'git status --porcelain'.
+	// Lines starting with '??' are untracked, others are staged/modified.
+	Status() (string, error)
+
+	// CurrentBranch returns the name of the current branch.
+	// Returns "HEAD" if in detached HEAD state.
+	CurrentBranch() (string, error)
+
+	// TagsAtHead returns all tags pointing at the current HEAD commit.
+	TagsAtHead() ([]string, error)
+}
+
+// RealGitRunner executes actual git commands.
+type RealGitRunner struct{}
+
+func (r *RealGitRunner) IsGitRepo() (bool, error) {
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	err := cmd.Run()
+	if err != nil {
+		// Exit code 128 = not a git repository
+		return false, nil
+	}
+	return true, nil
+}
+
+func (r *RealGitRunner) Status() (string, error) {
+	cmd := exec.Command("git", "status", "--porcelain")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func (r *RealGitRunner) CurrentBranch() (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func (r *RealGitRunner) TagsAtHead() ([]string, error) {
+	cmd := exec.Command("git", "tag", "--points-at", "HEAD")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return nil, err
+	}
+	output := strings.TrimSpace(out.String())
+	if output == "" {
+		return nil, nil
+	}
+	return strings.Split(output, "\n"), nil
+}

--- a/pkg/gitcheck/runner_test.go
+++ b/pkg/gitcheck/runner_test.go
@@ -1,0 +1,102 @@
+package gitcheck
+
+import (
+	"errors"
+	"testing"
+)
+
+type mockGitRunner struct {
+	IsGitRepoFunc     func() (bool, error)
+	StatusFunc        func() (string, error)
+	CurrentBranchFunc func() (string, error)
+	TagsAtHeadFunc    func() ([]string, error)
+}
+
+func (m *mockGitRunner) IsGitRepo() (bool, error) {
+	return m.IsGitRepoFunc()
+}
+
+func (m *mockGitRunner) Status() (string, error) {
+	return m.StatusFunc()
+}
+
+func (m *mockGitRunner) CurrentBranch() (string, error) {
+	return m.CurrentBranchFunc()
+}
+
+func (m *mockGitRunner) TagsAtHead() ([]string, error) {
+	return m.TagsAtHeadFunc()
+}
+
+func TestMockGitRunner_IsGitRepo(t *testing.T) {
+	mock := &mockGitRunner{
+		IsGitRepoFunc: func() (bool, error) {
+			return true, nil
+		},
+	}
+
+	isRepo, err := mock.IsGitRepo()
+	if err != nil {
+		t.Fatalf("IsGitRepo() error = %v", err)
+	}
+	if !isRepo {
+		t.Error("IsGitRepo() = false, want true")
+	}
+
+	mock.IsGitRepoFunc = func() (bool, error) {
+		return false, errors.New("git not found")
+	}
+
+	_, err = mock.IsGitRepo()
+	if err == nil {
+		t.Error("IsGitRepo() error = nil, want error")
+	}
+}
+
+func TestMockGitRunner_Status(t *testing.T) {
+	mock := &mockGitRunner{
+		StatusFunc: func() (string, error) {
+			return " M modified.go\n?? untracked.txt", nil
+		},
+	}
+
+	status, err := mock.Status()
+	if err != nil {
+		t.Fatalf("Status() error = %v", err)
+	}
+	if status == "" {
+		t.Error("Status() returned empty string")
+	}
+}
+
+func TestMockGitRunner_CurrentBranch(t *testing.T) {
+	mock := &mockGitRunner{
+		CurrentBranchFunc: func() (string, error) {
+			return "main", nil
+		},
+	}
+
+	branch, err := mock.CurrentBranch()
+	if err != nil {
+		t.Fatalf("CurrentBranch() error = %v", err)
+	}
+	if branch != "main" {
+		t.Errorf("CurrentBranch() = %q, want %q", branch, "main")
+	}
+}
+
+func TestMockGitRunner_TagsAtHead(t *testing.T) {
+	mock := &mockGitRunner{
+		TagsAtHeadFunc: func() ([]string, error) {
+			return []string{"v1.0.0", "release-1"}, nil
+		},
+	}
+
+	tags, err := mock.TagsAtHead()
+	if err != nil {
+		t.Fatalf("TagsAtHead() error = %v", err)
+	}
+	if len(tags) != 2 {
+		t.Errorf("TagsAtHead() returned %d tags, want 2", len(tags))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `preflight git` command to verify git repository state
- Useful for CI pipelines that need clean working directories or branch/tag verification
- Replaces shell patterns like `test -z "$(git status --porcelain)"`

## Flags

| Flag | Description |
|------|-------------|
| `--clean` | No uncommitted or untracked files |
| `--no-uncommitted` | No staged/modified files allowed |
| `--no-untracked` | No untracked files allowed |
| `--branch <name>` | Must be on specified branch |
| `--tag-match <pattern>` | HEAD must have tag matching glob |

## Examples

```sh
# Verify clean state after code generation
go generate ./...
preflight git --clean

# Check formatting didn't change anything
go fmt ./...
preflight git --no-uncommitted

# Release checks
preflight git --branch main --tag-match "v*"
```