### PR TITLE
Improve error messages to show actual values

### DIFF
--- a/pkg/envcheck/check.go
+++ b/pkg/envcheck/check.go
@@ -76,13 +76,13 @@ func (c *Check) Run() check.Result {
 			return result.Failf("invalid regex pattern: %v", err)
 		}
 		if !re.MatchString(value) {
-			return result.Failf("value does not match pattern %q", c.Match)
+			return result.Failf("%q does not match pattern %q", c.formatValue(value), c.Match)
 		}
 	}
 
 	// --exact: exact value match
 	if c.Exact != "" && value != c.Exact {
-		return result.Failf("value does not equal %q", c.Exact)
+		return result.Failf("%q does not equal %q", c.formatValue(value), c.Exact)
 	}
 
 	// --one-of: value must be one of the allowed values
@@ -94,23 +94,23 @@ func (c *Check) Run() check.Result {
 
 	// --starts-with: value must start with prefix
 	if c.StartsWith != "" && !strings.HasPrefix(value, c.StartsWith) {
-		return result.Failf("value does not start with %q", c.StartsWith)
+		return result.Failf("%q does not start with %q", c.formatValue(value), c.StartsWith)
 	}
 
 	// --ends-with: value must end with suffix
 	if c.EndsWith != "" && !strings.HasSuffix(value, c.EndsWith) {
-		return result.Failf("value does not end with %q", c.EndsWith)
+		return result.Failf("%q does not end with %q", c.formatValue(value), c.EndsWith)
 	}
 
 	// --contains: value must contain substring
 	if c.Contains != "" && !strings.Contains(value, c.Contains) {
-		return result.Failf("value does not contain %q", c.Contains)
+		return result.Failf("%q does not contain %q", c.formatValue(value), c.Contains)
 	}
 
 	// --is-numeric: value must be a valid number
 	if c.IsNumeric {
 		if _, err := strconv.ParseFloat(value, 64); err != nil {
-			return result.Fail("value is not numeric", errors.New("value is not numeric"))
+			return result.Failf("%q is not numeric", c.formatValue(value))
 		}
 	}
 
@@ -133,7 +133,7 @@ func (c *Check) Run() check.Result {
 	// --is-json: value must be valid JSON
 	if c.IsJSON {
 		if !gjson.Valid(value) {
-			return result.Fail("value is not valid JSON", errors.New("invalid JSON"))
+			return result.Failf("%q is not valid JSON", c.formatValue(value))
 		}
 	}
 

--- a/pkg/envcheck/check_test.go
+++ b/pkg/envcheck/check_test.go
@@ -122,7 +122,7 @@ func TestEnvCheck_Run(t *testing.T) {
 				Getter: &mockEnvGetter{Vars: map[string]string{"DATABASE_URL": "mysql://localhost:3306/db"}},
 			},
 			wantStatus: check.StatusFail,
-			wantDetail: `value does not match pattern "^postgres://"`,
+			wantDetail: `"mysql://localhost:3306/db" does not match pattern "^postgres://"`,
 		},
 
 		// --exact flag tests
@@ -143,7 +143,7 @@ func TestEnvCheck_Run(t *testing.T) {
 				Getter: &mockEnvGetter{Vars: map[string]string{"NODE_ENV": "development"}},
 			},
 			wantStatus: check.StatusFail,
-			wantDetail: `value does not equal "production"`,
+			wantDetail: `"development" does not equal "production"`,
 		},
 
 		// --one-of flag tests
@@ -230,7 +230,7 @@ func TestEnvCheck_Run(t *testing.T) {
 				Getter:     &mockEnvGetter{Vars: map[string]string{"PATH": "/opt/bin"}},
 			},
 			wantStatus: check.StatusFail,
-			wantDetail: `value does not start with "/usr"`,
+			wantDetail: `"/opt/bin" does not start with "/usr"`,
 		},
 
 		// --ends-with flag tests
@@ -251,7 +251,7 @@ func TestEnvCheck_Run(t *testing.T) {
 				Getter:   &mockEnvGetter{Vars: map[string]string{"CONFIG": "/app/config.json"}},
 			},
 			wantStatus: check.StatusFail,
-			wantDetail: `value does not end with ".yaml"`,
+			wantDetail: `"/app/config.json" does not end with ".yaml"`,
 		},
 
 		// --contains flag tests
@@ -272,7 +272,7 @@ func TestEnvCheck_Run(t *testing.T) {
 				Getter:   &mockEnvGetter{Vars: map[string]string{"URL": "https://other.com/api"}},
 			},
 			wantStatus: check.StatusFail,
-			wantDetail: `value does not contain "example"`,
+			wantDetail: `"https://other.com/api" does not contain "example"`,
 		},
 
 		// --is-numeric flag tests
@@ -302,7 +302,7 @@ func TestEnvCheck_Run(t *testing.T) {
 				Getter:    &mockEnvGetter{Vars: map[string]string{"PORT": "not-a-number"}},
 			},
 			wantStatus: check.StatusFail,
-			wantDetail: "value is not numeric",
+			wantDetail: `"not-a-number" is not numeric`,
 		},
 
 		// --min-len flag tests
@@ -505,7 +505,7 @@ func TestEnvCheck_Run(t *testing.T) {
 				Getter: &mockEnvGetter{Vars: map[string]string{"BAD": `{key: value}`}},
 			},
 			wantStatus: check.StatusFail,
-			wantDetail: "value is not valid JSON",
+			wantDetail: `"{key: value}" is not valid JSON`,
 		},
 
 		// --is-bool flag tests

--- a/pkg/jsoncheck/check.go
+++ b/pkg/jsoncheck/check.go
@@ -1,7 +1,7 @@
 package jsoncheck
 
 import (
-	"errors"
+	"encoding/json"
 
 	"github.com/tidwall/gjson"
 
@@ -30,10 +30,16 @@ func (c *Check) Run() check.Result {
 		return result.Failf("failed to read file: %v", err)
 	}
 
-	// Validate JSON syntax
+	// Validate JSON syntax using encoding/json for detailed errors
 	jsonStr := string(content)
 	if !gjson.Valid(jsonStr) {
-		return result.Fail("invalid JSON", errors.New("invalid JSON syntax"))
+		// Use encoding/json to get detailed parse error
+		var v any
+		if err := json.Unmarshal(content, &v); err != nil {
+			return result.Failf("invalid JSON: %v", err)
+		}
+		// Fallback if gjson says invalid but encoding/json passes (shouldn't happen)
+		return result.Failf("invalid JSON")
 	}
 
 	result.AddDetail("syntax: valid")


### PR DESCRIPTION
## Summary

Error messages now show what value caused the failure, making debugging much easier.

**Before:**
```
[FAIL] env: HOME
       value does not match pattern "^/nonexistent"
```

**After:**
```
[FAIL] env: HOME
       "/Users/vertti" does not match pattern "^/nonexistent"
```

### Changes

**envcheck** (7 messages improved):
- `"value does not match"` → `"/Users/x" does not match pattern "^/app"`
- `"value does not equal"` → `"dev" does not equal "prod"`
- `"value does not start with"` → `"/tmp" does not start with "/app"`
- `"value does not end with"` → `"config.yaml" does not end with ".json"`
- `"value does not contain"` → `"hello" does not contain "world"`
- `"value is not numeric"` → `"abc" is not numeric`
- `"value is not valid JSON"` → `"{bad" is not valid JSON`

**jsoncheck** (1 message improved):
- `"invalid JSON"` → `"invalid JSON: unexpected character 'k' at position 2"`

Respects `--hide-value` and `--mask-value` for sensitive values.