### PR TITLE
Color error detail lines red

### DIFF
--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -36,12 +36,15 @@ func PrintResult(r check.Result) {
 	if r.OK() {
 		fmt.Printf("%s[OK]%s %s\n", green, reset, formatLabel(r.Name))
 		indent = "     " // align with content after "[OK] "
+		for _, d := range r.Details {
+			fmt.Printf("%s%s\n", indent, formatLabel(d))
+		}
 	} else {
 		fmt.Printf("%s[FAIL]%s %s\n", red, reset, formatLabel(r.Name))
 		indent = "       " // align with content after "[FAIL] "
-	}
-	for _, d := range r.Details {
-		fmt.Printf("%s%s\n", indent, formatLabel(d))
+		for _, d := range r.Details {
+			fmt.Printf("%s%s%s%s\n", indent, red, d, reset)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Make failure detail lines red, not just the `[FAIL]` tag.

**Before:**
```
[FAIL] env: HOME           ← red
       "/Users/x" does not match pattern "^/app"  ← default color
```

**After:**
```
[FAIL] env: HOME           ← red
       "/Users/x" does not match pattern "^/app"  ← also red
```

Makes failures pop more in long output. Success details remain default color.