### PR TITLE
Add --socket flag to file command

### DIFF
--- a/cmd/preflight/cmd_file.go
+++ b/cmd/preflight/cmd_file.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	fileDir        bool
+	fileSocket     bool
 	fileWritable   bool
 	fileExecutable bool
 	fileNotEmpty   bool
@@ -29,6 +30,7 @@ var fileCmd = &cobra.Command{
 
 func init() {
 	fileCmd.Flags().BoolVar(&fileDir, "dir", false, "expect a directory")
+	fileCmd.Flags().BoolVar(&fileSocket, "socket", false, "expect a Unix socket")
 	fileCmd.Flags().BoolVar(&fileWritable, "writable", false, "check write permission")
 	fileCmd.Flags().BoolVar(&fileExecutable, "executable", false, "check execute permission")
 	fileCmd.Flags().BoolVar(&fileNotEmpty, "not-empty", false, "file must have size > 0")
@@ -46,19 +48,20 @@ func runFileCheck(_ *cobra.Command, args []string) error {
 	path := args[0]
 
 	c := &filecheck.Check{
-		Path:       path,
-		ExpectDir:  fileDir,
-		Writable:   fileWritable,
-		Executable: fileExecutable,
-		NotEmpty:   fileNotEmpty,
-		MinSize:    fileMinSize,
-		MaxSize:    fileMaxSize,
-		Match:      fileMatch,
-		Contains:   fileContains,
-		Head:       fileHead,
-		Mode:       fileMode,
-		ModeExact:  fileModeExact,
-		FS:         &filecheck.RealFileSystem{},
+		Path:         path,
+		ExpectDir:    fileDir,
+		ExpectSocket: fileSocket,
+		Writable:     fileWritable,
+		Executable:   fileExecutable,
+		NotEmpty:     fileNotEmpty,
+		MinSize:      fileMinSize,
+		MaxSize:      fileMaxSize,
+		Match:        fileMatch,
+		Contains:     fileContains,
+		Head:         fileHead,
+		Mode:         fileMode,
+		ModeExact:    fileModeExact,
+		FS:           &filecheck.RealFileSystem{},
 	}
 
 	return runCheck(c)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -123,6 +123,7 @@ preflight file <path> [flags]
 | Flag                   | Description                                          |
 | ---------------------- | ---------------------------------------------------- |
 | `--dir`                | Expect a directory (fail if it's a file)             |
+| `--socket`             | Expect a Unix socket (e.g., docker.sock)             |
 | `--writable`           | Check write permission                               |
 | `--executable`         | Check execute permission                             |
 | `--not-empty`          | File must have size > 0                              |
@@ -142,6 +143,10 @@ preflight file /etc/nginx/nginx.conf
 
 # Directory checks
 preflight file /var/log/app --dir --writable
+
+# Unix socket checks (Docker-in-Docker, containerd)
+preflight file /var/run/docker.sock --socket
+preflight file /run/containerd/containerd.sock --socket
 
 # Permission checks (minimum - file has at least these perms)
 preflight file /etc/ssl/private/key.pem --mode 0600


### PR DESCRIPTION
## Summary

- Add `--socket` flag to `preflight file` command for Unix socket detection
- Enables Docker-in-Docker and containerd socket verification patterns

## Usage

```sh
preflight file /var/run/docker.sock --socket
preflight file /run/containerd/containerd.sock --socket
```

## Changes

- Added `ExpectSocket` field and `isSocket()` helper to filecheck package
- Updated type constraint checking to handle sockets
- Added CLI flag wiring
- Added unit tests (4 cases) and integration tests (2 cases)
- Updated docs/usage.md