### PR TITLE
Add prometheus check command

### DIFF
--- a/cmd/preflight/cmd_prometheus.go
+++ b/cmd/preflight/cmd_prometheus.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -62,7 +61,7 @@ func runPrometheusCheck(cmd *cobra.Command, args []string) error {
 	promMaxSet = cmd.Flags().Changed("max")
 	promExactSet = cmd.Flags().Changed("exact")
 
-	headers := parsePrometheusHeaders(promHeaders)
+	headers := parseHeaders(promHeaders)
 
 	c := &promcheck.Check{
 		URL:        url,
@@ -87,16 +86,4 @@ func runPrometheusCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	return runCheck(c)
-}
-
-// parsePrometheusHeaders converts ["key:value", ...] to map[string]string
-func parsePrometheusHeaders(headers []string) map[string]string {
-	result := make(map[string]string)
-	for _, h := range headers {
-		parts := strings.SplitN(h, ":", 2)
-		if len(parts) == 2 {
-			result[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
-		}
-	}
-	return result
 }

--- a/cmd/preflight/cmd_prometheus.go
+++ b/cmd/preflight/cmd_prometheus.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/vertti/preflight/pkg/promcheck"
+)
+
+var (
+	promQuery      string
+	promMin        float64
+	promMax        float64
+	promExact      float64
+	promMinSet     bool
+	promMaxSet     bool
+	promExactSet   bool
+	promTimeout    time.Duration
+	promRetry      int
+	promRetryDelay time.Duration
+	promInsecure   bool
+	promHeaders    []string
+)
+
+var prometheusCmd = &cobra.Command{
+	Use:   "prometheus <url>",
+	Short: "Check Prometheus metric value",
+	Long: `Query a Prometheus server and validate metric values against thresholds.
+
+Examples:
+  preflight prometheus http://prometheus:9090 --query 'up{job="myapp"}' --exact 1
+  preflight prometheus http://prometheus:9090 --query 'error_rate' --max 0.05
+  preflight prometheus http://prometheus:9090 --query 'request_count' --min 100`,
+	Args: cobra.ExactArgs(1),
+	RunE: runPrometheusCheck,
+}
+
+func init() {
+	prometheusCmd.Flags().StringVar(&promQuery, "query", "", "PromQL query (required)")
+	_ = prometheusCmd.MarkFlagRequired("query")
+
+	prometheusCmd.Flags().Float64Var(&promMin, "min", 0, "minimum value (fail if below)")
+	prometheusCmd.Flags().Float64Var(&promMax, "max", 0, "maximum value (fail if above)")
+	prometheusCmd.Flags().Float64Var(&promExact, "exact", 0, "exact value match")
+
+	prometheusCmd.Flags().DurationVar(&promTimeout, "timeout", 5*time.Second, "request timeout")
+	prometheusCmd.Flags().IntVar(&promRetry, "retry", 0, "retry count on failure")
+	prometheusCmd.Flags().DurationVar(&promRetryDelay, "retry-delay", 1*time.Second, "delay between retries")
+	prometheusCmd.Flags().BoolVar(&promInsecure, "insecure", false, "skip TLS certificate verification")
+	prometheusCmd.Flags().StringSliceVar(&promHeaders, "header", nil, "custom header (key:value), can be repeated")
+
+	rootCmd.AddCommand(prometheusCmd)
+}
+
+func runPrometheusCheck(cmd *cobra.Command, args []string) error {
+	url := args[0]
+
+	// Track which flags were explicitly set
+	promMinSet = cmd.Flags().Changed("min")
+	promMaxSet = cmd.Flags().Changed("max")
+	promExactSet = cmd.Flags().Changed("exact")
+
+	headers := parsePrometheusHeaders(promHeaders)
+
+	c := &promcheck.Check{
+		URL:        url,
+		Query:      promQuery,
+		Timeout:    promTimeout,
+		Retry:      promRetry,
+		RetryDelay: promRetryDelay,
+		Insecure:   promInsecure,
+		Headers:    headers,
+		Client:     &promcheck.RealHTTPClient{Timeout: promTimeout, Insecure: promInsecure},
+	}
+
+	// Only set threshold pointers if flags were explicitly provided
+	if promMinSet {
+		c.Min = &promMin
+	}
+	if promMaxSet {
+		c.Max = &promMax
+	}
+	if promExactSet {
+		c.Exact = &promExact
+	}
+
+	return runCheck(c)
+}
+
+// parsePrometheusHeaders converts ["key:value", ...] to map[string]string
+func parsePrometheusHeaders(headers []string) map[string]string {
+	result := make(map[string]string)
+	for _, h := range headers {
+		parts := strings.SplitN(h, ":", 2)
+		if len(parts) == 2 {
+			result[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		}
+	}
+	return result
+}

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -12,7 +12,7 @@ import (
 var Version = "dev"
 
 // knownSubcommands lists all valid preflight subcommands
-var knownSubcommands = []string{"cmd", "env", "file", "git", "hash", "http", "resource", "sys", "tcp", "user", "run", "version", "help", "--help", "-h"}
+var knownSubcommands = []string{"cmd", "env", "file", "git", "hash", "http", "json", "prometheus", "resource", "sys", "tcp", "user", "run", "version", "help", "--help", "-h"}
 
 // fileChecker abstracts file existence checks for testing
 type fileChecker func(path string) (isFile bool)

--- a/pkg/promcheck/check.go
+++ b/pkg/promcheck/check.go
@@ -1,0 +1,251 @@
+package promcheck
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/tidwall/gjson"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+// HTTPClient abstracts HTTP requests for testability.
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// RealHTTPClient uses the real net/http package.
+type RealHTTPClient struct {
+	Timeout  time.Duration
+	Insecure bool
+}
+
+// Do executes an HTTP request.
+func (c *RealHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	transport := &http.Transport{}
+	if c.Insecure {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // intentional for --insecure flag
+	}
+
+	client := &http.Client{
+		Timeout:   c.Timeout,
+		Transport: transport,
+	}
+
+	return client.Do(req)
+}
+
+// Check queries Prometheus and validates metric values.
+type Check struct {
+	URL        string            // Prometheus server URL (required)
+	Query      string            // PromQL query (required)
+	Min        *float64          // minimum value (fail if below)
+	Max        *float64          // maximum value (fail if above)
+	Exact      *float64          // exact value match
+	Timeout    time.Duration     // request timeout (default: 5s)
+	Retry      int               // retry count on failure
+	RetryDelay time.Duration     // delay between retries (default: 1s)
+	Insecure   bool              // skip TLS verification
+	Headers    map[string]string // custom headers (for auth)
+	Client     HTTPClient        // injected for testing
+}
+
+// Run executes the Prometheus query check.
+func (c *Check) Run() check.Result {
+	result := check.Result{
+		Name: "prometheus: " + c.URL,
+	}
+
+	// Validate required fields
+	if c.URL == "" {
+		return result.Failf("URL is required")
+	}
+	if c.Query == "" {
+		return result.Failf("query is required")
+	}
+
+	// Validate URL
+	parsedURL, err := url.Parse(c.URL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return result.Failf("invalid URL: %s", c.URL)
+	}
+
+	// Set defaults
+	timeout := c.Timeout
+	if timeout == 0 {
+		timeout = 5 * time.Second
+	}
+	retryDelay := c.RetryDelay
+	if retryDelay == 0 {
+		retryDelay = 1 * time.Second
+	}
+
+	// Initialize client if not injected
+	client := c.Client
+	if client == nil {
+		client = &RealHTTPClient{Timeout: timeout, Insecure: c.Insecure}
+	}
+
+	// Build query URL
+	queryURL := fmt.Sprintf("%s/api/v1/query?query=%s", c.URL, url.QueryEscape(c.Query))
+
+	// Retry loop
+	maxAttempts := c.Retry + 1
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		req, err := http.NewRequest("GET", queryURL, http.NoBody)
+		if err != nil {
+			return result.Failf("failed to create request: %v", err)
+		}
+
+		// Add custom headers
+		for k, v := range c.Headers {
+			req.Header.Set(k, v)
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			if attempt < maxAttempts {
+				time.Sleep(retryDelay)
+				continue
+			}
+			if maxAttempts > 1 {
+				return result.Failf("request failed after %d attempts: %v", maxAttempts, err)
+			}
+			return result.Failf("request failed: %v", err)
+		}
+
+		// Read response body
+		bodyBytes := make([]byte, 0, 4096)
+		buf := make([]byte, 4096)
+		for {
+			n, err := resp.Body.Read(buf)
+			if n > 0 {
+				bodyBytes = append(bodyBytes, buf[:n]...)
+			}
+			if err != nil {
+				break
+			}
+		}
+		_ = resp.Body.Close()
+		respBody := string(bodyBytes)
+
+		// Check HTTP status
+		if resp.StatusCode != 200 {
+			lastErr = fmt.Errorf("prometheus returned status %d", resp.StatusCode)
+			if attempt < maxAttempts {
+				time.Sleep(retryDelay)
+				continue
+			}
+			if maxAttempts > 1 {
+				return result.Failf("prometheus returned status %d (after %d attempts)", resp.StatusCode, maxAttempts)
+			}
+			return result.Failf("prometheus returned status %d", resp.StatusCode)
+		}
+
+		// Parse Prometheus response
+		status := gjson.Get(respBody, "status").String()
+		if status != "success" {
+			errorMsg := gjson.Get(respBody, "error").String()
+			if errorMsg != "" {
+				return result.Failf("prometheus error: %s", errorMsg)
+			}
+			return result.Failf("prometheus returned status %q", status)
+		}
+
+		// Get result type and extract value
+		resultType := gjson.Get(respBody, "data.resultType").String()
+		var valueStr string
+		var metricLabels string
+
+		switch resultType {
+		case "vector":
+			results := gjson.Get(respBody, "data.result")
+			if !results.Exists() || len(results.Array()) == 0 {
+				lastErr = errors.New("query returned no data")
+				if attempt < maxAttempts {
+					time.Sleep(retryDelay)
+					continue
+				}
+				if maxAttempts > 1 {
+					return result.Failf("query %q returned no data (after %d attempts)", c.Query, maxAttempts)
+				}
+				return result.Failf("query %q returned no data", c.Query)
+			}
+			if len(results.Array()) > 1 {
+				return result.Failf("query returned %d results, expected 1 (use a more specific query)", len(results.Array()))
+			}
+			valueStr = gjson.Get(respBody, "data.result.0.value.1").String()
+			metricLabels = gjson.Get(respBody, "data.result.0.metric").String()
+		case "scalar":
+			valueStr = gjson.Get(respBody, "data.result.1").String()
+		default:
+			return result.Failf("unsupported result type: %s", resultType)
+		}
+
+		// Parse value as float64
+		value, err := strconv.ParseFloat(valueStr, 64)
+		if err != nil {
+			return result.Failf("failed to parse metric value %q as number", valueStr)
+		}
+
+		// Validate against thresholds
+		if c.Exact != nil && value != *c.Exact {
+			lastErr = fmt.Errorf("value %v does not equal %v", value, *c.Exact)
+			if attempt < maxAttempts {
+				time.Sleep(retryDelay)
+				continue
+			}
+			if maxAttempts > 1 {
+				return result.Failf("value %v does not equal %v (after %d attempts)", value, *c.Exact, maxAttempts)
+			}
+			return result.Failf("value %v does not equal %v", value, *c.Exact)
+		}
+
+		if c.Min != nil && value < *c.Min {
+			lastErr = fmt.Errorf("value %v < minimum %v", value, *c.Min)
+			if attempt < maxAttempts {
+				time.Sleep(retryDelay)
+				continue
+			}
+			if maxAttempts > 1 {
+				return result.Failf("value %v < minimum %v (after %d attempts)", value, *c.Min, maxAttempts)
+			}
+			return result.Failf("value %v < minimum %v", value, *c.Min)
+		}
+
+		if c.Max != nil && value > *c.Max {
+			lastErr = fmt.Errorf("value %v > maximum %v", value, *c.Max)
+			if attempt < maxAttempts {
+				time.Sleep(retryDelay)
+				continue
+			}
+			if maxAttempts > 1 {
+				return result.Failf("value %v > maximum %v (after %d attempts)", value, *c.Max, maxAttempts)
+			}
+			return result.Failf("value %v > maximum %v", value, *c.Max)
+		}
+
+		// Success
+		result.Status = check.StatusOK
+		result.AddDetailf("query: %s", c.Query)
+		if metricLabels != "" {
+			result.AddDetailf("metric: %s", metricLabels)
+		}
+		result.AddDetailf("value: %v", value)
+		if maxAttempts > 1 && attempt > 1 {
+			result.AddDetailf("succeeded on attempt %d of %d", attempt, maxAttempts)
+		}
+		return result
+	}
+
+	// Should not reach here, but handle edge case
+	return result.Failf("unexpected error: %v", lastErr)
+}

--- a/pkg/promcheck/check_test.go
+++ b/pkg/promcheck/check_test.go
@@ -1,0 +1,443 @@
+package promcheck
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/vertti/preflight/pkg/check"
+)
+
+// mockHTTPClient implements HTTPClient for testing.
+type mockHTTPClient struct {
+	DoFunc func(req *http.Request) (*http.Response, error)
+}
+
+func (m *mockHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return m.DoFunc(req)
+}
+
+// mockResponse creates a mock HTTP response with the given status code and body.
+func mockResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+// Sample Prometheus responses
+const (
+	promSuccessVector = `{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": [
+				{
+					"metric": {"__name__": "up", "job": "myapp"},
+					"value": [1702000000, "1"]
+				}
+			]
+		}
+	}`
+
+	promSuccessScalar = `{
+		"status": "success",
+		"data": {
+			"resultType": "scalar",
+			"result": [1702000000, "42.5"]
+		}
+	}`
+
+	promEmptyResult = `{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": []
+		}
+	}`
+
+	promMultipleResults = `{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": [
+				{"metric": {"job": "a"}, "value": [1702000000, "1"]},
+				{"metric": {"job": "b"}, "value": [1702000000, "2"]}
+			]
+		}
+	}`
+
+	promError = `{
+		"status": "error",
+		"errorType": "bad_data",
+		"error": "invalid expression"
+	}`
+
+	promValueFloat = `{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": [{"metric": {}, "value": [1702000000, "0.05"]}]
+		}
+	}`
+
+	promValueHigh = `{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": [{"metric": {}, "value": [1702000000, "100"]}]
+		}
+	}`
+
+	promValueLow = `{
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": [{"metric": {}, "value": [1702000000, "5"]}]
+		}
+	}`
+)
+
+func ptr(f float64) *float64 {
+	return &f
+}
+
+func TestPrometheusCheck(t *testing.T) {
+	tests := []struct {
+		name          string
+		check         Check
+		wantStatus    check.Status
+		wantName      string
+		wantDetailSub string // substring to find in details or error
+	}{
+		// --- Validation ---
+		{
+			name: "missing URL fails",
+			check: Check{
+				Query: "up",
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "URL is required",
+		},
+		{
+			name: "missing query fails",
+			check: Check{
+				URL: "http://prometheus:9090",
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "query is required",
+		},
+		{
+			name: "invalid URL fails",
+			check: Check{
+				URL:   "not-a-url",
+				Query: "up",
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "invalid URL",
+		},
+
+		// --- Successful Queries ---
+		{
+			name: "successful vector query",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "up{job=\"myapp\"}",
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promSuccessVector), nil
+					},
+				},
+			},
+			wantStatus:    check.StatusOK,
+			wantName:      "prometheus: http://prometheus:9090",
+			wantDetailSub: "value: 1",
+		},
+		{
+			name: "successful scalar query",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "42.5",
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promSuccessScalar), nil
+					},
+				},
+			},
+			wantStatus:    check.StatusOK,
+			wantDetailSub: "value: 42.5",
+		},
+		{
+			name: "query shown in details",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "error_rate",
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promSuccessVector), nil
+					},
+				},
+			},
+			wantStatus:    check.StatusOK,
+			wantDetailSub: "query: error_rate",
+		},
+
+		// --- Error Cases ---
+		{
+			name: "connection error",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "up",
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return nil, errors.New("connection refused")
+					},
+				},
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "connection refused",
+		},
+		{
+			name: "non-200 status",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "up",
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(500, ""), nil
+					},
+				},
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "prometheus returned status 500",
+		},
+		{
+			name: "prometheus error response",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "invalid(",
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promError), nil
+					},
+				},
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "invalid expression",
+		},
+		{
+			name: "empty result",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "nonexistent_metric",
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promEmptyResult), nil
+					},
+				},
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "returned no data",
+		},
+		{
+			name: "multiple results fails",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "up",
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promMultipleResults), nil
+					},
+				},
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "returned 2 results",
+		},
+
+		// --- Value Thresholds ---
+		{
+			name: "exact match passes",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "up",
+				Exact: ptr(1),
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promSuccessVector), nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "exact match fails",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "up",
+				Exact: ptr(0),
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promSuccessVector), nil
+					},
+				},
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "does not equal 0",
+		},
+		{
+			name: "min threshold passes",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "request_count",
+				Min:   ptr(50),
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promValueHigh), nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "min threshold fails",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "request_count",
+				Min:   ptr(50),
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promValueLow), nil
+					},
+				},
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "< minimum 50",
+		},
+		{
+			name: "max threshold passes",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "error_rate",
+				Max:   ptr(0.1),
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promValueFloat), nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+		{
+			name: "max threshold fails",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "error_rate",
+				Max:   ptr(0.01),
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						return mockResponse(200, promValueFloat), nil
+					},
+				},
+			},
+			wantStatus:    check.StatusFail,
+			wantDetailSub: "> maximum 0.01",
+		},
+
+		// --- Headers ---
+		{
+			name: "custom headers are sent",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "up",
+				Headers: map[string]string{
+					"Authorization": "Bearer token123",
+				},
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						if req.Header.Get("Authorization") != "Bearer token123" {
+							t.Error("Authorization header not set")
+						}
+						return mockResponse(200, promSuccessVector), nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+
+		// --- URL Construction ---
+		{
+			name: "query is URL encoded",
+			check: Check{
+				URL:   "http://prometheus:9090",
+				Query: "up{job=\"myapp\"}",
+				Client: &mockHTTPClient{
+					DoFunc: func(req *http.Request) (*http.Response, error) {
+						expectedQuery := "up%7Bjob%3D%22myapp%22%7D"
+						if !strings.Contains(req.URL.RawQuery, expectedQuery) {
+							t.Errorf("query not properly encoded: %s", req.URL.RawQuery)
+						}
+						return mockResponse(200, promSuccessVector), nil
+					},
+				},
+			},
+			wantStatus: check.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.check.Run()
+
+			if result.Status != tt.wantStatus {
+				t.Errorf("Status = %v, want %v (details: %v)", result.Status, tt.wantStatus, result.Details)
+			}
+
+			if tt.wantName != "" && result.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", result.Name, tt.wantName)
+			}
+
+			if tt.wantDetailSub != "" {
+				found := false
+				for _, d := range result.Details {
+					if strings.Contains(d, tt.wantDetailSub) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("Details %v should contain %q", result.Details, tt.wantDetailSub)
+				}
+			}
+		})
+	}
+}
+
+func TestPrometheusCheckRetry(t *testing.T) {
+	attempts := 0
+	c := Check{
+		URL:        "http://prometheus:9090",
+		Query:      "up",
+		Retry:      2,
+		RetryDelay: 1, // 1 nanosecond for fast tests
+		Client: &mockHTTPClient{
+			DoFunc: func(req *http.Request) (*http.Response, error) {
+				attempts++
+				if attempts < 3 {
+					return nil, errors.New("connection refused")
+				}
+				return mockResponse(200, promSuccessVector), nil
+			},
+		},
+	}
+
+	result := c.Run()
+
+	if result.Status != check.StatusOK {
+		t.Errorf("Status = %v, want OK", result.Status)
+	}
+	if attempts != 3 {
+		t.Errorf("attempts = %d, want 3", attempts)
+	}
+}


### PR DESCRIPTION
## Summary

Add `preflight prometheus` command to query Prometheus metrics and validate values against thresholds.

**Features:**
- `--query`: PromQL query (required)
- `--min/--max/--exact`: Value thresholds
- `--retry`: Retry on failure
- `--header`: Custom headers for auth

**Zero new dependencies** - uses existing HTTP client + gjson.

**Example:**
```sh
preflight prometheus http://prom:9090 --query 'up{job="myapp"}' --exact 1
preflight prometheus http://prom:9090 --query 'error_rate' --max 0.05
```

**Use cases:**
- Pre-deployment validation ("don't deploy if error rate is already high")
- CI health gates
- Kubernetes readiness checks via Prometheus