### PR TITLE
Add env command validators for type and path checking

### DIFF
--- a/cmd/preflight/cmd_env.go
+++ b/cmd/preflight/cmd_env.go
@@ -22,6 +22,8 @@ var (
 	envIsURL      bool
 	envIsJSON     bool
 	envIsBool     bool
+	envIsFile     bool
+	envIsDir      bool
 	envMinLen     int
 	envMaxLen     int
 	envMinValue   float64
@@ -51,6 +53,8 @@ func init() {
 	envCmd.Flags().BoolVar(&envIsURL, "is-url", false, "value must be valid URL")
 	envCmd.Flags().BoolVar(&envIsJSON, "is-json", false, "value must be valid JSON")
 	envCmd.Flags().BoolVar(&envIsBool, "is-bool", false, "value must be boolean (true/false/1/0/yes/no/on/off)")
+	envCmd.Flags().BoolVar(&envIsFile, "is-file", false, "value must be path to existing file")
+	envCmd.Flags().BoolVar(&envIsDir, "is-dir", false, "value must be path to existing directory")
 	envCmd.Flags().IntVar(&envMinLen, "min-len", 0, "minimum string length")
 	envCmd.Flags().IntVar(&envMaxLen, "max-len", 0, "maximum string length")
 	envCmd.Flags().Float64Var(&envMinValue, "min-value", 0, "minimum numeric value (use with --is-numeric)")
@@ -78,9 +82,12 @@ func runEnvCheck(cmd *cobra.Command, args []string) error {
 		IsURL:      envIsURL,
 		IsJSON:     envIsJSON,
 		IsBool:     envIsBool,
+		IsFile:     envIsFile,
+		IsDir:      envIsDir,
 		MinLen:     envMinLen,
 		MaxLen:     envMaxLen,
 		Getter:     &envcheck.RealEnvGetter{},
+		Stater:     &envcheck.RealFileStater{},
 	}
 
 	// Only set MinValue/MaxValue if the flags were explicitly provided

--- a/cmd/preflight/cmd_env.go
+++ b/cmd/preflight/cmd_env.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	envNotSet     bool
 	envAllowEmpty bool
 	envMatch      string
 	envExact      string
@@ -29,6 +30,7 @@ var envCmd = &cobra.Command{
 }
 
 func init() {
+	envCmd.Flags().BoolVar(&envNotSet, "not-set", false, "verify variable is NOT defined")
 	envCmd.Flags().BoolVar(&envAllowEmpty, "allow-empty", false, "pass if defined but empty")
 	envCmd.Flags().StringVar(&envMatch, "match", "", "regex pattern to match value")
 	envCmd.Flags().StringVar(&envExact, "exact", "", "exact value required")
@@ -49,6 +51,7 @@ func runEnvCheck(_ *cobra.Command, args []string) error {
 
 	c := &envcheck.Check{
 		Name:       varName,
+		NotSet:     envNotSet,
 		AllowEmpty: envAllowEmpty,
 		Match:      envMatch,
 		Exact:      envExact,

--- a/pkg/envcheck/check_test.go
+++ b/pkg/envcheck/check_test.go
@@ -314,6 +314,38 @@ func TestEnvCheck_Run(t *testing.T) {
 			wantStatus: check.StatusFail,
 			wantDetail: "value length 12 > maximum 5",
 		},
+
+		// --not-set flag tests
+		{
+			name: "not-set passes when variable undefined",
+			check: Check{
+				Name:   "SHOULD_NOT_EXIST",
+				NotSet: true,
+				Getter: &mockEnvGetter{Vars: map[string]string{}},
+			},
+			wantStatus: check.StatusOK,
+			wantDetail: "not set (as expected)",
+		},
+		{
+			name: "not-set fails when variable is defined",
+			check: Check{
+				Name:   "EXISTS",
+				NotSet: true,
+				Getter: &mockEnvGetter{Vars: map[string]string{"EXISTS": "some-value"}},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "variable is set (expected not set)",
+		},
+		{
+			name: "not-set fails when variable is defined but empty",
+			check: Check{
+				Name:   "EMPTY",
+				NotSet: true,
+				Getter: &mockEnvGetter{Vars: map[string]string{"EMPTY": ""}},
+			},
+			wantStatus: check.StatusFail,
+			wantDetail: "variable is set (expected not set)",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/envcheck/env.go
+++ b/pkg/envcheck/env.go
@@ -11,3 +11,15 @@ type RealEnvGetter struct{}
 func (r *RealEnvGetter) LookupEnv(key string) (string, bool) {
 	return os.LookupEnv(key)
 }
+
+// FileStater provides file system stat operations for testing.
+type FileStater interface {
+	Stat(path string) (os.FileInfo, error)
+}
+
+// RealFileStater uses actual os.Stat.
+type RealFileStater struct{}
+
+func (r *RealFileStater) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}


### PR DESCRIPTION
## Summary
- Add `--not-set` flag to verify an env variable is NOT defined
- Add type validators: `--is-port`, `--is-url`, `--is-json`, `--is-bool`
- Add numeric range validators: `--min-value`, `--max-value`
- Add path validators: `--is-file`, `--is-dir`

All validators include comprehensive unit tests with mock interfaces for isolated testing.