### PR TITLE
Add recvcheck and nilnil linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,9 @@ linters:
     - exhaustive     # check exhaustiveness of enum switch statements
     - intrange       # use Go 1.22 range-over-integers
     - copyloopvar    # detect issues with loop variable copying
+    # Consistency
+    - recvcheck      # check receiver type consistency
+    - nilnil         # check for nil,nil returns (excluding intentional cases)
   settings:
     gocritic:
       enabled-tags:

--- a/pkg/check/helpers.go
+++ b/pkg/check/helpers.go
@@ -33,7 +33,7 @@ func (r *Result) AddDetailf(format string, args ...any) *Result {
 // This provides a consistent pattern for optional regex compilation across check packages.
 func CompileRegex(pattern string) (*regexp.Regexp, error) {
 	if pattern == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional: empty pattern means "no regex"
 	}
 	return regexp.Compile(pattern)
 }

--- a/pkg/check/result.go
+++ b/pkg/check/result.go
@@ -17,6 +17,6 @@ type Result struct {
 }
 
 // OK returns true if the check passed.
-func (r Result) OK() bool {
+func (r *Result) OK() bool {
 	return r.Status == StatusOK
 }

--- a/pkg/version/parse.go
+++ b/pkg/version/parse.go
@@ -47,7 +47,7 @@ func Parse(s string) (Version, error) {
 func ParseOptional(s string) (*Version, error) {
 	s = strings.TrimSpace(s)
 	if s == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil // intentional: empty string means "no version constraint"
 	}
 	v, err := Parse(s)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Enable `recvcheck` linter to ensure receiver type consistency
- Enable `nilnil` linter to detect accidental nil,nil returns

## Changes
- Fix `Result.OK()` to use pointer receiver (consistency with `Fail`/`AddDetail`)
- Add `//nolint:nilnil` for intentional cases where empty optional params return nil,nil

4 files changed, +6/-3 lines.