### PR TITLE
Improve code quality: reduce repetition, improve readability

### DIFF
--- a/cmd/preflight/cmd_cmd.go
+++ b/cmd/preflight/cmd_cmd.go
@@ -41,7 +41,7 @@ func runCmdCheck(_ *cobra.Command, args []string) error {
 		Name:         commandName,
 		VersionArgs:  parseVersionArgs(versionCmd),
 		MatchPattern: matchPattern,
-		Runner:       &cmdcheck.RealRunner{},
+		Runner:       &cmdcheck.RealCmdRunner{},
 	}
 
 	var err error

--- a/cmd/preflight/cmd_cmd.go
+++ b/cmd/preflight/cmd_cmd.go
@@ -2,13 +2,11 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/vertti/preflight/pkg/cmdcheck"
-	"github.com/vertti/preflight/pkg/output"
 	"github.com/vertti/preflight/pkg/version"
 )
 
@@ -36,7 +34,7 @@ func init() {
 	rootCmd.AddCommand(cmdCmd)
 }
 
-func runCmdCheck(cmd *cobra.Command, args []string) error {
+func runCmdCheck(_ *cobra.Command, args []string) error {
 	commandName := args[0]
 
 	c := &cmdcheck.Check{
@@ -57,13 +55,7 @@ func runCmdCheck(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid --exact version: %w", err)
 	}
 
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
+	return runCheck(c)
 }
 
 func parseVersionArgs(s string) []string {

--- a/cmd/preflight/cmd_env.go
+++ b/cmd/preflight/cmd_env.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/vertti/preflight/pkg/envcheck"
-	"github.com/vertti/preflight/pkg/output"
 )
 
 var (
@@ -47,7 +44,7 @@ func init() {
 	rootCmd.AddCommand(envCmd)
 }
 
-func runEnvCheck(cmd *cobra.Command, args []string) error {
+func runEnvCheck(_ *cobra.Command, args []string) error {
 	varName := args[0]
 
 	c := &envcheck.Check{
@@ -67,11 +64,5 @@ func runEnvCheck(cmd *cobra.Command, args []string) error {
 		Getter:     &envcheck.RealEnvGetter{},
 	}
 
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
+	return runCheck(c)
 }

--- a/cmd/preflight/cmd_file.go
+++ b/cmd/preflight/cmd_file.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
 	"github.com/vertti/preflight/pkg/filecheck"
-	"github.com/vertti/preflight/pkg/output"
 )
 
 var (
@@ -45,7 +42,7 @@ func init() {
 	rootCmd.AddCommand(fileCmd)
 }
 
-func runFileCheck(cmd *cobra.Command, args []string) error {
+func runFileCheck(_ *cobra.Command, args []string) error {
 	path := args[0]
 
 	c := &filecheck.Check{
@@ -64,11 +61,5 @@ func runFileCheck(cmd *cobra.Command, args []string) error {
 		FS:         &filecheck.RealFileSystem{},
 	}
 
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
+	return runCheck(c)
 }

--- a/cmd/preflight/cmd_git.go
+++ b/cmd/preflight/cmd_git.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/vertti/preflight/pkg/gitcheck"
-	"github.com/vertti/preflight/pkg/output"
 )
 
 var (
@@ -46,7 +44,7 @@ func init() {
 	rootCmd.AddCommand(gitCmd)
 }
 
-func runGitCheck(cmd *cobra.Command, args []string) error {
+func runGitCheck(_ *cobra.Command, _ []string) error {
 	// Require at least one check flag
 	if !gitClean && !gitNoUncommitted && !gitNoUntracked &&
 		gitBranch == "" && gitTagMatch == "" {
@@ -62,11 +60,5 @@ func runGitCheck(cmd *cobra.Command, args []string) error {
 		Runner:        &gitcheck.RealGitRunner{},
 	}
 
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
+	return runCheck(c)
 }

--- a/cmd/preflight/cmd_git.go
+++ b/cmd/preflight/cmd_git.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/vertti/preflight/pkg/gitcheck"
@@ -46,9 +44,14 @@ func init() {
 
 func runGitCheck(_ *cobra.Command, _ []string) error {
 	// Require at least one check flag
-	if !gitClean && !gitNoUncommitted && !gitNoUntracked &&
-		gitBranch == "" && gitTagMatch == "" {
-		return fmt.Errorf("at least one check flag required: --clean, --no-uncommitted, --no-untracked, --branch, or --tag-match")
+	if err := requireAtLeastOne(
+		flagSet{"--clean", gitClean},
+		flagSet{"--no-uncommitted", gitNoUncommitted},
+		flagSet{"--no-untracked", gitNoUntracked},
+		flagSet{"--branch", gitBranch != ""},
+		flagSet{"--tag-match", gitTagMatch != ""},
+	); err != nil {
+		return err
 	}
 
 	c := &gitcheck.Check{

--- a/cmd/preflight/cmd_git_test.go
+++ b/cmd/preflight/cmd_git_test.go
@@ -17,8 +17,8 @@ func TestRunGitCheck_RequiresFlag(t *testing.T) {
 		t.Error("expected error when no flags provided")
 	}
 
-	expectedMsg := "at least one check flag required"
-	if err != nil && err.Error()[:len(expectedMsg)] != expectedMsg {
-		t.Errorf("error = %q, want prefix %q", err.Error(), expectedMsg)
+	expectedPrefix := "at least one of"
+	if err != nil && len(err.Error()) >= len(expectedPrefix) && err.Error()[:len(expectedPrefix)] != expectedPrefix {
+		t.Errorf("error = %q, want prefix %q", err.Error(), expectedPrefix)
 	}
 }

--- a/cmd/preflight/cmd_hash.go
+++ b/cmd/preflight/cmd_hash.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/vertti/preflight/pkg/hashcheck"
-	"github.com/vertti/preflight/pkg/output"
 )
 
 var (
@@ -39,7 +37,7 @@ func init() {
 	rootCmd.AddCommand(hashCmd)
 }
 
-func runHashCheck(cmd *cobra.Command, args []string) error {
+func runHashCheck(_ *cobra.Command, args []string) error {
 	file := args[0]
 
 	// Determine algorithm and expected hash from flags
@@ -81,11 +79,5 @@ func runHashCheck(cmd *cobra.Command, args []string) error {
 		Opener:       &hashcheck.RealFileOpener{},
 	}
 
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
+	return runCheck(c)
 }

--- a/cmd/preflight/cmd_hash.go
+++ b/cmd/preflight/cmd_hash.go
@@ -68,7 +68,7 @@ func runHashCheck(_ *cobra.Command, args []string) error {
 		ExpectedHash: expectedHash,
 		Algorithm:    algorithm,
 		ChecksumFile: hashChecksumFile,
-		Opener:       &hashcheck.RealFileOpener{},
+		Opener:       &hashcheck.RealHashFileOpener{},
 	}
 
 	return runCheck(c)

--- a/cmd/preflight/cmd_hash.go
+++ b/cmd/preflight/cmd_hash.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/vertti/preflight/pkg/hashcheck"
@@ -40,35 +38,29 @@ func init() {
 func runHashCheck(_ *cobra.Command, args []string) error {
 	file := args[0]
 
+	// Validate exactly one hash flag is set
+	if err := requireExactlyOne(
+		flagValue{"--sha256", hashSHA256},
+		flagValue{"--sha512", hashSHA512},
+		flagValue{"--md5", hashMD5},
+		flagValue{"--checksum-file", hashChecksumFile},
+	); err != nil {
+		return err
+	}
+
 	// Determine algorithm and expected hash from flags
 	var algorithm hashcheck.HashAlgorithm
 	var expectedHash string
-
-	flagCount := 0
-	if hashSHA256 != "" {
+	switch {
+	case hashSHA256 != "":
 		algorithm = hashcheck.AlgorithmSHA256
 		expectedHash = hashSHA256
-		flagCount++
-	}
-	if hashSHA512 != "" {
+	case hashSHA512 != "":
 		algorithm = hashcheck.AlgorithmSHA512
 		expectedHash = hashSHA512
-		flagCount++
-	}
-	if hashMD5 != "" {
+	case hashMD5 != "":
 		algorithm = hashcheck.AlgorithmMD5
 		expectedHash = hashMD5
-		flagCount++
-	}
-	if hashChecksumFile != "" {
-		flagCount++
-	}
-
-	if flagCount == 0 {
-		return fmt.Errorf("one of --sha256, --sha512, --md5, or --checksum-file is required")
-	}
-	if flagCount > 1 {
-		return fmt.Errorf("only one of --sha256, --sha512, --md5, or --checksum-file can be specified")
 	}
 
 	c := &hashcheck.Check{

--- a/cmd/preflight/cmd_http.go
+++ b/cmd/preflight/cmd_http.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"os"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/vertti/preflight/pkg/httpcheck"
-	"github.com/vertti/preflight/pkg/output"
 )
 
 var (
@@ -43,7 +41,7 @@ func init() {
 	rootCmd.AddCommand(httpCmd)
 }
 
-func runHTTPCheck(cmd *cobra.Command, args []string) error {
+func runHTTPCheck(_ *cobra.Command, args []string) error {
 	url := args[0]
 
 	headers := parseHeaders(httpHeaders)
@@ -60,13 +58,7 @@ func runHTTPCheck(cmd *cobra.Command, args []string) error {
 		Client:         &httpcheck.RealHTTPClient{Timeout: httpTimeout, Insecure: httpInsecure},
 	}
 
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
+	return runCheck(c)
 }
 
 // parseHeaders converts ["key:value", ...] to map[string]string

--- a/cmd/preflight/cmd_resource.go
+++ b/cmd/preflight/cmd_resource.go
@@ -43,8 +43,12 @@ func init() {
 
 func runResourceCheck(_ *cobra.Command, _ []string) error {
 	// Require at least one check flag
-	if resourceMinDisk == "" && resourceMinMemory == "" && resourceMinCPUs == 0 {
-		return fmt.Errorf("at least one check flag required: --min-disk, --min-memory, or --min-cpus")
+	if err := requireAtLeastOne(
+		flagSet{"--min-disk", resourceMinDisk != ""},
+		flagSet{"--min-memory", resourceMinMemory != ""},
+		flagSet{"--min-cpus", resourceMinCPUs != 0},
+	); err != nil {
+		return err
 	}
 
 	c := &resourcecheck.Check{

--- a/cmd/preflight/cmd_resource.go
+++ b/cmd/preflight/cmd_resource.go
@@ -2,11 +2,9 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 
-	"github.com/vertti/preflight/pkg/output"
 	"github.com/vertti/preflight/pkg/resourcecheck"
 )
 
@@ -43,7 +41,7 @@ func init() {
 	rootCmd.AddCommand(resourceCmd)
 }
 
-func runResourceCheck(cmd *cobra.Command, args []string) error {
+func runResourceCheck(_ *cobra.Command, _ []string) error {
 	// Require at least one check flag
 	if resourceMinDisk == "" && resourceMinMemory == "" && resourceMinCPUs == 0 {
 		return fmt.Errorf("at least one check flag required: --min-disk, --min-memory, or --min-cpus")
@@ -73,11 +71,5 @@ func runResourceCheck(cmd *cobra.Command, args []string) error {
 		c.MinMemory = size
 	}
 
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
+	return runCheck(c)
 }

--- a/cmd/preflight/cmd_sys.go
+++ b/cmd/preflight/cmd_sys.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
-	"github.com/vertti/preflight/pkg/output"
 	"github.com/vertti/preflight/pkg/syscheck"
 )
 
@@ -32,18 +29,12 @@ func init() {
 	rootCmd.AddCommand(sysCmd)
 }
 
-func runSysCheck(cmd *cobra.Command, args []string) error {
+func runSysCheck(_ *cobra.Command, _ []string) error {
 	c := &syscheck.Check{
 		ExpectedOS:   sysOS,
 		ExpectedArch: sysArch,
 		Info:         &syscheck.RealSysInfo{},
 	}
 
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
+	return runCheck(c)
 }

--- a/cmd/preflight/cmd_tcp.go
+++ b/cmd/preflight/cmd_tcp.go
@@ -28,7 +28,7 @@ func runTCPCheck(_ *cobra.Command, args []string) error {
 	c := &tcpcheck.Check{
 		Address: address,
 		Timeout: tcpTimeout,
-		Dialer:  &tcpcheck.RealDialer{},
+		Dialer:  &tcpcheck.RealTCPDialer{},
 	}
 
 	return runCheck(c)

--- a/cmd/preflight/cmd_tcp.go
+++ b/cmd/preflight/cmd_tcp.go
@@ -1,12 +1,10 @@
 package main
 
 import (
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
 
-	"github.com/vertti/preflight/pkg/output"
 	"github.com/vertti/preflight/pkg/tcpcheck"
 )
 
@@ -24,7 +22,7 @@ func init() {
 	rootCmd.AddCommand(tcpCmd)
 }
 
-func runTCPCheck(cmd *cobra.Command, args []string) error {
+func runTCPCheck(_ *cobra.Command, args []string) error {
 	address := args[0]
 
 	c := &tcpcheck.Check{
@@ -33,11 +31,5 @@ func runTCPCheck(cmd *cobra.Command, args []string) error {
 		Dialer:  &tcpcheck.RealDialer{},
 	}
 
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
+	return runCheck(c)
 }

--- a/cmd/preflight/cmd_user.go
+++ b/cmd/preflight/cmd_user.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 
-	"github.com/vertti/preflight/pkg/output"
 	"github.com/vertti/preflight/pkg/usercheck"
 )
 
@@ -29,7 +26,7 @@ func init() {
 	rootCmd.AddCommand(userCmd)
 }
 
-func runUserCheck(cmd *cobra.Command, args []string) error {
+func runUserCheck(_ *cobra.Command, args []string) error {
 	username := args[0]
 
 	c := &usercheck.Check{
@@ -40,11 +37,5 @@ func runUserCheck(cmd *cobra.Command, args []string) error {
 		Lookup:   &usercheck.RealUserLookup{},
 	}
 
-	result := c.Run()
-	output.PrintResult(result)
-
-	if !result.OK() {
-		os.Exit(1)
-	}
-	return nil
+	return runCheck(c)
 }

--- a/cmd/preflight/run.go
+++ b/cmd/preflight/run.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"os"
+
+	"github.com/vertti/preflight/pkg/check"
+	"github.com/vertti/preflight/pkg/output"
+)
+
+// Checker is implemented by all check types.
+type Checker interface {
+	Run() check.Result
+}
+
+// runCheck executes a check, prints the result, and exits with code 1 if failed.
+func runCheck(c Checker) error {
+	result := c.Run()
+	output.PrintResult(result)
+
+	if !result.OK() {
+		os.Exit(1)
+	}
+	return nil
+}

--- a/cmd/preflight/validation.go
+++ b/cmd/preflight/validation.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+// flagValue represents a flag name and its current value for validation.
+type flagValue struct {
+	name  string
+	value string
+}
+
+// flagSet represents a flag that is either set (true) or not set (false).
+type flagSet struct {
+	name  string
+	isSet bool
+}
+
+// requireExactlyOne returns an error if not exactly one of the given flags is set (non-empty).
+func requireExactlyOne(flags ...flagValue) error {
+	var set []string
+	for _, f := range flags {
+		if f.value != "" {
+			set = append(set, f.name)
+		}
+	}
+
+	names := make([]string, len(flags))
+	for i, f := range flags {
+		names[i] = f.name
+	}
+	flagList := strings.Join(names, ", ")
+
+	if len(set) == 0 {
+		return fmt.Errorf("one of %s is required", flagList)
+	}
+	if len(set) > 1 {
+		return fmt.Errorf("only one of %s can be specified", flagList)
+	}
+	return nil
+}
+
+// requireAtLeastOne returns an error if none of the given flags are set.
+func requireAtLeastOne(flags ...flagSet) error {
+	for _, f := range flags {
+		if f.isSet {
+			return nil
+		}
+	}
+
+	names := make([]string, len(flags))
+	for i, f := range flags {
+		names[i] = f.name
+	}
+	flagList := strings.Join(names, ", ")
+	return fmt.Errorf("at least one of %s is required", flagList)
+}

--- a/cmd/preflight/validation_test.go
+++ b/cmd/preflight/validation_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRequireExactlyOne(t *testing.T) {
+	tests := []struct {
+		name      string
+		flags     []flagValue
+		wantErr   bool
+		errPrefix string
+	}{
+		{
+			name: "no flags set",
+			flags: []flagValue{
+				{"--foo", ""},
+				{"--bar", ""},
+			},
+			wantErr:   true,
+			errPrefix: "one of",
+		},
+		{
+			name: "one flag set",
+			flags: []flagValue{
+				{"--foo", "value"},
+				{"--bar", ""},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple flags set",
+			flags: []flagValue{
+				{"--foo", "value1"},
+				{"--bar", "value2"},
+			},
+			wantErr:   true,
+			errPrefix: "only one of",
+		},
+		{
+			name: "all flags set",
+			flags: []flagValue{
+				{"--foo", "a"},
+				{"--bar", "b"},
+				{"--baz", "c"},
+			},
+			wantErr:   true,
+			errPrefix: "only one of",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireExactlyOne(tt.flags...)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+					return
+				}
+				if tt.errPrefix != "" && !strings.HasPrefix(err.Error(), tt.errPrefix) {
+					t.Errorf("error = %q, want prefix %q", err.Error(), tt.errPrefix)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRequireAtLeastOne(t *testing.T) {
+	tests := []struct {
+		name      string
+		flags     []flagSet
+		wantErr   bool
+		errPrefix string
+	}{
+		{
+			name: "no flags set",
+			flags: []flagSet{
+				{"--foo", false},
+				{"--bar", false},
+			},
+			wantErr:   true,
+			errPrefix: "at least one of",
+		},
+		{
+			name: "one flag set",
+			flags: []flagSet{
+				{"--foo", true},
+				{"--bar", false},
+			},
+			wantErr: false,
+		},
+		{
+			name: "multiple flags set",
+			flags: []flagSet{
+				{"--foo", true},
+				{"--bar", true},
+			},
+			wantErr: false,
+		},
+		{
+			name: "last flag set",
+			flags: []flagSet{
+				{"--foo", false},
+				{"--bar", false},
+				{"--baz", true},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireAtLeastOne(tt.flags...)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+					return
+				}
+				if tt.errPrefix != "" && !strings.HasPrefix(err.Error(), tt.errPrefix) {
+					t.Errorf("error = %q, want prefix %q", err.Error(), tt.errPrefix)
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -138,7 +138,7 @@ func TestIntegration_TCP(t *testing.T) {
 	c := tcpcheck.Check{
 		Address: addr,
 		Timeout: 5 * time.Second,
-		Dialer:  &tcpcheck.RealDialer{},
+		Dialer:  &tcpcheck.RealTCPDialer{},
 	}
 
 	result := c.Run()

--- a/integration_test.go
+++ b/integration_test.go
@@ -27,7 +27,7 @@ import (
 func TestIntegration_Cmd(t *testing.T) {
 	c := cmdcheck.Check{
 		Name:   "bash", // bash --version is universally available
-		Runner: &cmdcheck.RealRunner{},
+		Runner: &cmdcheck.RealCmdRunner{},
 	}
 
 	result := c.Run()

--- a/pkg/check/helpers.go
+++ b/pkg/check/helpers.go
@@ -1,6 +1,9 @@
 package check
 
-import "fmt"
+import (
+	"fmt"
+	"regexp"
+)
 
 // Fail sets the result to failed status with a detail message.
 func (r *Result) Fail(detail string, err error) Result {
@@ -24,4 +27,13 @@ func (r *Result) AddDetail(detail string) *Result {
 // AddDetailf appends a formatted detail line to the result.
 func (r *Result) AddDetailf(format string, args ...interface{}) *Result {
 	return r.AddDetail(fmt.Sprintf(format, args...))
+}
+
+// CompileRegex compiles a regex pattern if non-empty, returning nil if pattern is empty.
+// This provides a consistent pattern for optional regex compilation across check packages.
+func CompileRegex(pattern string) (*regexp.Regexp, error) {
+	if pattern == "" {
+		return nil, nil
+	}
+	return regexp.Compile(pattern)
 }

--- a/pkg/check/helpers_test.go
+++ b/pkg/check/helpers_test.go
@@ -63,3 +63,53 @@ func TestResult_AddDetailf(t *testing.T) {
 		t.Errorf("Details = %v, want [path: /usr/bin/go]", result.Details)
 	}
 }
+
+func TestCompileRegex(t *testing.T) {
+	tests := []struct {
+		name      string
+		pattern   string
+		wantNil   bool
+		wantError bool
+	}{
+		{
+			name:    "empty pattern returns nil",
+			pattern: "",
+			wantNil: true,
+		},
+		{
+			name:    "valid pattern compiles",
+			pattern: "^foo.*bar$",
+			wantNil: false,
+		},
+		{
+			name:      "invalid pattern returns error",
+			pattern:   "[invalid",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			re, err := CompileRegex(tt.pattern)
+
+			if tt.wantError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if tt.wantNil && re != nil {
+				t.Errorf("expected nil regex, got %v", re)
+			}
+			if !tt.wantNil && re == nil {
+				t.Error("expected non-nil regex, got nil")
+			}
+		})
+	}
+}

--- a/pkg/cmdcheck/check.go
+++ b/pkg/cmdcheck/check.go
@@ -2,7 +2,6 @@ package cmdcheck
 
 import (
 	"fmt"
-	"regexp"
 
 	"github.com/vertti/preflight/pkg/check"
 	"github.com/vertti/preflight/pkg/version"
@@ -73,7 +72,7 @@ func (c *Check) Run() check.Result {
 }
 
 func (c *Check) checkMatchPattern(output string, result *check.Result) error {
-	re, err := regexp.Compile(c.MatchPattern)
+	re, err := check.CompileRegex(c.MatchPattern)
 	if err != nil {
 		result.Failf("invalid regex pattern: %v", err)
 		return err

--- a/pkg/cmdcheck/check.go
+++ b/pkg/cmdcheck/check.go
@@ -15,7 +15,7 @@ type Check struct {
 	MaxVersion   *version.Version // maximum version allowed (exclusive)
 	ExactVersion *version.Version // exact version required
 	MatchPattern string           // regex pattern to match against version output
-	Runner       Runner           // injected for testing
+	Runner       CmdRunner        // injected for testing
 }
 
 // Run executes the command check.

--- a/pkg/cmdcheck/check_test.go
+++ b/pkg/cmdcheck/check_test.go
@@ -20,7 +20,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			name: "command not found",
 			check: Check{
 				Name: "nonexistent",
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "", errors.New("executable file not found in $PATH")
 					},
@@ -33,7 +33,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			name: "version command fails",
 			check: Check{
 				Name: "broken",
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/broken", nil
 					},
@@ -48,7 +48,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			name: "command found and runs",
 			check: Check{
 				Name: "node",
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -67,7 +67,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "node",
 				MinVersion: &version.Version{Major: 18, Minor: 0, Patch: 0},
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -83,7 +83,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "node",
 				MinVersion: &version.Version{Major: 18, Minor: 0, Patch: 0},
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -101,7 +101,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "node",
 				MaxVersion: &version.Version{Major: 22, Minor: 0, Patch: 0},
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -117,7 +117,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "node",
 				MaxVersion: &version.Version{Major: 22, Minor: 0, Patch: 0},
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -135,7 +135,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:         "node",
 				ExactVersion: &version.Version{Major: 18, Minor: 17, Patch: 0},
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -151,7 +151,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:         "node",
 				ExactVersion: &version.Version{Major: 18, Minor: 17, Patch: 0},
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -169,7 +169,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:         "node",
 				MatchPattern: `^v18\.`,
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -185,7 +185,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:         "node",
 				MatchPattern: `^v18\.`,
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -201,7 +201,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:         "node",
 				MatchPattern: `[invalid`,
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
@@ -217,7 +217,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:       "myapp",
 				MinVersion: &version.Version{Major: 1, Minor: 0, Patch: 0},
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/myapp", nil
 					},
@@ -232,7 +232,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			name: "version from stderr when stdout empty",
 			check: Check{
 				Name: "java",
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/java", nil
 					},
@@ -248,7 +248,7 @@ func TestCommandCheck_Run(t *testing.T) {
 			check: Check{
 				Name:        "ffmpeg",
 				VersionArgs: []string{"-version"},
-				Runner: &mockRunner{
+				Runner: &mockCmdRunner{
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/ffmpeg", nil
 					},

--- a/pkg/cmdcheck/runner.go
+++ b/pkg/cmdcheck/runner.go
@@ -5,18 +5,20 @@ import (
 	"os/exec"
 )
 
-type Runner interface {
+// CmdRunner abstracts command execution for testability.
+type CmdRunner interface {
 	LookPath(file string) (string, error)
 	RunCommand(name string, args ...string) (stdout, stderr string, err error)
 }
 
-type RealRunner struct{}
+// RealCmdRunner implements CmdRunner using actual os/exec.
+type RealCmdRunner struct{}
 
-func (r *RealRunner) LookPath(file string) (string, error) {
+func (r *RealCmdRunner) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
 
-func (r *RealRunner) RunCommand(name string, args ...string) (stdout, stderr string, err error) {
+func (r *RealCmdRunner) RunCommand(name string, args ...string) (stdout, stderr string, err error) {
 	cmd := exec.Command(name, args...)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf

--- a/pkg/cmdcheck/runner_test.go
+++ b/pkg/cmdcheck/runner_test.go
@@ -5,21 +5,21 @@ import (
 	"testing"
 )
 
-type mockRunner struct {
+type mockCmdRunner struct {
 	LookPathFunc   func(file string) (string, error)
 	RunCommandFunc func(name string, args ...string) (string, string, error)
 }
 
-func (m *mockRunner) LookPath(file string) (string, error) {
+func (m *mockCmdRunner) LookPath(file string) (string, error) {
 	return m.LookPathFunc(file)
 }
 
-func (m *mockRunner) RunCommand(name string, args ...string) (stdout, stderr string, err error) {
+func (m *mockCmdRunner) RunCommand(name string, args ...string) (stdout, stderr string, err error) {
 	return m.RunCommandFunc(name, args...)
 }
 
-func TestMockRunner_LookPath(t *testing.T) {
-	mock := &mockRunner{
+func TestMockCmdRunner_LookPath(t *testing.T) {
+	mock := &mockCmdRunner{
 		LookPathFunc: func(file string) (string, error) {
 			if file == "node" {
 				return "/usr/bin/node", nil
@@ -42,8 +42,8 @@ func TestMockRunner_LookPath(t *testing.T) {
 	}
 }
 
-func TestMockRunner_RunCommand(t *testing.T) {
-	mock := &mockRunner{
+func TestMockCmdRunner_RunCommand(t *testing.T) {
+	mock := &mockCmdRunner{
 		RunCommandFunc: func(name string, args ...string) (string, string, error) {
 			if name == "node" && len(args) == 1 && args[0] == "--version" {
 				return "v18.17.0", "", nil

--- a/pkg/envcheck/check.go
+++ b/pkg/envcheck/check.go
@@ -62,16 +62,7 @@ func (c *Check) Run() check.Result {
 
 	// --one-of: value must be one of the allowed values
 	if len(c.OneOf) > 0 {
-		found := false
-		for _, allowed := range c.OneOf {
-			if value == allowed {
-				found = true
-				break
-			}
-		}
-		if !found {
-			result.Fail(fmt.Sprintf("value %q not in allowed list %v", c.formatValue(value), c.OneOf),
-				fmt.Errorf("value not in allowed list %v", c.OneOf))
+		if err := c.validateOneOf(value, &result); err != nil {
 			return result
 		}
 	}
@@ -128,4 +119,15 @@ func maskValue(value string) string {
 		return "•••"
 	}
 	return value[:3] + "•••" + value[len(value)-3:]
+}
+
+func (c *Check) validateOneOf(value string, result *check.Result) error {
+	for _, allowed := range c.OneOf {
+		if value == allowed {
+			return nil
+		}
+	}
+	err := fmt.Errorf("value not in allowed list %v", c.OneOf)
+	result.Fail(fmt.Sprintf("value %q not in allowed list %v", c.formatValue(value), c.OneOf), err)
+	return err
 }

--- a/pkg/envcheck/check.go
+++ b/pkg/envcheck/check.go
@@ -2,7 +2,6 @@ package envcheck
 
 import (
 	"fmt"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -47,7 +46,7 @@ func (c *Check) Run() check.Result {
 
 	// --match: regex pattern
 	if c.Match != "" {
-		re, err := regexp.Compile(c.Match)
+		re, err := check.CompileRegex(c.Match)
 		if err != nil {
 			return result.Failf("invalid regex pattern: %v", err)
 		}

--- a/pkg/filecheck/check.go
+++ b/pkg/filecheck/check.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"regexp"
 	"strings"
 
 	"github.com/vertti/preflight/pkg/check"
@@ -176,7 +175,7 @@ func (c *Check) checkContent(result *check.Result) error {
 
 	// --match: regex pattern
 	if c.Match != "" {
-		re, err := regexp.Compile(c.Match)
+		re, err := check.CompileRegex(c.Match)
 		if err != nil {
 			result.Failf("invalid regex pattern: %v", err)
 			return err

--- a/pkg/hashcheck/check.go
+++ b/pkg/hashcheck/check.go
@@ -17,15 +17,15 @@ import (
 	"github.com/vertti/preflight/pkg/check"
 )
 
-// FileOpener abstracts file operations for testability.
-type FileOpener interface {
+// HashFileOpener abstracts file operations for testability.
+type HashFileOpener interface {
 	Open(name string) (io.ReadCloser, error)
 }
 
-// RealFileOpener implements FileOpener using the real filesystem.
-type RealFileOpener struct{}
+// RealHashFileOpener implements HashFileOpener using the real filesystem.
+type RealHashFileOpener struct{}
 
-func (r *RealFileOpener) Open(name string) (io.ReadCloser, error) {
+func (r *RealHashFileOpener) Open(name string) (io.ReadCloser, error) {
 	return os.Open(name)
 }
 
@@ -66,7 +66,7 @@ type Check struct {
 	ExpectedHash string
 	Algorithm    HashAlgorithm
 	ChecksumFile string
-	Opener       FileOpener
+	Opener       HashFileOpener
 }
 
 func (c *Check) Run() check.Result {
@@ -104,7 +104,7 @@ func (c *Check) Run() check.Result {
 
 	opener := c.Opener
 	if opener == nil {
-		opener = &RealFileOpener{}
+		opener = &RealHashFileOpener{}
 	}
 
 	f, err := opener.Open(c.File)
@@ -160,7 +160,7 @@ var bsdFormatRegex = regexp.MustCompile(`^(SHA256|SHA512|MD5)\s+\((.+)\)\s*=\s*(
 func (c *Check) parseChecksumFile() (string, HashAlgorithm, error) {
 	opener := c.Opener
 	if opener == nil {
-		opener = &RealFileOpener{}
+		opener = &RealHashFileOpener{}
 	}
 
 	f, err := opener.Open(c.ChecksumFile)

--- a/pkg/hashcheck/check_test.go
+++ b/pkg/hashcheck/check_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/vertti/preflight/pkg/check"
 )
 
-// mockFileOpener implements FileOpener for testing.
-type mockFileOpener struct {
+// mockHashFileOpener implements HashFileOpener for testing.
+type mockHashFileOpener struct {
 	OpenFunc func(name string) (io.ReadCloser, error)
 }
 
-func (m *mockFileOpener) Open(name string) (io.ReadCloser, error) {
+func (m *mockHashFileOpener) Open(name string) (io.ReadCloser, error) {
 	return m.OpenFunc(name)
 }
 
@@ -61,7 +61,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: testContentSHA256,
 				Algorithm:    AlgorithmSHA256,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -76,7 +76,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: testContentSHA512,
 				Algorithm:    AlgorithmSHA512,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -90,7 +90,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: testContentMD5,
 				Algorithm:    AlgorithmMD5,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -104,7 +104,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: testContentSHA256,
 				// Algorithm not set - should default to SHA256
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -118,7 +118,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: strings.ToUpper(testContentSHA256),
 				Algorithm:    AlgorithmSHA256,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -134,7 +134,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: "0000000000000000000000000000000000000000000000000000000000000000",
 				Algorithm:    AlgorithmSHA256,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -149,7 +149,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: "0000000000000000000000000000000000000000000000000000000000000000",
 				Algorithm:    AlgorithmSHA256,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -166,7 +166,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "nonexistent.txt",
 				ExpectedHash: testContentSHA256,
 				Algorithm:    AlgorithmSHA256,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return nil, os.ErrNotExist
 					},
@@ -181,7 +181,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "protected.txt",
 				ExpectedHash: testContentSHA256,
 				Algorithm:    AlgorithmSHA256,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return nil, os.ErrPermission
 					},
@@ -196,7 +196,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "error.txt",
 				ExpectedHash: testContentSHA256,
 				Algorithm:    AlgorithmSHA256,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return nil, errors.New("disk I/O error")
 					},
@@ -221,7 +221,7 @@ func TestHashCheck(t *testing.T) {
 			check: Check{
 				File:         "test.txt",
 				ExpectedHash: "",
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -236,7 +236,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
 				Algorithm:    AlgorithmSHA256,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -251,7 +251,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: "abcd1234", // too short
 				Algorithm:    AlgorithmSHA256,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -266,7 +266,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: testContentSHA256, // 64 chars, but SHA512 needs 128
 				Algorithm:    AlgorithmSHA512,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -281,7 +281,7 @@ func TestHashCheck(t *testing.T) {
 				File:         "test.txt",
 				ExpectedHash: testContentSHA256, // 64 chars, but MD5 needs 32
 				Algorithm:    AlgorithmMD5,
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						return newMockReader("test content"), nil
 					},
@@ -413,7 +413,7 @@ def456  another.txt
 			c := &Check{
 				File:         tt.targetFile,
 				ChecksumFile: "checksums.txt",
-				Opener: &mockFileOpener{
+				Opener: &mockHashFileOpener{
 					OpenFunc: func(name string) (io.ReadCloser, error) {
 						if name == "checksums.txt" {
 							return newMockReader(tt.checksumContent), nil
@@ -457,7 +457,7 @@ func TestChecksumFileIntegration(t *testing.T) {
 		c := Check{
 			File:         "test.txt",
 			ChecksumFile: "checksums.txt",
-			Opener: &mockFileOpener{
+			Opener: &mockHashFileOpener{
 				OpenFunc: func(name string) (io.ReadCloser, error) {
 					if name == "checksums.txt" {
 						return newMockReader(checksumContent), nil
@@ -478,7 +478,7 @@ func TestChecksumFileIntegration(t *testing.T) {
 		c := Check{
 			File:         "test.txt",
 			ChecksumFile: "nonexistent.txt",
-			Opener: &mockFileOpener{
+			Opener: &mockHashFileOpener{
 				OpenFunc: func(name string) (io.ReadCloser, error) {
 					if name == "nonexistent.txt" {
 						return nil, os.ErrNotExist
@@ -500,9 +500,9 @@ func TestChecksumFileIntegration(t *testing.T) {
 	})
 }
 
-func TestRealFileOpener(t *testing.T) {
+func TestRealHashFileOpener(t *testing.T) {
 	t.Run("opens real file", func(t *testing.T) {
-		opener := &RealFileOpener{}
+		opener := &RealHashFileOpener{}
 		// This file should exist in any Go project
 		f, err := opener.Open("check.go")
 		if err != nil {

--- a/pkg/tcpcheck/check.go
+++ b/pkg/tcpcheck/check.go
@@ -8,16 +8,16 @@ import (
 	"github.com/vertti/preflight/pkg/check"
 )
 
-// Dialer abstracts network dialing for testability.
-type Dialer interface {
+// TCPDialer abstracts network dialing for testability.
+type TCPDialer interface {
 	DialTimeout(network, address string, timeout time.Duration) (net.Conn, error)
 }
 
-// RealDialer uses the real net package.
-type RealDialer struct{}
+// RealTCPDialer uses the real net package.
+type RealTCPDialer struct{}
 
 // DialTimeout dials the network address with a timeout.
-func (d *RealDialer) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
+func (d *RealTCPDialer) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
 	return net.DialTimeout(network, address, timeout)
 }
 
@@ -25,7 +25,7 @@ func (d *RealDialer) DialTimeout(network, address string, timeout time.Duration)
 type Check struct {
 	Address string        // host:port to connect to
 	Timeout time.Duration // connection timeout (default 5s)
-	Dialer  Dialer        // injected for testing
+	Dialer  TCPDialer     // injected for testing
 }
 
 // Run executes the TCP connectivity check.

--- a/pkg/tcpcheck/check_test.go
+++ b/pkg/tcpcheck/check_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/vertti/preflight/pkg/check"
 )
 
-// mockDialer is a mock implementation of Dialer for testing.
-type mockDialer struct {
+// mockTCPDialer is a mock implementation of TCPDialer for testing.
+type mockTCPDialer struct {
 	DialFunc func(network, address string, timeout time.Duration) (net.Conn, error)
 }
 
-func (m *mockDialer) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
+func (m *mockTCPDialer) DialTimeout(network, address string, timeout time.Duration) (net.Conn, error) {
 	return m.DialFunc(network, address, timeout)
 }
 
@@ -109,7 +109,7 @@ func TestTCPCheck(t *testing.T) {
 			c := &Check{
 				Address: tt.address,
 				Timeout: tt.timeout,
-				Dialer: &mockDialer{
+				Dialer: &mockTCPDialer{
 					DialFunc: tt.dialFunc,
 				},
 			}


### PR DESCRIPTION
- Extract `runCheck()` helper to eliminate ~70 lines of duplicated CLI boilerplate across 10 commands
- Add flag validation helpers (`requireExactlyOne`, `requireAtLeastOne`) for consistent error handling
- Add `CompileRegex` helper for optional pattern compilation (used in cmdcheck, envcheck, filecheck)
- Standardize interface naming with package context (e.g., `CmdRunner`, `TCPDialer`, `HashFileOpener`)
- Extract validation helpers in envcheck and filecheck to reduce Run() method complexity
