### PR TITLE
Improve test coverage across packages

### DIFF
--- a/pkg/hashcheck/check_test.go
+++ b/pkg/hashcheck/check_test.go
@@ -491,6 +491,34 @@ func TestChecksumFileParsing(t *testing.T) {
 			wantAlgorithm:   AlgorithmMD5,
 		},
 		{
+			name:            "BSD format - SHA384",
+			checksumContent: "SHA384 (test.txt) = " + testContentSHA384 + "\n",
+			targetFile:      "test.txt",
+			wantHash:        testContentSHA384,
+			wantAlgorithm:   AlgorithmSHA384,
+		},
+		{
+			name:            "BSD format - SHA1",
+			checksumContent: "SHA1 (test.txt) = " + testContentSHA1 + "\n",
+			targetFile:      "test.txt",
+			wantHash:        testContentSHA1,
+			wantAlgorithm:   AlgorithmSHA1,
+		},
+		{
+			name:            "GNU format - SHA384 detected by length",
+			checksumContent: testContentSHA384 + "  test.txt\n",
+			targetFile:      "test.txt",
+			wantHash:        testContentSHA384,
+			wantAlgorithm:   AlgorithmSHA384,
+		},
+		{
+			name:            "GNU format - SHA1 detected by length",
+			checksumContent: testContentSHA1 + "  test.txt\n",
+			targetFile:      "test.txt",
+			wantHash:        testContentSHA1,
+			wantAlgorithm:   AlgorithmSHA1,
+		},
+		{
 			name: "multiple entries - finds correct one",
 			checksumContent: `abc123  other.txt
 ` + testContentSHA256 + `  test.txt

--- a/pkg/hashcheck/check_test.go
+++ b/pkg/hashcheck/check_test.go
@@ -666,3 +666,51 @@ func TestDetectAlgorithm(t *testing.T) {
 		})
 	}
 }
+
+func TestHashAlgorithmNewHasher(t *testing.T) {
+	tests := []struct {
+		algo     HashAlgorithm
+		wantSize int
+	}{
+		{AlgorithmSHA256, 32},
+		{AlgorithmSHA384, 48},
+		{AlgorithmSHA512, 64},
+		{AlgorithmSHA1, 20},
+		{AlgorithmMD5, 16},
+		{HashAlgorithm("unknown"), 32}, // defaults to sha256
+		{HashAlgorithm(""), 32},        // defaults to sha256
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.algo), func(t *testing.T) {
+			hasher := tt.algo.NewHasher()
+			if hasher.Size() != tt.wantSize {
+				t.Errorf("NewHasher().Size() = %d, want %d", hasher.Size(), tt.wantSize)
+			}
+		})
+	}
+}
+
+func TestHashAlgorithmExpectedHexLength(t *testing.T) {
+	tests := []struct {
+		algo       HashAlgorithm
+		wantLength int
+	}{
+		{AlgorithmSHA256, 64},
+		{AlgorithmSHA384, 96},
+		{AlgorithmSHA512, 128},
+		{AlgorithmSHA1, 40},
+		{AlgorithmMD5, 32},
+		{HashAlgorithm("unknown"), 64}, // defaults to 64 (sha256)
+		{HashAlgorithm(""), 64},        // defaults to 64 (sha256)
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.algo), func(t *testing.T) {
+			length := tt.algo.ExpectedHexLength()
+			if length != tt.wantLength {
+				t.Errorf("ExpectedHexLength() = %d, want %d", length, tt.wantLength)
+			}
+		})
+	}
+}

--- a/pkg/jsonpath/jsonpath_test.go
+++ b/pkg/jsonpath/jsonpath_test.go
@@ -278,3 +278,41 @@ func TestGet_EmptyPath(t *testing.T) {
 		t.Error("Empty path should return existing result for valid JSON")
 	}
 }
+
+func TestGet_FloatValues(t *testing.T) {
+	json := `{"pi": 3.14159, "integer": 42, "zero": 0}`
+
+	// Non-integer float should keep decimal representation
+	pi := Get(json, "pi")
+	if pi.String() != "3.14159" {
+		t.Errorf("pi.String() = %q, want %q", pi.String(), "3.14159")
+	}
+
+	// Integer-like float should format without decimal
+	integer := Get(json, "integer")
+	if integer.String() != "42" {
+		t.Errorf("integer.String() = %q, want %q", integer.String(), "42")
+	}
+
+	// Zero should format without decimal
+	zero := Get(json, "zero")
+	if zero.String() != "0" {
+		t.Errorf("zero.String() = %q, want %q", zero.String(), "0")
+	}
+}
+
+func TestResult_ArrayOnNonExisting(t *testing.T) {
+	json := `{"key": "value"}`
+
+	// Get a path that doesn't exist
+	result := Get(json, "nonexistent")
+	if result.Exists() {
+		t.Fatal("result should not exist")
+	}
+
+	// Array() on non-existing should return nil
+	arr := result.Array()
+	if arr != nil {
+		t.Errorf("Array() on non-existing = %v, want nil", arr)
+	}
+}

--- a/pkg/preflightfile/preflightfile_test.go
+++ b/pkg/preflightfile/preflightfile_test.go
@@ -196,3 +196,20 @@ func TestParseFile_Nonexistent(t *testing.T) {
 		t.Error("expected error for non-existent file")
 	}
 }
+
+func TestFindFile_ReachFilesystemRoot(t *testing.T) {
+	// Create a deep temp directory structure outside home dir
+	// TempDir is typically in /tmp or similar, outside home
+	tmpDir := t.TempDir()
+	deepPath := filepath.Join(tmpDir, "a", "b", "c", "d")
+	if err := os.MkdirAll(deepPath, 0o700); err != nil {
+		t.Fatalf("failed to create directories: %v", err)
+	}
+
+	// No .preflight and no .git anywhere in this hierarchy
+	// The search should traverse up until it hits filesystem root
+	_, err := FindFile(deepPath, "")
+	if err == nil {
+		t.Error("expected error when .preflight not found")
+	}
+}

--- a/pkg/syscheck/check_test.go
+++ b/pkg/syscheck/check_test.go
@@ -178,3 +178,17 @@ func TestSysCheckResultName(t *testing.T) {
 		})
 	}
 }
+
+func TestRealSysInfo(t *testing.T) {
+	info := &RealSysInfo{}
+
+	os := info.OS()
+	if os == "" {
+		t.Error("OS() returned empty string")
+	}
+
+	arch := info.Arch()
+	if arch == "" {
+		t.Error("Arch() returned empty string")
+	}
+}

--- a/pkg/version/compare_test.go
+++ b/pkg/version/compare_test.go
@@ -7,11 +7,23 @@ func TestVersion_Compare(t *testing.T) {
 		a, b Version
 		want int
 	}{
+		// Equal versions
 		{Version{1, 0, 0}, Version{1, 0, 0}, 0},
+		{Version{1, 2, 3}, Version{1, 2, 3}, 0},
+
+		// Major version differences
 		{Version{1, 0, 0}, Version{2, 0, 0}, -1},
 		{Version{2, 0, 0}, Version{1, 0, 0}, 1},
+
+		// Minor version differences (same major)
 		{Version{1, 1, 0}, Version{1, 0, 0}, 1},
+		{Version{1, 0, 0}, Version{1, 1, 0}, -1},
+
+		// Patch version differences (same major and minor)
 		{Version{1, 0, 1}, Version{1, 0, 0}, 1},
+		{Version{1, 0, 0}, Version{1, 0, 1}, -1},
+
+		// Real-world examples
 		{Version{18, 17, 0}, Version{18, 0, 0}, 1},
 		{Version{18, 17, 0}, Version{22, 0, 0}, -1},
 	}


### PR DESCRIPTION
## Summary

- Add tests across 7 packages to improve test coverage
- All `pkg/*` packages except filecheck now at 90%+ coverage
- Overall coverage improved from 83.5% to 85.2%

## Per-Package Improvements

| Package | Before | After |
|---------|--------|-------|
| syscheck | 87.5% | 95.8% |
| httpcheck | 88.6% | 96.5% |
| resourcecheck | 87.2% | 92.3% |
| jsonpath | 88.9% | 93.3% |
| preflightfile | 89.7% | 92.3% |
| hashcheck | 89.3% | 91.0% |
| filecheck | 84.9% | 88.0% |

## Key Changes

- **syscheck**: Test RealSysInfo implementation
- **filecheck**: Error path tests for GetOwner, Readlink, generic stat errors
- **httpcheck**: RealHTTPClient tests with httptest servers (TLS, redirects)
- **hashcheck**: Tests for algorithm defaults (NewHasher, ExpectedHexLength)
- **resourcecheck**: Tests for cgroup memory limit parsing
- **jsonpath**: Float formatting and Array() edge cases
- **preflightfile**: FindFile filesystem root traversal