### PR TITLE
Add modern Go idiom linters and apply fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,6 +23,12 @@ linters:
     # Code quality
     - predeclared    # shadowing of predeclared identifiers
     - dupword        # duplicate words in comments
+    # Modern Go idioms (Go 1.21+)
+    - modernize      # use modern Go idioms (any, slices.Contains, etc.)
+    - perfsprint     # faster alternatives to fmt.Sprintf/Errorf
+    - exhaustive     # check exhaustiveness of enum switch statements
+    - intrange       # use Go 1.22 range-over-integers
+    - copyloopvar    # detect issues with loop variable copying
   settings:
     gocritic:
       enabled-tags:

--- a/cmd/preflight/cmd_json.go
+++ b/cmd/preflight/cmd_json.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/spf13/cobra"
 
@@ -35,7 +35,7 @@ func runJSONCheck(_ *cobra.Command, args []string) error {
 
 	// Validate flag combinations
 	if (jsonExact != "" || jsonMatch != "") && jsonKey == "" {
-		return fmt.Errorf("--exact and --match require --key to be set")
+		return errors.New("--exact and --match require --key to be set")
 	}
 
 	c := &jsoncheck.Check{

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -39,10 +40,8 @@ func transformArgsForHashbang(args []string, checkFile fileChecker) (newArgs []s
 	}
 
 	// Skip if it's a known subcommand
-	for _, subcmd := range knownSubcommands {
-		if firstArg == subcmd {
-			return args, ""
-		}
+	if slices.Contains(knownSubcommands, firstArg) {
+		return args, ""
 	}
 
 	// Check if it's a file - if so, treat as hashbang invocation

--- a/integration_test.go
+++ b/integration_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -148,13 +149,7 @@ func TestIntegration_FileSocket(t *testing.T) {
 	}
 
 	// Verify we see the socket type in details
-	foundSocketType := false
-	for _, detail := range result.Details {
-		if detail == "type: socket" {
-			foundSocketType = true
-			break
-		}
-	}
+	foundSocketType := slices.Contains(result.Details, "type: socket")
 	if !foundSocketType {
 		t.Errorf("Details = %v, want to contain 'type: socket'", result.Details)
 	}
@@ -214,13 +209,7 @@ func TestIntegration_FileSymlink(t *testing.T) {
 	}
 
 	// Verify we see the symlink type in details
-	foundSymlinkType := false
-	for _, detail := range result.Details {
-		if detail == "type: symlink" {
-			foundSymlinkType = true
-			break
-		}
-	}
+	foundSymlinkType := slices.Contains(result.Details, "type: symlink")
 	if !foundSymlinkType {
 		t.Errorf("Details = %v, want to contain 'type: symlink'", result.Details)
 	}

--- a/pkg/check/helpers.go
+++ b/pkg/check/helpers.go
@@ -14,7 +14,7 @@ func (r *Result) Fail(detail string, err error) Result {
 }
 
 // Failf sets the result to failed status with a formatted detail message.
-func (r *Result) Failf(format string, args ...interface{}) Result {
+func (r *Result) Failf(format string, args ...any) Result {
 	return r.Fail(fmt.Sprintf(format, args...), fmt.Errorf(format, args...))
 }
 
@@ -25,7 +25,7 @@ func (r *Result) AddDetail(detail string) *Result {
 }
 
 // AddDetailf appends a formatted detail line to the result.
-func (r *Result) AddDetailf(format string, args ...interface{}) *Result {
+func (r *Result) AddDetailf(format string, args ...any) *Result {
 	return r.AddDetail(fmt.Sprintf(format, args...))
 }
 

--- a/pkg/cmdcheck/check.go
+++ b/pkg/cmdcheck/check.go
@@ -28,7 +28,7 @@ type Check struct {
 // Run executes the command check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("cmd: %s", c.Name),
+		Name: "cmd: " + c.Name,
 	}
 
 	path, err := c.Runner.LookPath(c.Name)

--- a/pkg/envcheck/check_test.go
+++ b/pkg/envcheck/check_test.go
@@ -3,6 +3,7 @@ package envcheck
 import (
 	"errors"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ func (m *mockFileInfo) Size() int64        { return 0 }
 func (m *mockFileInfo) Mode() os.FileMode  { return 0 }
 func (m *mockFileInfo) ModTime() time.Time { return time.Time{} }
 func (m *mockFileInfo) IsDir() bool        { return m.isDir }
-func (m *mockFileInfo) Sys() interface{}   { return nil }
+func (m *mockFileInfo) Sys() any           { return nil }
 
 // mockFileStater mocks file system stat operations.
 type mockFileStater struct {
@@ -724,13 +725,7 @@ func TestEnvCheck_Run(t *testing.T) {
 			}
 
 			if tt.wantDetail != "" {
-				found := false
-				for _, d := range result.Details {
-					if d == tt.wantDetail {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(result.Details, tt.wantDetail)
 				if !found {
 					t.Errorf("expected detail %q not found in %v", tt.wantDetail, result.Details)
 				}

--- a/pkg/filecheck/check.go
+++ b/pkg/filecheck/check.go
@@ -1,6 +1,7 @@
 package filecheck
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -33,7 +34,7 @@ type Check struct {
 // Run executes the file check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("file: %s", c.Path),
+		Name: "file: " + c.Path,
 	}
 
 	// Use Lstat for symlink checks (doesn't follow symlinks), Stat otherwise
@@ -87,14 +88,14 @@ func (c *Check) Run() check.Result {
 	// --writable
 	if c.Writable {
 		if !isWritable(info.Mode()) {
-			return result.Fail("not writable", fmt.Errorf("file is not writable"))
+			return result.Fail("not writable", errors.New("file is not writable"))
 		}
 	}
 
 	// --executable
 	if c.Executable {
 		if !isExecutable(info.Mode()) {
-			return result.Fail("not executable", fmt.Errorf("file is not executable"))
+			return result.Fail("not executable", errors.New("file is not executable"))
 		}
 	}
 
@@ -154,7 +155,7 @@ func (c *Check) checkTypeConstraint(info fs.FileInfo, result *check.Result) erro
 
 	if c.ExpectSymlink {
 		if !isSymlink(mode) {
-			err := fmt.Errorf("expected symlink, got file/directory")
+			err := errors.New("expected symlink, got file/directory")
 			result.Fail("expected symlink, got file/directory", err)
 			return err
 		}
@@ -168,7 +169,7 @@ func (c *Check) checkTypeConstraint(info fs.FileInfo, result *check.Result) erro
 
 	if c.ExpectSocket {
 		if !isSocket(mode) {
-			err := fmt.Errorf("expected socket, got file/directory")
+			err := errors.New("expected socket, got file/directory")
 			result.Fail("expected socket, got file/directory", err)
 			return err
 		}
@@ -178,7 +179,7 @@ func (c *Check) checkTypeConstraint(info fs.FileInfo, result *check.Result) erro
 
 	if c.ExpectDir {
 		if !info.IsDir() {
-			err := fmt.Errorf("expected directory, got file")
+			err := errors.New("expected directory, got file")
 			result.Fail("expected directory, got file", err)
 			return err
 		}
@@ -203,7 +204,7 @@ func (c *Check) checkSizeConstraints(info fs.FileInfo, result *check.Result) err
 
 	// --not-empty
 	if c.NotEmpty && info.Size() == 0 {
-		err := fmt.Errorf("file is empty")
+		err := errors.New("file is empty")
 		result.Fail("file is empty", err)
 		return err
 	}

--- a/pkg/filecheck/check_test.go
+++ b/pkg/filecheck/check_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io/fs"
 	"os"
+	"slices"
 	"testing"
 	"time"
 
@@ -59,7 +60,7 @@ func (m *mockFileInfo) Name() string       { return m.NameValue }
 func (m *mockFileInfo) Size() int64        { return m.SizeValue }
 func (m *mockFileInfo) Mode() fs.FileMode  { return m.ModeValue }
 func (m *mockFileInfo) IsDir() bool        { return m.IsDirValue }
-func (m *mockFileInfo) Sys() interface{}   { return nil }
+func (m *mockFileInfo) Sys() any           { return nil }
 func (m *mockFileInfo) ModTime() time.Time { return time.Unix(m.ModTimeValue, 0) }
 
 func TestCheck_Run(t *testing.T) {
@@ -854,13 +855,7 @@ func TestCheck_Run(t *testing.T) {
 			}
 
 			if tt.wantDetail != "" {
-				found := false
-				for _, d := range result.Details {
-					if d == tt.wantDetail {
-						found = true
-						break
-					}
-				}
+				found := slices.Contains(result.Details, tt.wantDetail)
 				if !found {
 					t.Errorf("expected detail %q not found in %v", tt.wantDetail, result.Details)
 				}

--- a/pkg/gitcheck/check.go
+++ b/pkg/gitcheck/check.go
@@ -1,7 +1,7 @@
 package gitcheck
 
 import (
-	"fmt"
+	"errors"
 	"path"
 	"strings"
 
@@ -99,7 +99,7 @@ func (c *Check) checkStatus(noUncommitted, noUntracked bool, result *check.Resul
 			result.AddDetailf("  %s", f)
 		}
 		result.Failf("found %d uncommitted file(s)", len(uncommitted))
-		return fmt.Errorf("uncommitted files")
+		return errors.New("uncommitted files")
 	}
 
 	if noUntracked && len(untracked) > 0 {
@@ -108,7 +108,7 @@ func (c *Check) checkStatus(noUncommitted, noUntracked bool, result *check.Resul
 			result.AddDetailf("  %s", f)
 		}
 		result.Failf("found %d untracked file(s)", len(untracked))
-		return fmt.Errorf("untracked files")
+		return errors.New("untracked files")
 	}
 
 	result.AddDetail("working directory clean")
@@ -126,7 +126,7 @@ func (c *Check) checkBranch(result *check.Result) error {
 
 	if branch != c.Branch {
 		result.Failf("on branch %q, expected %q", branch, c.Branch)
-		return fmt.Errorf("wrong branch")
+		return errors.New("wrong branch")
 	}
 
 	return nil
@@ -141,7 +141,7 @@ func (c *Check) checkTagMatch(result *check.Result) error {
 
 	if len(tags) == 0 {
 		result.Failf("no tags at HEAD, expected match for %q", c.TagMatch)
-		return fmt.Errorf("no tags")
+		return errors.New("no tags")
 	}
 
 	// Check if any tag matches the glob pattern
@@ -159,5 +159,5 @@ func (c *Check) checkTagMatch(result *check.Result) error {
 
 	result.AddDetailf("tags at HEAD: %s", strings.Join(tags, ", "))
 	result.Failf("no tag matches pattern %q", c.TagMatch)
-	return fmt.Errorf("no matching tag")
+	return errors.New("no matching tag")
 }

--- a/pkg/httpcheck/check.go
+++ b/pkg/httpcheck/check.go
@@ -85,7 +85,7 @@ type Check struct {
 // Run executes the HTTP health check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("http: %s", c.URL),
+		Name: "http: " + c.URL,
 	}
 
 	// Validate URL

--- a/pkg/jsoncheck/check.go
+++ b/pkg/jsoncheck/check.go
@@ -1,7 +1,7 @@
 package jsoncheck
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/tidwall/gjson"
 
@@ -21,7 +21,7 @@ type Check struct {
 // Run executes the JSON check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("json: %s", c.File),
+		Name: "json: " + c.File,
 	}
 
 	// Read file
@@ -33,7 +33,7 @@ func (c *Check) Run() check.Result {
 	// Validate JSON syntax
 	jsonStr := string(content)
 	if !gjson.Valid(jsonStr) {
-		return result.Fail("invalid JSON", fmt.Errorf("invalid JSON syntax"))
+		return result.Fail("invalid JSON", errors.New("invalid JSON syntax"))
 	}
 
 	result.AddDetail("syntax: valid")

--- a/pkg/preflightfile/preflightfile.go
+++ b/pkg/preflightfile/preflightfile.go
@@ -1,6 +1,7 @@
 package preflightfile
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -48,7 +49,7 @@ func FindFile(startDir, explicitPath string) (string, error) {
 		currentDir = parentDir
 	}
 
-	return "", fmt.Errorf(".preflight file not found")
+	return "", errors.New(".preflight file not found")
 }
 
 func ParseFile(path string) ([]string, error) {

--- a/pkg/resourcecheck/size.go
+++ b/pkg/resourcecheck/size.go
@@ -1,6 +1,7 @@
 package resourcecheck
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -21,7 +22,7 @@ const (
 func ParseSize(s string) (uint64, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return 0, fmt.Errorf("empty size string")
+		return 0, errors.New("empty size string")
 	}
 
 	// Match number (with optional decimal) and optional unit

--- a/pkg/syscheck/check.go
+++ b/pkg/syscheck/check.go
@@ -56,13 +56,13 @@ func (c *Check) Run() check.Result {
 	result.AddDetailf("arch: %s", actualArch)
 
 	if c.ExpectedOS != "" {
-		result.Name = fmt.Sprintf("sys: os=%s", c.ExpectedOS)
+		result.Name = "sys: os=" + c.ExpectedOS
 	}
 	if c.ExpectedArch != "" {
 		if c.ExpectedOS != "" {
 			result.Name = fmt.Sprintf("sys: os=%s arch=%s", c.ExpectedOS, c.ExpectedArch)
 		} else {
-			result.Name = fmt.Sprintf("sys: arch=%s", c.ExpectedArch)
+			result.Name = "sys: arch=" + c.ExpectedArch
 		}
 	}
 

--- a/pkg/tcpcheck/check.go
+++ b/pkg/tcpcheck/check.go
@@ -1,7 +1,6 @@
 package tcpcheck
 
 import (
-	"fmt"
 	"net"
 	"time"
 
@@ -31,7 +30,7 @@ type Check struct {
 // Run executes the TCP connectivity check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("tcp: %s", c.Address),
+		Name: "tcp: " + c.Address,
 	}
 
 	timeout := c.Timeout

--- a/pkg/usercheck/check.go
+++ b/pkg/usercheck/check.go
@@ -32,7 +32,7 @@ type Check struct {
 // Run executes the user check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
-		Name: fmt.Sprintf("user: %s", c.Username),
+		Name: "user: " + c.Username,
 	}
 
 	u, err := c.Lookup.Lookup(c.Username)

--- a/pkg/version/parse.go
+++ b/pkg/version/parse.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -26,7 +27,7 @@ var versionRegex = regexp.MustCompile(`v?(\d+)(?:\.(\d+))?(?:\.(\d+))?`)
 func Parse(s string) (Version, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return Version{}, fmt.Errorf("empty version string")
+		return Version{}, errors.New("empty version string")
 	}
 
 	matches := versionRegex.FindStringSubmatch(s)


### PR DESCRIPTION
## Summary
- Enable new linters: modernize, perfsprint, exhaustive, intrange, copyloopvar
- Apply auto-fixes for modern Go idioms
- Fix exhaustive switch issues in hashcheck (explicit cases)

## Changes
| Linter | What it does |
|--------|--------------|
| modernize | Use modern Go idioms (`any`, `slices.Contains`) |
| perfsprint | Faster alternatives to `fmt.Sprintf`/`Errorf` |
| exhaustive | Check exhaustiveness of enum switch statements |
| intrange | Use Go 1.22 range-over-integers |
| copyloopvar | Detect issues with loop variable copying |

### Code improvements
- `interface{}` → `any` (Go 1.18+)
- Manual loops → `slices.Contains` (Go 1.21+)
- `fmt.Errorf("static")` → `errors.New()` (faster, no allocations)
- `fmt.Sprintf("prefix: %s", s)` → string concatenation (faster)
- Added explicit switch cases in hashcheck for exhaustiveness

20 files changed, net -8 lines (cleaner and slightly faster).