### PR TITLE
Enable additional linters and fix all issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,15 @@ linters:
     - unconvert
     - gocritic
     - nolintlint
+    # Error handling
+    - errorlint      # proper error wrapping with errors.Is/As
+    - nilerr         # return nil when err != nil
+    # Safety
+    - bodyclose      # HTTP response body must be closed
+    - forcetypeassert # type assertions must be checked
+    # Code quality
+    - predeclared    # shadowing of predeclared identifiers
+    - dupword        # duplicate words in comments
   settings:
     gocritic:
       enabled-tags:

--- a/cmd/preflight/cmd_run.go
+++ b/cmd/preflight/cmd_run.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -62,7 +63,8 @@ func runRun(cmd *cobra.Command, args []string) error {
 		execCmd.Stdin = os.Stdin
 
 		if err := execCmd.Run(); err != nil {
-			if exitError, ok := err.(*exec.ExitError); ok {
+			var exitError *exec.ExitError
+			if errors.As(err, &exitError) {
 				os.Exit(exitError.ExitCode())
 			}
 			return fmt.Errorf("failed to execute command %q: %w", command, err)

--- a/pkg/check/helpers_test.go
+++ b/pkg/check/helpers_test.go
@@ -17,7 +17,7 @@ func TestResult_Fail(t *testing.T) {
 	if len(result.Details) != 1 || result.Details[0] != "something failed" {
 		t.Errorf("Details = %v, want [something failed]", result.Details)
 	}
-	if result.Err != err {
+	if !errors.Is(result.Err, err) {
 		t.Errorf("Err = %v, want %v", result.Err, err)
 	}
 }

--- a/pkg/filecheck/fs_unix.go
+++ b/pkg/filecheck/fs_unix.go
@@ -3,6 +3,7 @@
 package filecheck
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 )
@@ -13,6 +14,9 @@ func (r *RealFileSystem) GetOwner(name string) (uid, gid uint32, err error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	stat := info.Sys().(*syscall.Stat_t)
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, fmt.Errorf("unexpected file info type for %s", name)
+	}
 	return stat.Uid, stat.Gid, nil
 }

--- a/pkg/gitcheck/runner.go
+++ b/pkg/gitcheck/runner.go
@@ -2,6 +2,7 @@ package gitcheck
 
 import (
 	"bytes"
+	"errors"
 	"os/exec"
 	"strings"
 )
@@ -30,8 +31,13 @@ func (r *RealGitRunner) IsGitRepo() (bool, error) {
 	cmd := exec.Command("git", "rev-parse", "--git-dir")
 	err := cmd.Run()
 	if err != nil {
-		// Exit code 128 = not a git repository
-		return false, nil
+		// ExitError means git ran but returned non-zero (not a git repo)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return false, nil
+		}
+		// Other errors (e.g., git not found) should be returned
+		return false, err
 	}
 	return true, nil
 }

--- a/pkg/hashcheck/check.go
+++ b/pkg/hashcheck/check.go
@@ -216,7 +216,7 @@ func (c *Check) parseChecksumFile() (string, HashAlgorithm, error) {
 
 	f, err := opener.Open(c.ChecksumFile)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to open checksum file: %v", err)
+		return "", "", fmt.Errorf("failed to open checksum file: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 
@@ -239,7 +239,7 @@ func (c *Check) parseChecksumFile() (string, HashAlgorithm, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return "", "", fmt.Errorf("error reading checksum file: %v", err)
+		return "", "", fmt.Errorf("error reading checksum file: %w", err)
 	}
 
 	return "", "", fmt.Errorf("file %q not found in checksum file", targetFile)

--- a/pkg/hashcheck/check_test.go
+++ b/pkg/hashcheck/check_test.go
@@ -678,7 +678,7 @@ func TestRealHashFileOpener(t *testing.T) {
 		// Read a bit to verify it works
 		buf := make([]byte, 10)
 		n, err := f.Read(buf)
-		if err != nil && err != io.EOF {
+		if err != nil && !errors.Is(err, io.EOF) {
 			t.Errorf("failed to read: %v", err)
 		}
 		if n == 0 {


### PR DESCRIPTION
## Summary

Enable 6 new linters to catch bugs and improve code quality:

| Linter | Purpose |
|--------|---------|
| `errorlint` | Proper error wrapping with `errors.Is`/`errors.As` |
| `nilerr` | Catch `return nil` when `err != nil` |
| `bodyclose` | HTTP response body must be closed |
| `forcetypeassert` | Type assertions must be checked |
| `predeclared` | Shadowing of predeclared identifiers |
| `dupword` | Duplicate words in comments |

## Issues Fixed

- **errorlint**: Use `errors.As` instead of type assertion on `*exec.ExitError`
- **errorlint**: Use `errors.Is` for error comparisons in tests
- **errorlint**: Use `%w` instead of `%v` for error wrapping in `fmt.Errorf`
- **forcetypeassert**: Add type assertion check in `fs_unix.go`
- **nilerr**: Handle git command errors properly in `IsGitRepo()` - now returns actual errors (like "git not found") instead of silently ignoring them