### PR TITLE
Add documentation for keeping containers clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Exit code `0` on success, `1` on failure. Works with `set -e`, Docker `RUN`, and
 COPY --from=ghcr.io/vertti/preflight:latest /preflight /usr/local/bin/preflight
 ```
 
+> Want to keep your final image lean? See [Keeping Containers Clean](docs/usage.md#keeping-containers-clean) for multi-stage builds and external validation.
+
 **Shell**:
 
 ```sh

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1265,6 +1265,8 @@ CMD ["myapp"]
 
 The container waits for dependencies and validates its environment before starting the main process.
 
+See [examples/runtime-checks-with-entrypoint](../examples/runtime-checks-with-entrypoint) for a complete example.
+
 ### Multi-stage Build (Zero Bloat)
 
 Use a dedicated validation stage that runs checks during build but doesn't ship preflight:
@@ -1290,6 +1292,8 @@ CMD ["myapp"]
 ```
 
 The validate stage runs during build—if any check fails, the build fails. But the final image only contains your app.
+
+See [examples/multistage-dockerfile](../examples/multistage-dockerfile) for a complete example.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1285,9 +1285,8 @@ COPY --from=build /app/myapp /usr/local/bin/myapp
 RUN preflight cmd myapp --min 2.0
 RUN preflight file /usr/local/bin/myapp --executable
 
-# Stage 3: Final (clean, no preflight)
-FROM alpine:3.19
-COPY --from=build /app/myapp /usr/local/bin/myapp
+# Stage 3: Final (continues from build, no preflight)
+FROM build AS final
 CMD ["myapp"]
 ```
 

--- a/examples/multistage-dockerfile/Dockerfile
+++ b/examples/multistage-dockerfile/Dockerfile
@@ -18,7 +18,6 @@ COPY --from=build /app/myapp /usr/local/bin/myapp
 RUN preflight cmd myapp --min 2.0
 RUN preflight file /usr/local/bin/myapp --executable
 
-# Stage 3: Final (clean, no preflight)
-FROM alpine:3.19
-COPY --from=build /app/myapp /usr/local/bin/myapp
+# Stage 3: Final (continues from build, no preflight)
+FROM build AS final
 CMD ["myapp"]

--- a/examples/multistage-dockerfile/Dockerfile
+++ b/examples/multistage-dockerfile/Dockerfile
@@ -1,0 +1,24 @@
+# Example: Multi-stage build with preflight validation
+#
+# The validate stage runs checks during build but doesn't ship preflight
+# in the final image. If any check fails, the build fails.
+#
+# Build: docker build -t myapp .
+
+# Stage 1: Build
+FROM golang:1.21 AS build
+WORKDIR /app
+COPY . .
+RUN go build -o myapp
+
+# Stage 2: Validate (runs checks, not included in final image)
+FROM alpine:3.19 AS validate
+COPY --from=ghcr.io/vertti/preflight:latest /preflight /usr/local/bin/preflight
+COPY --from=build /app/myapp /usr/local/bin/myapp
+RUN preflight cmd myapp --min 2.0
+RUN preflight file /usr/local/bin/myapp --executable
+
+# Stage 3: Final (clean, no preflight)
+FROM alpine:3.19
+COPY --from=build /app/myapp /usr/local/bin/myapp
+CMD ["myapp"]

--- a/examples/runtime-checks-with-entrypoint/Dockerfile
+++ b/examples/runtime-checks-with-entrypoint/Dockerfile
@@ -1,0 +1,22 @@
+# Example: Runtime checks with entrypoint script
+#
+# Preflight checks run at container startup before your app starts.
+# The container waits for dependencies (postgres) and validates its
+# environment before starting the main process.
+#
+# Build: docker build -t myapp .
+# Run:   docker run -e DATABASE_URL=postgres://... myapp
+
+FROM alpine:3.19
+
+COPY --from=ghcr.io/vertti/preflight:latest /preflight /usr/local/bin/preflight
+
+WORKDIR /app
+COPY entrypoint.sh /entrypoint.sh
+COPY myapp /usr/local/bin/myapp
+COPY config.yaml /app/config.yaml
+
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["myapp"]

--- a/examples/runtime-checks-with-entrypoint/entrypoint.sh
+++ b/examples/runtime-checks-with-entrypoint/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Example: Runtime checks before app starts
+#
+# This entrypoint script runs preflight checks at container startup,
+# waiting for dependencies and validating the environment before
+# starting the main process.
+
+set -e
+
+preflight tcp postgres:5432 --timeout 30s
+preflight env DATABASE_URL
+preflight file /app/config.yaml --not-empty
+
+exec "$@"


### PR DESCRIPTION
## Summary
- Add "Keeping Containers Clean" section to docs/usage.md with patterns for running preflight checks without adding bloat to final images
- Add brief note in README.md pointing to the new section

Covers three patterns:
- **External validation**: Run checks via `docker run myapp preflight run`
- **Entrypoint script**: Runtime checks before app starts
- **Multi-stage build**: Validate during build, ship clean final image