### PR TITLE
Add --symlink and --symlink-target flags to file command

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ These commands replace extremely common shell patterns found in virtually every 
 | `preflight sys`      | `uname -m \| sed`, `dpkg --print-architecture`, TARGETARCH    | ⭐⭐⭐⭐⭐ |
 | `preflight cmd`      | `which`, `command -v`, version parsing scripts                | ⭐⭐⭐⭐⭐ |
 | `preflight env`      | `test -z "$VAR"`, parameter expansion checks                  | ⭐⭐⭐⭐⭐ |
-| `preflight file`     | `test -f`, `test -d`, `test -r`, `-S` socket, ownership       | ⭐⭐⭐⭐⭐ |
+| `preflight file`     | `test -f`, `-d`, `-r`, `-S` socket, `-L` symlink, ownership   | ⭐⭐⭐⭐⭐ |
 | `preflight http`     | `curl --fail`, `wget --spider`, healthcheck scripts           | ⭐⭐⭐⭐   |
 | `preflight hash`     | `sha256sum -c`, GPG verification scripts                      | ⭐⭐⭐⭐   |
 | `preflight git`      | `git status --porcelain`, `git diff --exit-code`, CI checks   | ⭐⭐⭐⭐   |
@@ -191,33 +191,12 @@ preflight dns host.docker.internal --timeout 5s
 
 ---
 
-### `preflight file` Extensions (Symlinks)
-
-Symlink resolution handles path complexity in capability management.
-
-**Tools/patterns replaced:**
-
-```bash
-# From HashiCorp Vault
-setcap cap_ipc_lock=-ep $(readlink -f $(which vault))
-```
-
-**Proposed new flags:**
-
-| Flag                      | Description                  |
-| ------------------------- | ---------------------------- |
-| `--symlink`               | Path must be a symlink       |
-| `--symlink-target <path>` | Symlink must point to target |
-
----
-
 ## Summary by Impact
 
-| Priority | Command           | Impact                              |
-| -------- | ----------------- | ----------------------------------- |
-| 1        | `proc`            | Healthchecks, service orchestration |
-| 1        | `pkg`             | Package verification                |
-| 1        | `cert`            | TLS validation                      |
-| 1        | `yaml`            | Kubernetes manifest validation      |
-| 2        | `dns`             | Service discovery                   |
-| 2        | `file` (symlinks) | Capability management               |
+| Priority | Command | Impact                              |
+| -------- | ------- | ----------------------------------- |
+| 1        | `proc`  | Healthchecks, service orchestration |
+| 1        | `pkg`   | Package verification                |
+| 1        | `cert`  | TLS validation                      |
+| 1        | `yaml`  | Kubernetes manifest validation      |
+| 2        | `dns`   | Service discovery                   |

