### PR TITLE
Add --owner flag to file command for UID verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: jdx/mise-action@v3
 
       - name: Run tests
-        run: go test -race -coverprofile=coverage.out ./...
+        run: go test -race -coverprofile=coverage.out -coverpkg=./... ./...
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5

--- a/cmd/preflight/cmd_file.go
+++ b/cmd/preflight/cmd_file.go
@@ -19,6 +19,7 @@ var (
 	fileHead       int64
 	fileMode       string
 	fileModeExact  string
+	fileOwner      int
 )
 
 var fileCmd = &cobra.Command{
@@ -41,6 +42,7 @@ func init() {
 	fileCmd.Flags().Int64Var(&fileHead, "head", 0, "limit content read to first N bytes")
 	fileCmd.Flags().StringVar(&fileMode, "mode", "", "minimum permissions (e.g., 0644)")
 	fileCmd.Flags().StringVar(&fileModeExact, "mode-exact", "", "exact permissions required")
+	fileCmd.Flags().IntVar(&fileOwner, "owner", -1, "expected owner UID")
 	rootCmd.AddCommand(fileCmd)
 }
 
@@ -61,6 +63,7 @@ func runFileCheck(_ *cobra.Command, args []string) error {
 		Head:         fileHead,
 		Mode:         fileMode,
 		ModeExact:    fileModeExact,
+		Owner:        fileOwner,
 		FS:           &filecheck.RealFileSystem{},
 	}
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -158,6 +158,7 @@ preflight file <path> [flags]
 | `--head <bytes>`       | Limit content read to first N bytes                  |
 | `--mode <perms>`       | Minimum permissions (e.g., `0644` passes for `0666`) |
 | `--mode-exact <perms>` | Exact permissions required                           |
+| `--owner <uid>`        | Expected owner UID                                   |
 
 ### Examples
 
@@ -177,6 +178,10 @@ preflight file /etc/ssl/private/key.pem --mode 0600
 
 # Permission checks (exact)
 preflight file /etc/ssl/private/key.pem --mode-exact 0600
+
+# Ownership checks (HashiCorp Consul/Vault pattern)
+preflight file /data --owner 1000
+preflight file /app/data --dir --owner 1000
 
 # Content checks (reads full file)
 preflight file /etc/nginx/nginx.conf --contains "worker_processes"

--- a/pkg/filecheck/fs.go
+++ b/pkg/filecheck/fs.go
@@ -9,6 +9,7 @@ import (
 type FileSystem interface {
 	Stat(name string) (fs.FileInfo, error)
 	ReadFile(name string, limit int64) ([]byte, error)
+	GetOwner(name string) (uid, gid uint32, err error)
 }
 
 type RealFileSystem struct{}

--- a/pkg/filecheck/fs_unix.go
+++ b/pkg/filecheck/fs_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+
+package filecheck
+
+import (
+	"os"
+	"syscall"
+)
+
+// GetOwner returns the UID and GID of the file owner.
+func (r *RealFileSystem) GetOwner(name string) (uid, gid uint32, err error) {
+	info, err := os.Stat(name)
+	if err != nil {
+		return 0, 0, err
+	}
+	stat := info.Sys().(*syscall.Stat_t)
+	return stat.Uid, stat.Gid, nil
+}

--- a/pkg/filecheck/fs_windows.go
+++ b/pkg/filecheck/fs_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package filecheck
+
+import "errors"
+
+// GetOwner is not supported on Windows.
+func (r *RealFileSystem) GetOwner(name string) (uid, gid uint32, err error) {
+	return 0, 0, errors.New("file ownership check not supported on Windows")
+}

--- a/pkg/resourcecheck/resource_common.go
+++ b/pkg/resourcecheck/resource_common.go
@@ -1,0 +1,25 @@
+package resourcecheck
+
+import "runtime"
+
+// ResourceChecker abstracts system resource detection for testability.
+type ResourceChecker interface {
+	// FreeDiskSpace returns free disk space in bytes at the given path.
+	FreeDiskSpace(path string) (uint64, error)
+
+	// AvailableMemory returns available memory in bytes.
+	// In containers, this respects cgroup limits.
+	AvailableMemory() (uint64, error)
+
+	// NumCPUs returns the number of available CPUs.
+	NumCPUs() int
+}
+
+// RealResourceChecker implements ResourceChecker using actual system calls.
+type RealResourceChecker struct{}
+
+// NumCPUs returns the number of available CPUs.
+// Go's runtime.NumCPU() already respects container CPU limits.
+func (r *RealResourceChecker) NumCPUs() int {
+	return runtime.NumCPU()
+}

--- a/pkg/resourcecheck/resource_unix.go
+++ b/pkg/resourcecheck/resource_unix.go
@@ -1,30 +1,13 @@
-//go:build !windows
+//go:build unix
 
 package resourcecheck
 
 import (
 	"os"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
 )
-
-// ResourceChecker abstracts system resource detection for testability.
-type ResourceChecker interface {
-	// FreeDiskSpace returns free disk space in bytes at the given path.
-	FreeDiskSpace(path string) (uint64, error)
-
-	// AvailableMemory returns available memory in bytes.
-	// In containers, this respects cgroup limits.
-	AvailableMemory() (uint64, error)
-
-	// NumCPUs returns the number of available CPUs.
-	NumCPUs() int
-}
-
-// RealResourceChecker implements ResourceChecker using actual system calls.
-type RealResourceChecker struct{}
 
 // FreeDiskSpace returns free disk space in bytes.
 func (r *RealResourceChecker) FreeDiskSpace(path string) (uint64, error) {
@@ -51,12 +34,6 @@ func (r *RealResourceChecker) AvailableMemory() (uint64, error) {
 
 	// Fall back to system memory
 	return getSystemMemory()
-}
-
-// NumCPUs returns the number of available CPUs.
-// Go's runtime.NumCPU() already respects container CPU limits.
-func (r *RealResourceChecker) NumCPUs() int {
-	return runtime.NumCPU()
 }
 
 // readCgroupMemoryLimit reads memory limit from a cgroup file.

--- a/pkg/resourcecheck/resource_windows.go
+++ b/pkg/resourcecheck/resource_windows.go
@@ -2,41 +2,14 @@
 
 package resourcecheck
 
-import (
-	"fmt"
-	"runtime"
-)
+import "errors"
 
-// ResourceChecker abstracts system resource detection for testability.
-type ResourceChecker interface {
-	// FreeDiskSpace returns free disk space in bytes at the given path.
-	FreeDiskSpace(path string) (uint64, error)
-
-	// AvailableMemory returns available memory in bytes.
-	// In containers, this respects cgroup limits.
-	AvailableMemory() (uint64, error)
-
-	// NumCPUs returns the number of available CPUs.
-	NumCPUs() int
-}
-
-// RealResourceChecker implements ResourceChecker using actual system calls.
-type RealResourceChecker struct{}
-
-// FreeDiskSpace returns free disk space in bytes.
-// Not implemented on Windows.
+// FreeDiskSpace is not supported on Windows.
 func (r *RealResourceChecker) FreeDiskSpace(path string) (uint64, error) {
-	return 0, fmt.Errorf("disk space check not supported on Windows")
+	return 0, errors.New("disk space check not supported on Windows")
 }
 
-// AvailableMemory returns available memory in bytes.
-// Not implemented on Windows.
+// AvailableMemory is not supported on Windows.
 func (r *RealResourceChecker) AvailableMemory() (uint64, error) {
-	return 0, fmt.Errorf("memory check not supported on Windows")
-}
-
-// NumCPUs returns the number of available CPUs.
-// Go's runtime.NumCPU() already respects container CPU limits.
-func (r *RealResourceChecker) NumCPUs() int {
-	return runtime.NumCPU()
+	return 0, errors.New("memory check not supported on Windows")
 }


### PR DESCRIPTION
## Summary

Adds `--owner <uid>` flag to `preflight file` command for verifying file ownership.

This enables the HashiCorp Consul/Vault pattern for bind-mount volume verification:

```sh
# Check file is owned by uid 1000
preflight file /data --owner 1000

# Check directory owned by app user
preflight file /app/data --dir --owner 1000
```

## Implementation

- Adds `Owner` field to `filecheck.Check` struct (-1 = don't check)
- Uses `syscall.Stat_t` to get UID on Unix systems
- Updates `FileSystem` interface with `GetOwner()` method