### PR TITLE
Add security scanning to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,18 @@ jobs:
             dist/preflight-windows-amd64.exe
           ls -lh dist/
 
+  security:
+    name: Security
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v3
+
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...
+
   container-test:
     name: Container Test
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,7 @@ linters:
     # Safety
     - bodyclose      # HTTP response body must be closed
     - forcetypeassert # type assertions must be checked
+    - gosec          # security issues (command injection, hardcoded creds, weak crypto)
     # Code quality
     - predeclared    # shadowing of predeclared identifiers
     - dupword        # duplicate words in comments

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test test-coverage lint fmt fmt-md check-md clean install-hooks
+.PHONY: all build test test-coverage lint fmt fmt-md check-md clean install-hooks security
 
 # Build the preflight binary
 build:
@@ -35,6 +35,10 @@ all: lint test build
 # Install pre-commit hooks
 install-hooks:
 	hk install --mise
+
+# Run security checks
+security:
+	govulncheck ./...
 
 # Clean build artifacts
 clean:

--- a/cmd/preflight/cmd_run.go
+++ b/cmd/preflight/cmd_run.go
@@ -57,7 +57,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 			parts[0] = executable
 		}
 
-		execCmd := exec.Command(parts[0], parts[1:]...)
+		execCmd := exec.Command(parts[0], parts[1:]...) //nolint:gosec // intentional: executing commands from .preflight file
 		execCmd.Stdout = os.Stdout
 		execCmd.Stderr = os.Stderr
 		execCmd.Stdin = os.Stdin