--- a/cmd/preflight/cmd_file.go
+++ b/cmd/preflight/cmd_file.go
@@ -7,19 +7,21 @@ import (
 )
 
 var (
-	fileDir        bool
-	fileSocket     bool
-	fileWritable   bool
-	fileExecutable bool
-	fileNotEmpty   bool
-	fileMinSize    int64
-	fileMaxSize    int64
-	fileMatch      string
-	fileContains   string
-	fileHead       int64
-	fileMode       string
-	fileModeExact  string
-	fileOwner      int
+	fileDir           bool
+	fileSocket        bool
+	fileSymlink       bool
+	fileSymlinkTarget string
+	fileWritable      bool
+	fileExecutable    bool
+	fileNotEmpty      bool
+	fileMinSize       int64
+	fileMaxSize       int64
+	fileMatch         string
+	fileContains      string
+	fileHead          int64
+	fileMode          string
+	fileModeExact     string
+	fileOwner         int
 )
 
 var fileCmd = &cobra.Command{
@@ -32,6 +34,8 @@ var fileCmd = &cobra.Command{
 func init() {
 	fileCmd.Flags().BoolVar(&fileDir, "dir", false, "expect a directory")
 	fileCmd.Flags().BoolVar(&fileSocket, "socket", false, "expect a Unix socket")
+	fileCmd.Flags().BoolVar(&fileSymlink, "symlink", false, "expect a symbolic link")
+	fileCmd.Flags().StringVar(&fileSymlinkTarget, "symlink-target", "", "expected symlink target path")
 	fileCmd.Flags().BoolVar(&fileWritable, "writable", false, "check write permission")
 	fileCmd.Flags().BoolVar(&fileExecutable, "executable", false, "check execute permission")
 	fileCmd.Flags().BoolVar(&fileNotEmpty, "not-empty", false, "file must have size > 0")
@@ -50,21 +54,23 @@ func runFileCheck(_ *cobra.Command, args []string) error {
 	path := args[0]
 
 	c := &filecheck.Check{
-		Path:         path,
-		ExpectDir:    fileDir,
-		ExpectSocket: fileSocket,
-		Writable:     fileWritable,
-		Executable:   fileExecutable,
-		NotEmpty:     fileNotEmpty,
-		MinSize:      fileMinSize,
-		MaxSize:      fileMaxSize,
-		Match:        fileMatch,
-		Contains:     fileContains,
-		Head:         fileHead,
-		Mode:         fileMode,
-		ModeExact:    fileModeExact,
-		Owner:        fileOwner,
-		FS:           &filecheck.RealFileSystem{},
+		Path:          path,
+		ExpectDir:     fileDir,
+		ExpectSocket:  fileSocket,
+		ExpectSymlink: fileSymlink,
+		SymlinkTarget: fileSymlinkTarget,
+		Writable:      fileWritable,
+		Executable:    fileExecutable,
+		NotEmpty:      fileNotEmpty,
+		MinSize:       fileMinSize,
+		MaxSize:       fileMaxSize,
+		Match:         fileMatch,
+		Contains:      fileContains,
+		Head:          fileHead,
+		Mode:          fileMode,
+		ModeExact:     fileModeExact,
+		Owner:         fileOwner,
+		FS:            &filecheck.RealFileSystem{},
 	}
 
 	return runCheck(c)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -144,21 +144,23 @@ preflight file <path> [flags]
 
 ### Flags
 
-| Flag                   | Description                                          |
-| ---------------------- | ---------------------------------------------------- |
-| `--dir`                | Expect a directory (fail if it's a file)             |
-| `--socket`             | Expect a Unix socket (e.g., docker.sock)             |
-| `--writable`           | Check write permission                               |
-| `--executable`         | Check execute permission                             |
-| `--not-empty`          | File must have size > 0                              |
-| `--min-size <bytes>`   | Minimum file size                                    |
-| `--max-size <bytes>`   | Maximum file size                                    |
-| `--match <pattern>`    | Regex pattern to match against content               |
-| `--contains <string>`  | Literal string to search in content                  |
-| `--head <bytes>`       | Limit content read to first N bytes                  |
-| `--mode <perms>`       | Minimum permissions (e.g., `0644` passes for `0666`) |
-| `--mode-exact <perms>` | Exact permissions required                           |
-| `--owner <uid>`        | Expected owner UID                                   |
+| Flag                      | Description                                          |
+| ------------------------- | ---------------------------------------------------- |
+| `--dir`                   | Expect a directory (fail if it's a file)             |
+| `--socket`                | Expect a Unix socket (e.g., docker.sock)             |
+| `--symlink`               | Expect a symbolic link                               |
+| `--symlink-target <path>` | Expected symlink target path                         |
+| `--writable`              | Check write permission                               |
+| `--executable`            | Check execute permission                             |
+| `--not-empty`             | File must have size > 0                              |
+| `--min-size <bytes>`      | Minimum file size                                    |
+| `--max-size <bytes>`      | Maximum file size                                    |
+| `--match <pattern>`       | Regex pattern to match against content               |
+| `--contains <string>`     | Literal string to search in content                  |
+| `--head <bytes>`          | Limit content read to first N bytes                  |
+| `--mode <perms>`          | Minimum permissions (e.g., `0644` passes for `0666`) |
+| `--mode-exact <perms>`    | Exact permissions required                           |
+| `--owner <uid>`           | Expected owner UID                                   |
 
 ### Examples
 
@@ -182,6 +184,10 @@ preflight file /etc/ssl/private/key.pem --mode-exact 0600
 # Ownership checks (HashiCorp Consul/Vault pattern)
 preflight file /data --owner 1000
 preflight file /app/data --dir --owner 1000
+
+# Symlink checks (capability management, alternative binaries)
+preflight file /usr/bin/python --symlink
+preflight file /usr/bin/python --symlink --symlink-target /usr/bin/python3
 
 # Content checks (reads full file)
 preflight file /etc/nginx/nginx.conf --contains "worker_processes"

--- a/pkg/filecheck/fs.go
+++ b/pkg/filecheck/fs.go
@@ -8,7 +8,9 @@ import (
 
 type FileSystem interface {
 	Stat(name string) (fs.FileInfo, error)
+	Lstat(name string) (fs.FileInfo, error)
 	ReadFile(name string, limit int64) ([]byte, error)
+	Readlink(name string) (string, error)
 	GetOwner(name string) (uid, gid uint32, err error)
 }
 
@@ -16,6 +18,14 @@ type RealFileSystem struct{}
 
 func (r *RealFileSystem) Stat(name string) (fs.FileInfo, error) {
 	return os.Stat(name)
+}
+
+func (r *RealFileSystem) Lstat(name string) (fs.FileInfo, error) {
+	return os.Lstat(name)
+}
+
+func (r *RealFileSystem) Readlink(name string) (string, error) {
+	return os.Readlink(name)
 }
 
 // ReadFile reads up to limit bytes. If limit <= 0, reads entire file.


### PR DESCRIPTION
## Summary
- Add `--symlink` flag to verify a path is a symbolic link
- Add `--symlink-target` flag to verify the symlink points to expected target
- Uses `Lstat` (doesn't follow symlinks) for accurate symlink detection

## Example usage
```sh
preflight file /usr/bin/python --symlink
preflight file /usr/bin/python --symlink --symlink-target /usr/bin/python3
```

## Changes
- Add `Lstat` and `Readlink` to FileSystem interface
- Add `ExpectSymlink` and `SymlinkTarget` fields to Check struct
- Update docs and ROADMAP