### PR TITLE
Add resource command for system resource checks

### DIFF
--- a/cmd/preflight/cmd_resource.go
+++ b/cmd/preflight/cmd_resource.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vertti/preflight/pkg/output"
+	"github.com/vertti/preflight/pkg/resourcecheck"
+)
+
+var (
+	resourceMinDisk   string
+	resourceMinMemory string
+	resourceMinCPUs   int
+	resourcePath      string
+)
+
+var resourceCmd = &cobra.Command{
+	Use:   "resource",
+	Short: "Check system resources (disk, memory, CPU)",
+	Long: `Check system resources meet minimum requirements.
+
+Examples:
+  preflight resource --min-disk 10G                    # At least 10GB free disk
+  preflight resource --min-disk 10G --path /var/lib/docker  # Check specific path
+  preflight resource --min-memory 2G                   # At least 2GB memory
+  preflight resource --min-cpus 4                      # At least 4 CPU cores
+  preflight resource --min-disk 10G --min-memory 2G   # Combined checks`,
+	RunE: runResourceCheck,
+}
+
+func init() {
+	resourceCmd.Flags().StringVar(&resourceMinDisk, "min-disk", "",
+		"minimum free disk space (e.g., 10G, 500M)")
+	resourceCmd.Flags().StringVar(&resourceMinMemory, "min-memory", "",
+		"minimum available memory (e.g., 2G, 512M)")
+	resourceCmd.Flags().IntVar(&resourceMinCPUs, "min-cpus", 0,
+		"minimum number of CPU cores")
+	resourceCmd.Flags().StringVar(&resourcePath, "path", "",
+		"path for disk space check (default: current directory)")
+	rootCmd.AddCommand(resourceCmd)
+}
+
+func runResourceCheck(cmd *cobra.Command, args []string) error {
+	// Require at least one check flag
+	if resourceMinDisk == "" && resourceMinMemory == "" && resourceMinCPUs == 0 {
+		return fmt.Errorf("at least one check flag required: --min-disk, --min-memory, or --min-cpus")
+	}
+
+	c := &resourcecheck.Check{
+		Path:    resourcePath,
+		MinCPUs: resourceMinCPUs,
+		Checker: &resourcecheck.RealResourceChecker{},
+	}
+
+	// Parse disk size
+	if resourceMinDisk != "" {
+		size, err := resourcecheck.ParseSize(resourceMinDisk)
+		if err != nil {
+			return fmt.Errorf("invalid --min-disk value: %w", err)
+		}
+		c.MinDisk = size
+	}
+
+	// Parse memory size
+	if resourceMinMemory != "" {
+		size, err := resourcecheck.ParseSize(resourceMinMemory)
+		if err != nil {
+			return fmt.Errorf("invalid --min-memory value: %w", err)
+		}
+		c.MinMemory = size
+	}
+
+	result := c.Run()
+	output.PrintResult(result)
+
+	if !result.OK() {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -11,7 +11,7 @@ import (
 var Version = "dev"
 
 // knownSubcommands lists all valid preflight subcommands
-var knownSubcommands = []string{"cmd", "env", "file", "git", "hash", "http", "sys", "tcp", "user", "run", "version", "help", "--help", "-h"}
+var knownSubcommands = []string{"cmd", "env", "file", "git", "hash", "http", "resource", "sys", "tcp", "user", "run", "version", "help", "--help", "-h"}
 
 // fileChecker abstracts file existence checks for testing
 type fileChecker func(path string) (isFile bool)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -648,12 +648,12 @@ preflight resource [flags]
 
 ### Flags
 
-| Flag               | Description                                       |
-| ------------------ | ------------------------------------------------- |
-| `--min-disk <size>` | Minimum free disk space (e.g., 10G, 500M)        |
-| `--min-memory <size>` | Minimum available memory (e.g., 2G, 512M)      |
-| `--min-cpus <n>`   | Minimum number of CPU cores                       |
-| `--path <path>`    | Path for disk space check (default: current dir)  |
+| Flag                  | Description                                      |
+| --------------------- | ------------------------------------------------ |
+| `--min-disk <size>`   | Minimum free disk space (e.g., 10G, 500M)        |
+| `--min-memory <size>` | Minimum available memory (e.g., 2G, 512M)        |
+| `--min-cpus <n>`      | Minimum number of CPU cores                      |
+| `--path <path>`       | Path for disk space check (default: current dir) |
 
 At least one of `--min-disk`, `--min-memory`, or `--min-cpus` is required.
 
@@ -661,13 +661,13 @@ At least one of `--min-disk`, `--min-memory`, or `--min-cpus` is required.
 
 Sizes support common units (case-insensitive):
 
-| Unit       | Example | Bytes          |
-| ---------- | ------- | -------------- |
-| B (bytes)  | `1024`  | 1,024          |
-| K/KB       | `500K`  | 512,000        |
-| M/MB       | `500M`  | 524,288,000    |
-| G/GB       | `10G`   | 10,737,418,240 |
-| T/TB       | `1T`    | 1,099,511,627,776 |
+| Unit      | Example | Bytes             |
+| --------- | ------- | ----------------- |
+| B (bytes) | `1024`  | 1,024             |
+| K/KB      | `500K`  | 512,000           |
+| M/MB      | `500M`  | 524,288,000       |
+| G/GB      | `10G`   | 10,737,418,240    |
+| T/TB      | `1T`    | 1,099,511,627,776 |
 
 Decimals are supported: `1.5G`, `2.5TB`
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/vertti/preflight/pkg/gitcheck"
 	"github.com/vertti/preflight/pkg/hashcheck"
 	"github.com/vertti/preflight/pkg/httpcheck"
+	"github.com/vertti/preflight/pkg/resourcecheck"
 	"github.com/vertti/preflight/pkg/syscheck"
 	"github.com/vertti/preflight/pkg/tcpcheck"
 	"github.com/vertti/preflight/pkg/usercheck"
@@ -222,6 +223,46 @@ func TestIntegration_Git(t *testing.T) {
 	}
 
 	result := c.Run()
+
+	if result.Status != check.StatusOK {
+		t.Errorf("Status = %v, want OK (details: %v)", result.Status, result.Details)
+	}
+}
+
+func TestIntegration_Resource(t *testing.T) {
+	checker := &resourcecheck.RealResourceChecker{}
+
+	// Test disk space (should have at least 1MB free)
+	c := resourcecheck.Check{
+		MinDisk: 1 * 1024 * 1024, // 1MB
+		Checker: checker,
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusOK {
+		t.Errorf("Status = %v, want OK (details: %v)", result.Status, result.Details)
+	}
+
+	// Test memory (should have at least 100MB)
+	c = resourcecheck.Check{
+		MinMemory: 100 * 1024 * 1024, // 100MB
+		Checker:   checker,
+	}
+
+	result = c.Run()
+
+	if result.Status != check.StatusOK {
+		t.Errorf("Status = %v, want OK (details: %v)", result.Status, result.Details)
+	}
+
+	// Test CPUs (should have at least 1)
+	c = resourcecheck.Check{
+		MinCPUs: 1,
+		Checker: checker,
+	}
+
+	result = c.Run()
 
 	if result.Status != check.StatusOK {
 		t.Errorf("Status = %v, want OK (details: %v)", result.Status, result.Details)

--- a/pkg/resourcecheck/check.go
+++ b/pkg/resourcecheck/check.go
@@ -1,0 +1,72 @@
+package resourcecheck
+
+import (
+	"github.com/vertti/preflight/pkg/check"
+)
+
+// Check verifies system resources meet requirements.
+type Check struct {
+	MinDisk   uint64 // minimum free disk space in bytes
+	MinMemory uint64 // minimum available memory in bytes
+	MinCPUs   int    // minimum number of CPUs
+	Path      string // path for disk space check (default: ".")
+	Checker   ResourceChecker
+}
+
+// Run executes the resource check.
+func (c *Check) Run() check.Result {
+	result := check.Result{
+		Name: "resource",
+	}
+
+	if c.Checker == nil {
+		c.Checker = &RealResourceChecker{}
+	}
+
+	path := c.Path
+	if path == "" {
+		path = "."
+	}
+
+	// Check disk space
+	if c.MinDisk > 0 {
+		free, err := c.Checker.FreeDiskSpace(path)
+		if err != nil {
+			return result.Failf("failed to check disk space: %v", err)
+		}
+
+		result.AddDetailf("disk free: %s (path: %s)", FormatSize(free), path)
+
+		if free < c.MinDisk {
+			return result.Failf("disk space %s < required %s", FormatSize(free), FormatSize(c.MinDisk))
+		}
+	}
+
+	// Check memory
+	if c.MinMemory > 0 {
+		mem, err := c.Checker.AvailableMemory()
+		if err != nil {
+			return result.Failf("failed to check memory: %v", err)
+		}
+
+		result.AddDetailf("memory: %s", FormatSize(mem))
+
+		if mem < c.MinMemory {
+			return result.Failf("memory %s < required %s", FormatSize(mem), FormatSize(c.MinMemory))
+		}
+	}
+
+	// Check CPUs
+	if c.MinCPUs > 0 {
+		cpus := c.Checker.NumCPUs()
+
+		result.AddDetailf("cpus: %d", cpus)
+
+		if cpus < c.MinCPUs {
+			return result.Failf("cpus %d < required %d", cpus, c.MinCPUs)
+		}
+	}
+
+	result.Status = check.StatusOK
+	return result
+}

--- a/pkg/resourcecheck/check_test.go
+++ b/pkg/resourcecheck/check_test.go
@@ -1,0 +1,192 @@
+package resourcecheck
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+func TestResourceCheck_Run(t *testing.T) {
+	tests := []struct {
+		name       string
+		check      Check
+		wantStatus check.Status
+	}{
+		// Disk checks
+		{
+			name: "disk check passes",
+			check: Check{
+				MinDisk: 10 * GB,
+				Checker: &mockResourceChecker{
+					freeDiskSpace: 20 * GB,
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "disk check fails - not enough space",
+			check: Check{
+				MinDisk: 20 * GB,
+				Checker: &mockResourceChecker{
+					freeDiskSpace: 10 * GB,
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "disk check fails - error",
+			check: Check{
+				MinDisk: 10 * GB,
+				Checker: &mockResourceChecker{
+					freeDiskErr: errors.New("disk error"),
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "disk check with custom path",
+			check: Check{
+				MinDisk: 10 * GB,
+				Path:    "/var/lib/docker",
+				Checker: &mockResourceChecker{
+					freeDiskSpace: 20 * GB,
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+
+		// Memory checks
+		{
+			name: "memory check passes",
+			check: Check{
+				MinMemory: 2 * GB,
+				Checker: &mockResourceChecker{
+					availableMemory: 8 * GB,
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "memory check fails - not enough memory",
+			check: Check{
+				MinMemory: 16 * GB,
+				Checker: &mockResourceChecker{
+					availableMemory: 8 * GB,
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "memory check fails - error",
+			check: Check{
+				MinMemory: 2 * GB,
+				Checker: &mockResourceChecker{
+					availableMemErr: errors.New("memory error"),
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+
+		// CPU checks
+		{
+			name: "cpu check passes",
+			check: Check{
+				MinCPUs: 2,
+				Checker: &mockResourceChecker{
+					numCPUs: 8,
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "cpu check fails - not enough cpus",
+			check: Check{
+				MinCPUs: 16,
+				Checker: &mockResourceChecker{
+					numCPUs: 8,
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "cpu check exact match",
+			check: Check{
+				MinCPUs: 4,
+				Checker: &mockResourceChecker{
+					numCPUs: 4,
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+
+		// Combined checks
+		{
+			name: "all checks pass",
+			check: Check{
+				MinDisk:   10 * GB,
+				MinMemory: 2 * GB,
+				MinCPUs:   2,
+				Checker: &mockResourceChecker{
+					freeDiskSpace:   50 * GB,
+					availableMemory: 16 * GB,
+					numCPUs:         8,
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "disk passes but memory fails",
+			check: Check{
+				MinDisk:   10 * GB,
+				MinMemory: 32 * GB,
+				Checker: &mockResourceChecker{
+					freeDiskSpace:   50 * GB,
+					availableMemory: 16 * GB,
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "disk and memory pass but cpu fails",
+			check: Check{
+				MinDisk:   10 * GB,
+				MinMemory: 2 * GB,
+				MinCPUs:   16,
+				Checker: &mockResourceChecker{
+					freeDiskSpace:   50 * GB,
+					availableMemory: 16 * GB,
+					numCPUs:         8,
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+
+		// No checks specified (should pass)
+		{
+			name: "no checks specified",
+			check: Check{
+				Checker: &mockResourceChecker{
+					freeDiskSpace:   50 * GB,
+					availableMemory: 16 * GB,
+					numCPUs:         8,
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.check.Run()
+
+			if result.Status != tt.wantStatus {
+				t.Errorf("status = %v, want %v (details: %v)", result.Status, tt.wantStatus, result.Details)
+			}
+
+			if result.Name != "resource" {
+				t.Errorf("name = %q, want %q", result.Name, "resource")
+			}
+		})
+	}
+}

--- a/pkg/resourcecheck/resource.go
+++ b/pkg/resourcecheck/resource.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package resourcecheck
 
 import (

--- a/pkg/resourcecheck/resource.go
+++ b/pkg/resourcecheck/resource.go
@@ -1,0 +1,75 @@
+package resourcecheck
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// ResourceChecker abstracts system resource detection for testability.
+type ResourceChecker interface {
+	// FreeDiskSpace returns free disk space in bytes at the given path.
+	FreeDiskSpace(path string) (uint64, error)
+
+	// AvailableMemory returns available memory in bytes.
+	// In containers, this respects cgroup limits.
+	AvailableMemory() (uint64, error)
+
+	// NumCPUs returns the number of available CPUs.
+	NumCPUs() int
+}
+
+// RealResourceChecker implements ResourceChecker using actual system calls.
+type RealResourceChecker struct{}
+
+// FreeDiskSpace returns free disk space in bytes.
+func (r *RealResourceChecker) FreeDiskSpace(path string) (uint64, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return 0, err
+	}
+	// Available blocks * block size
+	return stat.Bavail * uint64(stat.Bsize), nil
+}
+
+// AvailableMemory returns available memory in bytes.
+// First checks cgroup limits (for containers), then falls back to system memory.
+func (r *RealResourceChecker) AvailableMemory() (uint64, error) {
+	// Try cgroup v2 first
+	if mem, err := readCgroupMemoryLimit("/sys/fs/cgroup/memory.max"); err == nil && mem > 0 {
+		return mem, nil
+	}
+
+	// Try cgroup v1
+	if mem, err := readCgroupMemoryLimit("/sys/fs/cgroup/memory/memory.limit_in_bytes"); err == nil && mem > 0 {
+		return mem, nil
+	}
+
+	// Fall back to system memory
+	return getSystemMemory()
+}
+
+// NumCPUs returns the number of available CPUs.
+// Go's runtime.NumCPU() already respects container CPU limits.
+func (r *RealResourceChecker) NumCPUs() int {
+	return runtime.NumCPU()
+}
+
+// readCgroupMemoryLimit reads memory limit from a cgroup file.
+func readCgroupMemoryLimit(path string) (uint64, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+
+	content := strings.TrimSpace(string(data))
+
+	// "max" means unlimited in cgroup v2
+	if content == "max" {
+		return 0, nil
+	}
+
+	return strconv.ParseUint(content, 10, 64)
+}

--- a/pkg/resourcecheck/resource_darwin.go
+++ b/pkg/resourcecheck/resource_darwin.go
@@ -1,0 +1,29 @@
+//go:build darwin
+
+package resourcecheck
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// getSystemMemory returns total system memory on macOS.
+func getSystemMemory() (uint64, error) {
+	mib := []int32{6, 24} // CTL_HW, HW_MEMSIZE
+	var size uint64
+	length := unsafe.Sizeof(size)
+
+	_, _, err := syscall.Syscall6(
+		syscall.SYS___SYSCTL,
+		uintptr(unsafe.Pointer(&mib[0])),
+		uintptr(2), // len(mib)
+		uintptr(unsafe.Pointer(&size)),
+		uintptr(unsafe.Pointer(&length)),
+		0,
+		0,
+	)
+	if err != 0 {
+		return 0, err
+	}
+	return size, nil
+}

--- a/pkg/resourcecheck/resource_linux.go
+++ b/pkg/resourcecheck/resource_linux.go
@@ -1,0 +1,14 @@
+//go:build linux
+
+package resourcecheck
+
+import "syscall"
+
+// getSystemMemory returns total system memory on Linux.
+func getSystemMemory() (uint64, error) {
+	var info syscall.Sysinfo_t
+	if err := syscall.Sysinfo(&info); err != nil {
+		return 0, err
+	}
+	return info.Totalram * uint64(info.Unit), nil
+}

--- a/pkg/resourcecheck/resource_test.go
+++ b/pkg/resourcecheck/resource_test.go
@@ -1,0 +1,98 @@
+package resourcecheck
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRealResourceChecker_FreeDiskSpace(t *testing.T) {
+	r := &RealResourceChecker{}
+
+	// Test current directory (should always work)
+	space, err := r.FreeDiskSpace(".")
+	if err != nil {
+		t.Errorf("FreeDiskSpace(\".\") error = %v", err)
+	}
+	if space == 0 {
+		t.Error("FreeDiskSpace(\".\") = 0, expected > 0")
+	}
+
+	// Test non-existent path
+	_, err = r.FreeDiskSpace("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Error("FreeDiskSpace(nonexistent) error = nil, expected error")
+	}
+}
+
+func TestRealResourceChecker_FreeDiskSpace_TempDir(t *testing.T) {
+	r := &RealResourceChecker{}
+
+	tmpDir, err := os.MkdirTemp("", "preflight-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	space, err := r.FreeDiskSpace(tmpDir)
+	if err != nil {
+		t.Errorf("FreeDiskSpace(tmpDir) error = %v", err)
+	}
+	if space == 0 {
+		t.Error("FreeDiskSpace(tmpDir) = 0, expected > 0")
+	}
+}
+
+func TestRealResourceChecker_AvailableMemory(t *testing.T) {
+	r := &RealResourceChecker{}
+
+	mem, err := r.AvailableMemory()
+	if err != nil {
+		t.Errorf("AvailableMemory() error = %v", err)
+	}
+	if mem == 0 {
+		t.Error("AvailableMemory() = 0, expected > 0")
+	}
+
+	// Should be at least 100MB (reasonable minimum for any system)
+	if mem < 100*MB {
+		t.Errorf("AvailableMemory() = %d, expected at least 100MB", mem)
+	}
+}
+
+func TestRealResourceChecker_NumCPUs(t *testing.T) {
+	r := &RealResourceChecker{}
+
+	cpus := r.NumCPUs()
+	if cpus < 1 {
+		t.Errorf("NumCPUs() = %d, expected >= 1", cpus)
+	}
+}
+
+func TestReadCgroupMemoryLimit(t *testing.T) {
+	// Test with non-existent file (common case on non-Linux or non-container)
+	_, err := readCgroupMemoryLimit("/nonexistent/path")
+	if err == nil {
+		t.Error("readCgroupMemoryLimit(nonexistent) error = nil, expected error")
+	}
+}
+
+// Mock implementation for unit testing Check
+type mockResourceChecker struct {
+	freeDiskSpace   uint64
+	freeDiskErr     error
+	availableMemory uint64
+	availableMemErr error
+	numCPUs         int
+}
+
+func (m *mockResourceChecker) FreeDiskSpace(path string) (uint64, error) {
+	return m.freeDiskSpace, m.freeDiskErr
+}
+
+func (m *mockResourceChecker) AvailableMemory() (uint64, error) {
+	return m.availableMemory, m.availableMemErr
+}
+
+func (m *mockResourceChecker) NumCPUs() int {
+	return m.numCPUs
+}

--- a/pkg/resourcecheck/resource_windows.go
+++ b/pkg/resourcecheck/resource_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package resourcecheck
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// ResourceChecker abstracts system resource detection for testability.
+type ResourceChecker interface {
+	// FreeDiskSpace returns free disk space in bytes at the given path.
+	FreeDiskSpace(path string) (uint64, error)
+
+	// AvailableMemory returns available memory in bytes.
+	// In containers, this respects cgroup limits.
+	AvailableMemory() (uint64, error)
+
+	// NumCPUs returns the number of available CPUs.
+	NumCPUs() int
+}
+
+// RealResourceChecker implements ResourceChecker using actual system calls.
+type RealResourceChecker struct{}
+
+// FreeDiskSpace returns free disk space in bytes.
+// Not implemented on Windows.
+func (r *RealResourceChecker) FreeDiskSpace(path string) (uint64, error) {
+	return 0, fmt.Errorf("disk space check not supported on Windows")
+}
+
+// AvailableMemory returns available memory in bytes.
+// Not implemented on Windows.
+func (r *RealResourceChecker) AvailableMemory() (uint64, error) {
+	return 0, fmt.Errorf("memory check not supported on Windows")
+}
+
+// NumCPUs returns the number of available CPUs.
+// Go's runtime.NumCPU() already respects container CPU limits.
+func (r *RealResourceChecker) NumCPUs() int {
+	return runtime.NumCPU()
+}

--- a/pkg/resourcecheck/size.go
+++ b/pkg/resourcecheck/size.go
@@ -1,0 +1,75 @@
+package resourcecheck
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	_         = iota
+	KB uint64 = 1 << (10 * iota)
+	MB
+	GB
+	TB
+)
+
+// ParseSize parses a human-readable size string into bytes.
+// Supports: B, K/KB, M/MB, G/GB, T/TB (case-insensitive)
+// Examples: "10G", "500M", "1TB", "1024", "1.5GB"
+func ParseSize(s string) (uint64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty size string")
+	}
+
+	// Match number (with optional decimal) and optional unit
+	re := regexp.MustCompile(`(?i)^(\d+(?:\.\d+)?)\s*([KMGT]?B?)?$`)
+	matches := re.FindStringSubmatch(s)
+	if matches == nil {
+		return 0, fmt.Errorf("invalid size format: %q", s)
+	}
+
+	numStr := matches[1]
+	unit := strings.ToUpper(matches[2])
+
+	num, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid number: %q", numStr)
+	}
+
+	var multiplier uint64
+	switch unit {
+	case "", "B":
+		multiplier = 1
+	case "K", "KB":
+		multiplier = KB
+	case "M", "MB":
+		multiplier = MB
+	case "G", "GB":
+		multiplier = GB
+	case "T", "TB":
+		multiplier = TB
+	default:
+		return 0, fmt.Errorf("unknown unit: %q", unit)
+	}
+
+	return uint64(num * float64(multiplier)), nil
+}
+
+// FormatSize formats bytes into a human-readable string.
+func FormatSize(bytes uint64) string {
+	switch {
+	case bytes >= TB:
+		return fmt.Sprintf("%.1fTB", float64(bytes)/float64(TB))
+	case bytes >= GB:
+		return fmt.Sprintf("%.1fGB", float64(bytes)/float64(GB))
+	case bytes >= MB:
+		return fmt.Sprintf("%.1fMB", float64(bytes)/float64(MB))
+	case bytes >= KB:
+		return fmt.Sprintf("%.1fKB", float64(bytes)/float64(KB))
+	default:
+		return fmt.Sprintf("%dB", bytes)
+	}
+}

--- a/pkg/resourcecheck/size_test.go
+++ b/pkg/resourcecheck/size_test.go
@@ -1,0 +1,91 @@
+package resourcecheck
+
+import (
+	"testing"
+)
+
+func TestParseSize(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    uint64
+		wantErr bool
+	}{
+		// Basic units
+		{"1024", 1024, false},
+		{"1024B", 1024, false},
+		{"1K", KB, false},
+		{"1KB", KB, false},
+		{"1M", MB, false},
+		{"1MB", MB, false},
+		{"1G", GB, false},
+		{"1GB", GB, false},
+		{"1T", TB, false},
+		{"1TB", TB, false},
+
+		// Case insensitivity
+		{"1g", GB, false},
+		{"1gb", GB, false},
+		{"1Gb", GB, false},
+
+		// Multipliers
+		{"10G", 10 * GB, false},
+		{"500M", 500 * MB, false},
+		{"2T", 2 * TB, false},
+		{"100K", 100 * KB, false},
+
+		// Decimals
+		{"1.5G", uint64(1.5 * float64(GB)), false},
+		{"2.5MB", uint64(2.5 * float64(MB)), false},
+
+		// Whitespace
+		{" 10G ", 10 * GB, false},
+		{"10 G", 10 * GB, false},
+
+		// Errors
+		{"", 0, true},
+		{"abc", 0, true},
+		{"10X", 0, true},
+		{"-10G", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseSize(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseSize(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("ParseSize(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatSize(t *testing.T) {
+	tests := []struct {
+		input uint64
+		want  string
+	}{
+		{0, "0B"},
+		{500, "500B"},
+		{1023, "1023B"},
+		{KB, "1.0KB"},
+		{MB, "1.0MB"},
+		{GB, "1.0GB"},
+		{TB, "1.0TB"},
+		{10 * GB, "10.0GB"},
+		{uint64(1.5 * float64(GB)), "1.5GB"},
+		{500 * MB, "500.0MB"},
+		{2 * TB, "2.0TB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := FormatSize(tt.input)
+			if got != tt.want {
+				t.Errorf("FormatSize(%d) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add `preflight resource` command to check system resources (disk, memory, CPU)
- Support human-readable size formats (10G, 500M, 1.5TB, etc.)
- Platform-specific implementations for Darwin and Linux
- Container-aware memory detection (checks cgroups limits on Linux)

## Examples

```sh
# Check disk space
preflight resource --min-disk 10G

# Check disk space at specific path
preflight resource --min-disk 10G --path /var/lib/docker

# Check available memory
preflight resource --min-memory 2G

# Check CPU cores
preflight resource --min-cpus 4

# Combined checks
preflight resource --min-disk 10G --min-memory 2G --min-cpus 2
```

## Shell Script Replaced

```bash
# Before
available=$(df -BG /var/lib/docker | tail -1 | awk '{print $4}' | tr -d 'G')
if [ "$available" -lt 10 ]; then
    echo "Not enough disk space"
    exit 1
fi

# After
preflight resource --min-disk 10G --path /var/lib/docker
```