### PR TITLE
Enhance cmd command with timeout, version-regex, and semver range support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ go.work.sum
 PLAN_PREFLIGHT.md
 *plan*.md
 
+# Research folder
+research/
+
 # Build output
 bin/
 

--- a/cmd/preflight/cmd_cmd.go
+++ b/cmd/preflight/cmd_cmd.go
@@ -12,12 +12,13 @@ import (
 )
 
 var (
-	minVersion   string
-	maxVersion   string
-	exactVersion string
-	matchPattern string
-	versionCmd   string
-	cmdTimeout   time.Duration
+	minVersion     string
+	maxVersion     string
+	exactVersion   string
+	matchPattern   string
+	versionCmd     string
+	cmdTimeout     time.Duration
+	versionPattern string
 )
 
 var cmdCmd = &cobra.Command{
@@ -32,6 +33,7 @@ func init() {
 	cmdCmd.Flags().StringVar(&maxVersion, "max", "", "maximum version allowed (exclusive)")
 	cmdCmd.Flags().StringVar(&exactVersion, "exact", "", "exact version required")
 	cmdCmd.Flags().StringVar(&matchPattern, "match", "", "regex pattern to match against version output")
+	cmdCmd.Flags().StringVar(&versionPattern, "version-regex", "", "regex with capture group to extract version")
 	cmdCmd.Flags().StringVar(&versionCmd, "version-cmd", "--version", "command to get version")
 	cmdCmd.Flags().DurationVar(&cmdTimeout, "timeout", cmdcheck.DefaultTimeout, "timeout for version command")
 	rootCmd.AddCommand(cmdCmd)
@@ -41,11 +43,12 @@ func runCmdCheck(_ *cobra.Command, args []string) error {
 	commandName := args[0]
 
 	c := &cmdcheck.Check{
-		Name:         commandName,
-		VersionArgs:  parseVersionArgs(versionCmd),
-		MatchPattern: matchPattern,
-		Timeout:      cmdTimeout,
-		Runner:       &cmdcheck.RealCmdRunner{},
+		Name:           commandName,
+		VersionArgs:    parseVersionArgs(versionCmd),
+		MatchPattern:   matchPattern,
+		VersionPattern: versionPattern,
+		Timeout:        cmdTimeout,
+		Runner:         &cmdcheck.RealCmdRunner{},
 	}
 
 	var err error

--- a/cmd/preflight/cmd_cmd.go
+++ b/cmd/preflight/cmd_cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -16,6 +17,7 @@ var (
 	exactVersion string
 	matchPattern string
 	versionCmd   string
+	cmdTimeout   time.Duration
 )
 
 var cmdCmd = &cobra.Command{
@@ -31,6 +33,7 @@ func init() {
 	cmdCmd.Flags().StringVar(&exactVersion, "exact", "", "exact version required")
 	cmdCmd.Flags().StringVar(&matchPattern, "match", "", "regex pattern to match against version output")
 	cmdCmd.Flags().StringVar(&versionCmd, "version-cmd", "--version", "command to get version")
+	cmdCmd.Flags().DurationVar(&cmdTimeout, "timeout", cmdcheck.DefaultTimeout, "timeout for version command")
 	rootCmd.AddCommand(cmdCmd)
 }
 
@@ -41,6 +44,7 @@ func runCmdCheck(_ *cobra.Command, args []string) error {
 		Name:         commandName,
 		VersionArgs:  parseVersionArgs(versionCmd),
 		MatchPattern: matchPattern,
+		Timeout:      cmdTimeout,
 		Runner:       &cmdcheck.RealCmdRunner{},
 	}
 

--- a/cmd/preflight/cmd_cmd.go
+++ b/cmd/preflight/cmd_cmd.go
@@ -15,6 +15,7 @@ var (
 	minVersion     string
 	maxVersion     string
 	exactVersion   string
+	versionRange   string
 	matchPattern   string
 	versionCmd     string
 	cmdTimeout     time.Duration
@@ -32,6 +33,7 @@ func init() {
 	cmdCmd.Flags().StringVar(&minVersion, "min", "", "minimum version required (inclusive)")
 	cmdCmd.Flags().StringVar(&maxVersion, "max", "", "maximum version allowed (exclusive)")
 	cmdCmd.Flags().StringVar(&exactVersion, "exact", "", "exact version required")
+	cmdCmd.Flags().StringVar(&versionRange, "range", "", "semver constraint (e.g., \">=1.0, <2.0\", \"^1.5\", \"~1.5\")")
 	cmdCmd.Flags().StringVar(&matchPattern, "match", "", "regex pattern to match against version output")
 	cmdCmd.Flags().StringVar(&versionPattern, "version-regex", "", "regex with capture group to extract version")
 	cmdCmd.Flags().StringVar(&versionCmd, "version-cmd", "--version", "command to get version")
@@ -45,6 +47,7 @@ func runCmdCheck(_ *cobra.Command, args []string) error {
 	c := &cmdcheck.Check{
 		Name:           commandName,
 		VersionArgs:    parseVersionArgs(versionCmd),
+		VersionRange:   versionRange,
 		MatchPattern:   matchPattern,
 		VersionPattern: versionPattern,
 		Timeout:        cmdTimeout,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,15 +44,16 @@ preflight cmd <command> [flags]
 
 ### Flags
 
-| Flag                    | Description                                   |
-| ----------------------- | --------------------------------------------- |
-| `--min <version>`       | Minimum version required (inclusive)          |
-| `--max <version>`       | Maximum version allowed (exclusive)           |
-| `--exact <version>`     | Exact version required                        |
-| `--match <pattern>`     | Regex pattern to match against version output |
-| `--version-regex <pat>` | Regex with capture group to extract version   |
-| `--version-cmd <arg>`   | Override the default `--version` argument     |
-| `--timeout <duration>`  | Timeout for version command (default: 30s)    |
+| Flag                    | Description                                     |
+| ----------------------- | ----------------------------------------------- |
+| `--min <version>`       | Minimum version required (inclusive)            |
+| `--max <version>`       | Maximum version allowed (exclusive)             |
+| `--exact <version>`     | Exact version required                          |
+| `--range <constraint>`  | Semver constraint (e.g., `>=1.0, <2.0`, `^1.5`) |
+| `--match <pattern>`     | Regex pattern to match against version output   |
+| `--version-regex <pat>` | Regex with capture group to extract version     |
+| `--version-cmd <arg>`   | Override the default `--version` argument       |
+| `--timeout <duration>`  | Timeout for version command (default: 30s)      |
 
 ### Examples
 
@@ -79,6 +80,11 @@ preflight cmd quick-check --timeout 5s
 # Extract version from messy output using regex capture group
 # For output like "myapp version: 2.5.3 (built 2024-01-01)"
 preflight cmd myapp --version-regex "version[:\s]+(\d+\.\d+\.\d+)" --min 2.0
+
+# Semver range constraints
+preflight cmd terraform --range ">=1.0, <2.0"   # Between 1.x and 2.0
+preflight cmd node --range "^18.0.0"             # Compatible with 18.x
+preflight cmd python3 --range "~3.11.0"          # Patch releases of 3.11
 ```
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,14 +44,15 @@ preflight cmd <command> [flags]
 
 ### Flags
 
-| Flag                   | Description                                   |
-| ---------------------- | --------------------------------------------- |
-| `--min <version>`      | Minimum version required (inclusive)          |
-| `--max <version>`      | Maximum version allowed (exclusive)           |
-| `--exact <version>`    | Exact version required                        |
-| `--match <pattern>`    | Regex pattern to match against version output |
-| `--version-cmd <arg>`  | Override the default `--version` argument     |
-| `--timeout <duration>` | Timeout for version command (default: 30s)    |
+| Flag                    | Description                                   |
+| ----------------------- | --------------------------------------------- |
+| `--min <version>`       | Minimum version required (inclusive)          |
+| `--max <version>`       | Maximum version allowed (exclusive)           |
+| `--exact <version>`     | Exact version required                        |
+| `--match <pattern>`     | Regex pattern to match against version output |
+| `--version-regex <pat>` | Regex with capture group to extract version   |
+| `--version-cmd <arg>`   | Override the default `--version` argument     |
+| `--timeout <duration>`  | Timeout for version command (default: 30s)    |
 
 ### Examples
 
@@ -74,6 +75,10 @@ preflight cmd java --version-cmd "-version"  # runs: java -version
 # Custom timeout (for slow commands)
 preflight cmd slow-binary --timeout 60s
 preflight cmd quick-check --timeout 5s
+
+# Extract version from messy output using regex capture group
+# For output like "myapp version: 2.5.3 (built 2024-01-01)"
+preflight cmd myapp --version-regex "version[:\s]+(\d+\.\d+\.\d+)" --min 2.0
 ```
 
 ---

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,13 +44,14 @@ preflight cmd <command> [flags]
 
 ### Flags
 
-| Flag                  | Description                                   |
-| --------------------- | --------------------------------------------- |
-| `--min <version>`     | Minimum version required (inclusive)          |
-| `--max <version>`     | Maximum version allowed (exclusive)           |
-| `--exact <version>`   | Exact version required                        |
-| `--match <pattern>`   | Regex pattern to match against version output |
-| `--version-cmd <arg>` | Override the default `--version` argument     |
+| Flag                   | Description                                   |
+| ---------------------- | --------------------------------------------- |
+| `--min <version>`      | Minimum version required (inclusive)          |
+| `--max <version>`      | Maximum version allowed (exclusive)           |
+| `--exact <version>`    | Exact version required                        |
+| `--match <pattern>`    | Regex pattern to match against version output |
+| `--version-cmd <arg>`  | Override the default `--version` argument     |
+| `--timeout <duration>` | Timeout for version command (default: 30s)    |
 
 ### Examples
 
@@ -69,6 +70,10 @@ preflight cmd myapp --match "^v2\."
 # Custom version command
 preflight cmd ffmpeg --version-cmd -version  # runs: ffmpeg -version
 preflight cmd java --version-cmd "-version"  # runs: java -version
+
+# Custom timeout (for slow commands)
+preflight cmd slow-binary --timeout 60s
+preflight cmd quick-check --timeout 5s
 ```
 
 ---

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25
 require github.com/spf13/cobra v1.10.1
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jwalton/go-supportscolor v1.2.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/pkg/cmdcheck/check_test.go
+++ b/pkg/cmdcheck/check_test.go
@@ -403,6 +403,120 @@ func TestCommandCheck_Run(t *testing.T) {
 			},
 			wantStatus: check.StatusFail,
 		},
+
+		// --range semver constraint tests
+		{
+			name: "range constraint >= passes",
+			check: Check{
+				Name:         "myapp",
+				VersionRange: ">=2.0.0",
+				Runner: &mockCmdRunner{
+					LookPathFunc: func(file string) (string, error) {
+						return "/usr/bin/myapp", nil
+					},
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
+						return "v2.5.3", "", nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "range constraint >= fails",
+			check: Check{
+				Name:         "myapp",
+				VersionRange: ">=3.0.0",
+				Runner: &mockCmdRunner{
+					LookPathFunc: func(file string) (string, error) {
+						return "/usr/bin/myapp", nil
+					},
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
+						return "v2.5.3", "", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "range constraint with multiple conditions",
+			check: Check{
+				Name:         "myapp",
+				VersionRange: ">=2.0.0, <3.0.0",
+				Runner: &mockCmdRunner{
+					LookPathFunc: func(file string) (string, error) {
+						return "/usr/bin/myapp", nil
+					},
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
+						return "v2.5.3", "", nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "range constraint with caret",
+			check: Check{
+				Name:         "myapp",
+				VersionRange: "^1.5.0",
+				Runner: &mockCmdRunner{
+					LookPathFunc: func(file string) (string, error) {
+						return "/usr/bin/myapp", nil
+					},
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
+						return "v1.9.0", "", nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "range constraint with tilde",
+			check: Check{
+				Name:         "myapp",
+				VersionRange: "~1.5.0",
+				Runner: &mockCmdRunner{
+					LookPathFunc: func(file string) (string, error) {
+						return "/usr/bin/myapp", nil
+					},
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
+						return "v1.5.9", "", nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "range constraint tilde fails major bump",
+			check: Check{
+				Name:         "myapp",
+				VersionRange: "~1.5.0",
+				Runner: &mockCmdRunner{
+					LookPathFunc: func(file string) (string, error) {
+						return "/usr/bin/myapp", nil
+					},
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
+						return "v1.6.0", "", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "range constraint invalid syntax",
+			check: Check{
+				Name:         "myapp",
+				VersionRange: "invalid constraint",
+				Runner: &mockCmdRunner{
+					LookPathFunc: func(file string) (string, error) {
+						return "/usr/bin/myapp", nil
+					},
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
+						return "v1.0.0", "", nil
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/cmdcheck/check_test.go
+++ b/pkg/cmdcheck/check_test.go
@@ -1,8 +1,10 @@
 package cmdcheck
 
 import (
+	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/vertti/preflight/pkg/check"
 	"github.com/vertti/preflight/pkg/version"
@@ -37,7 +39,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/broken", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "", "error loading shared library", errors.New("exit 1")
 					},
 				},
@@ -52,7 +54,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "v18.17.0", "", nil
 					},
 				},
@@ -71,7 +73,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "v18.17.0", "", nil
 					},
 				},
@@ -87,7 +89,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "v16.0.0", "", nil
 					},
 				},
@@ -105,7 +107,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "v18.17.0", "", nil
 					},
 				},
@@ -121,7 +123,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "v22.0.0", "", nil
 					},
 				},
@@ -139,7 +141,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "v18.17.0", "", nil
 					},
 				},
@@ -155,7 +157,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "v18.17.1", "", nil
 					},
 				},
@@ -173,7 +175,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "v18.17.0", "", nil
 					},
 				},
@@ -189,7 +191,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "v16.0.0", "", nil
 					},
 				},
@@ -205,7 +207,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/node", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "v18.0.0", "", nil
 					},
 				},
@@ -221,7 +223,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/myapp", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "no version info here", "", nil
 					},
 				},
@@ -236,7 +238,7 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/java", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						return "", "openjdk 17.0.1 2021-10-19", nil
 					},
 				},
@@ -252,11 +254,47 @@ func TestCommandCheck_Run(t *testing.T) {
 					LookPathFunc: func(file string) (string, error) {
 						return "/usr/bin/ffmpeg", nil
 					},
-					RunCommandFunc: func(name string, args ...string) (string, string, error) {
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
 						if len(args) == 1 && args[0] == "-version" {
 							return "ffmpeg version 5.1.2", "", nil
 						}
 						return "", "", errors.New("wrong args")
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+
+		// --timeout tests
+		{
+			name: "timeout triggers on slow command",
+			check: Check{
+				Name:    "slowcmd",
+				Timeout: 10 * time.Millisecond,
+				Runner: &mockCmdRunner{
+					LookPathFunc: func(file string) (string, error) {
+						return "/usr/bin/slowcmd", nil
+					},
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
+						// Simulate slow command by waiting for context cancellation
+						<-ctx.Done()
+						return "", "", ctx.Err()
+					},
+				},
+			},
+			wantStatus: check.StatusFail,
+		},
+		{
+			name: "custom timeout passes when command is fast",
+			check: Check{
+				Name:    "fastcmd",
+				Timeout: 5 * time.Second,
+				Runner: &mockCmdRunner{
+					LookPathFunc: func(file string) (string, error) {
+						return "/usr/bin/fastcmd", nil
+					},
+					RunCommandContextFunc: func(ctx context.Context, name string, args ...string) (string, string, error) {
+						return "v1.0.0", "", nil
 					},
 				},
 			},

--- a/pkg/cmdcheck/runner.go
+++ b/pkg/cmdcheck/runner.go
@@ -2,13 +2,18 @@ package cmdcheck
 
 import (
 	"bytes"
+	"context"
 	"os/exec"
+	"time"
 )
+
+// DefaultTimeout is the default timeout for version commands.
+const DefaultTimeout = 30 * time.Second
 
 // CmdRunner abstracts command execution for testability.
 type CmdRunner interface {
 	LookPath(file string) (string, error)
-	RunCommand(name string, args ...string) (stdout, stderr string, err error)
+	RunCommandContext(ctx context.Context, name string, args ...string) (stdout, stderr string, err error)
 }
 
 // RealCmdRunner implements CmdRunner using actual os/exec.
@@ -18,8 +23,8 @@ func (r *RealCmdRunner) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
 
-func (r *RealCmdRunner) RunCommand(name string, args ...string) (stdout, stderr string, err error) {
-	cmd := exec.Command(name, args...)
+func (r *RealCmdRunner) RunCommandContext(ctx context.Context, name string, args ...string) (stdout, stderr string, err error) {
+	cmd := exec.CommandContext(ctx, name, args...)
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf


### PR DESCRIPTION
## Summary
- Add `--timeout` flag for version command timeout (default 30s)
- Add `--version-regex` flag to extract versions from messy command output using regex capture groups
- Add `--range` flag for semver constraint validation (e.g., `>=1.0, <2.0`, `^1.5`, `~1.5`)

Based on patterns from flaghunt.md research analyzing Goss, InSpec, Testinfra, and other infrastructure testing tools.

## New Flags

| Flag | Description |
|------|-------------|
| `--timeout <duration>` | Timeout for version command (default: 30s) |
| `--version-regex <pattern>` | Regex with capture group to extract version |
| `--range <constraint>` | Semver constraint (e.g., `>=1.0, <2.0`, `^1.5`) |

## Examples

```sh
# Timeout for slow commands
preflight cmd slow-binary --timeout 60s

# Extract version from messy output
preflight cmd myapp --version-regex "version[:\s]+(\d+\.\d+\.\d+)" --min 2.0

# Semver range constraints
preflight cmd terraform --range ">=1.0, <2.0"
preflight cmd node --range "^18.0.0"
```