--- a/integration_test.go
+++ b/integration_test.go
@@ -590,7 +590,7 @@ func TestIntegration_ExamplesShellSyntax(t *testing.T) {
 
 	for _, script := range shellScripts {
 		t.Run(script, func(t *testing.T) {
-			cmd := exec.Command("sh", "-n", script)
+			cmd := exec.Command("sh", "-n", script) //nolint:gosec // intentional: validating shell syntax of example scripts
 			if err := cmd.Run(); err != nil {
 				t.Errorf("shell syntax error in %s: %v", script, err)
 			}

--- a/pkg/filecheck/fs.go
+++ b/pkg/filecheck/fs.go
@@ -31,10 +31,10 @@ func (r *RealFileSystem) Readlink(name string) (string, error) {
 // ReadFile reads up to limit bytes. If limit <= 0, reads entire file.
 func (r *RealFileSystem) ReadFile(name string, limit int64) ([]byte, error) {
 	if limit <= 0 {
-		return os.ReadFile(name)
+		return os.ReadFile(name) //nolint:gosec // intentional: file path from user config
 	}
 
-	f, err := os.Open(name)
+	f, err := os.Open(name) //nolint:gosec // intentional: file path from user config
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hashcheck/check.go
+++ b/pkg/hashcheck/check.go
@@ -28,7 +28,7 @@ type HashFileOpener interface {
 type RealHashFileOpener struct{}
 
 func (r *RealHashFileOpener) Open(name string) (io.ReadCloser, error) {
-	return os.Open(name)
+	return os.Open(name) //nolint:gosec // intentional: file path from user config
 }
 
 // HashAlgorithm represents supported hash algorithms.

--- a/pkg/httpcheck/check.go
+++ b/pkg/httpcheck/check.go
@@ -60,7 +60,7 @@ type RealFileReader struct{}
 
 // ReadFile reads a file from the filesystem.
 func (r *RealFileReader) ReadFile(path string) ([]byte, error) {
-	return os.ReadFile(path)
+	return os.ReadFile(path) //nolint:gosec // intentional: reading TLS cert files from user config
 }
 
 // Check verifies HTTP endpoint health.

--- a/pkg/jsoncheck/fs.go
+++ b/pkg/jsoncheck/fs.go
@@ -12,5 +12,5 @@ type RealFileSystem struct{}
 
 // ReadFile reads the entire file contents.
 func (r *RealFileSystem) ReadFile(name string) ([]byte, error) {
-	return os.ReadFile(name)
+	return os.ReadFile(name) //nolint:gosec // intentional: file path from user config
 }

--- a/pkg/preflightfile/preflightfile.go
+++ b/pkg/preflightfile/preflightfile.go
@@ -53,7 +53,7 @@ func FindFile(startDir, explicitPath string) (string, error) {
 }
 
 func ParseFile(path string) ([]string, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // intentional: reading .preflight file
 	if err != nil {
 		return nil, fmt.Errorf("failed to read preflight file: %w", err)
 	}

--- a/pkg/preflightfile/preflightfile_test.go
+++ b/pkg/preflightfile/preflightfile_test.go
@@ -10,7 +10,7 @@ import (
 func TestFindFile_ExplicitPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	preflightPath := filepath.Join(tmpDir, ".preflight")
-	if err := os.WriteFile(preflightPath, []byte("test"), 0o644); err != nil {
+	if err := os.WriteFile(preflightPath, []byte("test"), 0o600); err != nil {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
@@ -33,12 +33,12 @@ func TestFindFile_TraverseUp(t *testing.T) {
 
 	subdir1 := filepath.Join(tmpDir, "subdir1")
 	subdir2 := filepath.Join(subdir1, "subdir2")
-	if err := os.MkdirAll(subdir2, 0o755); err != nil {
+	if err := os.MkdirAll(subdir2, 0o700); err != nil {
 		t.Fatalf("failed to create directories: %v", err)
 	}
 
 	preflightPath := filepath.Join(tmpDir, ".preflight")
-	if err := os.WriteFile(preflightPath, []byte("test"), 0o644); err != nil {
+	if err := os.WriteFile(preflightPath, []byte("test"), 0o600); err != nil {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
@@ -56,17 +56,17 @@ func TestFindFile_StopAtGit(t *testing.T) {
 
 	projectDir := filepath.Join(tmpDir, "project")
 	gitDir := filepath.Join(projectDir, ".git")
-	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+	if err := os.MkdirAll(gitDir, 0o700); err != nil {
 		t.Fatalf("failed to create directories: %v", err)
 	}
 
 	preflightPath := filepath.Join(tmpDir, ".preflight")
-	if err := os.WriteFile(preflightPath, []byte("test"), 0o644); err != nil {
+	if err := os.WriteFile(preflightPath, []byte("test"), 0o600); err != nil {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
 	projectPreflight := filepath.Join(projectDir, ".preflight")
-	if err := os.WriteFile(projectPreflight, []byte("test"), 0o644); err != nil {
+	if err := os.WriteFile(projectPreflight, []byte("test"), 0o600); err != nil {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 
@@ -86,7 +86,7 @@ func TestFindFile_StopAtHome(t *testing.T) {
 	}
 
 	testDir := filepath.Join(homeDir, "test_preflight")
-	if err := os.MkdirAll(testDir, 0o755); err != nil {
+	if err := os.MkdirAll(testDir, 0o700); err != nil {
 		t.Fatalf("failed to create test directory: %v", err)
 	}
 	defer func() {
@@ -174,7 +174,7 @@ cmd myapp`,
 		t.Run(tt.name, func(t *testing.T) {
 			tmpDir := t.TempDir()
 			preflightPath := filepath.Join(tmpDir, ".preflight")
-			if err := os.WriteFile(preflightPath, []byte(tt.content), 0o644); err != nil {
+			if err := os.WriteFile(preflightPath, []byte(tt.content), 0o600); err != nil {
 				t.Fatalf("failed to create test file: %v", err)
 			}
 

--- a/pkg/resourcecheck/resource_darwin.go
+++ b/pkg/resourcecheck/resource_darwin.go
@@ -8,6 +8,8 @@ import (
 )
 
 // getSystemMemory returns total system memory on macOS.
+//
+//nolint:gosec // G103: unsafe is required for syscall interface
 func getSystemMemory() (uint64, error) {
 	mib := []int32{6, 24} // CTL_HW, HW_MEMSIZE
 	var size uint64

--- a/pkg/resourcecheck/resource_unix.go
+++ b/pkg/resourcecheck/resource_unix.go
@@ -38,7 +38,7 @@ func (r *RealResourceChecker) AvailableMemory() (uint64, error) {
 
 // readCgroupMemoryLimit reads memory limit from a cgroup file.
 func readCgroupMemoryLimit(path string) (uint64, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // intentional: reading cgroup files
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
- Enable gosec in golangci-lint for static security analysis
- Add govulncheck CI job for dependency vulnerability scanning
- Add `make security` target for local checks