### PR TITLE
Update README to lead with value, add FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ COPY --from=ghcr.io/vertti/preflight:latest /preflight /usr/local/bin/preflight
 RUN preflight cmd node --min 18.0        # verify binary + version
 RUN preflight env DATABASE_URL           # env var exists
 RUN preflight file /app/config.yaml      # file exists
-RUN preflight tcp postgres:5432          # service reachable
+RUN preflight tcp postgres:5432 --retry 5 --retry-interval 2s  # wait for DB
+
+HEALTHCHECK CMD ["/preflight", "http", "http://localhost:8080/health"]
 ```
 
 ## What It Does

--- a/README.md
+++ b/README.md
@@ -6,49 +6,96 @@
 [![Security: gosec](https://img.shields.io/badge/security-gosec-blue)](https://github.com/securego/gosec)
 [![Security: govulncheck](https://img.shields.io/badge/security-govulncheck-blue)](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)
 
-> A swiss army knife for CI and container checks. Single binary, zero dependencies.
-
-Stop copying brittle shell scripts and installing a variety of tools for container validation. Preflight is a small, dependency-free binary that handles service readiness, health checks, environment validation, file verification, and more.
+> Validation toolkit for containers and CI. Single binary, zero dependencies.
 
 ![demo](demo/cli-demo.gif)
+
+## Quick Start
 
 ```dockerfile
 COPY --from=ghcr.io/vertti/preflight:latest /preflight /usr/local/bin/preflight
 
-RUN preflight cmd myapp --min 2.0
-RUN preflight env MODEL_PATH --match '^/models/'
-RUN preflight file /app/config.yaml --not-empty
-RUN preflight tcp postgres:5432
+RUN preflight cmd node --min 18.0        # verify binary + version
+RUN preflight env DATABASE_URL           # env var exists
+RUN preflight file /app/config.yaml      # file exists
+RUN preflight tcp postgres:5432          # service reachable
 ```
 
-**Use it for:**
+## What It Does
 
-- **Docker builds** – verify binaries, configs, and paths during image build
-- **Container startup** – wait for databases and services before your app starts
-- **CI pipelines** – validate environments, check connectivity, verify checksums
-- **Health checks** – HTTP and TCP checks without curl or netcat
+Pre-flight checks for containers: verify services, environment, dependencies. Each check does multiple things and tells you exactly what failed.
 
-**Clear output, CI-friendly exit codes:**
+**One command, multiple checks** — `preflight cmd node --min 18.0` verifies: on PATH, actually runs, returns version, meets constraint. Clear error if any step fails.
 
-Every check tells you exactly what passed or failed—no more guessing why your build broke.
+**Works without a shell** — Runs in distroless/scratch. No bash required.
+
+**Container-aware** — Reads cgroup limits, not just host /proc/meminfo.
+
+**Version constraints** — `--min ^1.0` uses semver, not string comparison.
 
 ```
 [OK] cmd: node
      path: /usr/local/bin/node
      version: 20.10.0
 
-[OK] file: /app/config.yaml
-     size: 1.2KB
-     mode: -rw-r--r--
-
 [FAIL] cmd: python
        version 3.9.0 < minimum 3.11
-
-[FAIL] tcp: postgres:5432
-       connection refused
 ```
 
-Exit code `0` on success, `1` on failure. Works with `set -e`, Docker `RUN`, and CI pipelines out of the box.
+Exit code `0` on success, `1` on failure. Works with `set -e`, Docker `RUN`, and CI pipelines.
+
+## Use Cases
+
+- **Docker builds** — verify binaries, configs during image build
+- **Startup** — wait for databases before your app starts
+- **CI** — validate environment, connectivity, checksums
+- **Health checks** — HTTP/TCP without curl or netcat
+
+## FAQ
+
+<details>
+<summary><b>Why not just shell scripts?</b></summary>
+
+Shell works for simple checks. Preflight helps when you need:
+
+- Checks in minimal images (no shell available)
+- Container-aware resource limits (cgroup detection)
+- Semantic version constraints (`^1.0`, `>=2.0, <3.0`)
+- Consistent output format across all checks
+
+One preflight command replaces complex shell chains:
+
+```bash
+# Shell: check node exists, runs, and version >= 18
+command -v node >/dev/null 2>&1 && \
+  node --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | \
+  awk -F. '{if ($1 >= 18) exit 0; else exit 1}' || \
+  (echo "node missing or wrong version"; exit 1)
+
+# Preflight: one command, clear error message
+preflight cmd node --min 18.0
+```
+
+</details>
+
+<details>
+<summary><b>Does this add bloat/attack surface?</b></summary>
+
+- 2MB binary (Linux), no C dependencies
+- 3 direct dependencies (cobra, semver, x/term)
+- Security scans on every commit (govulncheck, gosec)
+- Auto-updated via Renovate
+
+To exclude from final image: [multi-stage builds](docs/usage.md#keeping-containers-clean)
+
+</details>
+
+<details>
+<summary><b>Why not curl for health checks?</b></summary>
+
+Curl works. Preflight is useful when curl isn't in your image, or you need JSON path assertions, built-in retry, or you're already using it for other checks.
+
+</details>
 
 ## Install
 
@@ -73,8 +120,6 @@ curl -fsSL https://raw.githubusercontent.com/vertti/preflight/main/install.sh | 
 See the **[full usage guide](docs/usage.md)** for all commands and options.
 
 ### Check commands
-
-Like `which`, but actually runs the binary to verify it works.
 
 ```sh
 preflight cmd node                            # exists and runs
@@ -106,8 +151,6 @@ preflight file /app/entrypoint.sh --executable # script is executable
 
 ### Check HTTP endpoints
 
-Health checks for services without requiring curl or wget in your container.
-
 ```sh
 preflight http http://localhost:8080/health         # basic health check
 preflight http https://api.example.com --status 204 # custom status code
@@ -118,8 +161,6 @@ preflight http http://localhost/ready --retry 3     # retry on failure
 
 ### Verify file checksums
 
-Supply chain security - verify downloaded binaries match expected hashes.
-
 ```sh
 preflight hash --sha256 67574ee...2cf myfile.tar.gz  # verify SHA256
 preflight hash --checksum-file SHASUMS256.txt app.tar.gz  # from checksum file
@@ -129,7 +170,7 @@ preflight hash --checksum-file SHASUMS256.txt app.tar.gz  # from checksum file
 
 ### Run checks from a file
 
-Create a `.preflight` file in your project to define all checks in one place:
+Create a `.preflight` file in your project:
 
 ```sh
 # .preflight
@@ -148,14 +189,12 @@ preflight run --file /path/to/.preflight  # specify file explicitly
 
 [File format, discovery, and hashbang support](docs/usage.md#preflight-run)
 
-[Full usage guide](docs/usage.md)
-
 ## Security
 
-Preflight is designed to replace shell scripts in security-sensitive environments like CI pipelines and container builds. We take code quality seriously:
+Preflight is designed for security-sensitive environments like CI pipelines and container builds. We take code quality seriously:
 
-- **[gosec](https://github.com/securego/gosec)** - Static analysis for security vulnerabilities
-- **[govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)** - Dependency vulnerability scanning
+- **[gosec](https://github.com/securego/gosec)** — Static analysis for security vulnerabilities
+- **[govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck)** — Dependency vulnerability scanning
 - **20+ linters** via [golangci-lint](https://golangci-lint.run/) including nil-safety and error handling checks
 
 All security checks run in CI on every commit.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -918,6 +918,8 @@ RUN preflight sys --os linux --arch arm64
 
 Checks system resources meet minimum requirements. Critical for CI pipelines where runners have limited disk space, or containers with memory limits.
 
+> **Container-aware**: Memory checks read cgroup limits (v1 and v2), not just host `/proc/meminfo`. Your 512MB container limit is detected correctly.
+
 ```sh
 preflight resource [flags]
 ```


### PR DESCRIPTION
## Summary

Restructures README based on Reddit feedback to lead with unique value instead of defensive comparisons.

- **Quick Start first** - Example code within 15 lines of top
- **New tagline** - "Validation toolkit for containers and CI" (not "stop copying shell scripts")
- **What It Does** - Highlights genuinely unique capabilities:
  - One command does multiple checks (PATH, runs, version, constraint)
  - Works in distroless/scratch (no shell needed)
  - Container-aware (cgroup limits, not host /proc/meminfo)
  - Semver constraints (`^1.0`, `>=2.0, <3.0`)
- **Collapsible FAQ** - Addresses common objections with facts:
  - "Why not shell?" - Shows before/after comparison
  - "Bloat/attack surface?" - 2MB binary, 3 deps, security scans
  - "Why not curl?" - Honest: curl works, here's when preflight helps
- **docs/usage.md** - Added cgroup detection callout in resource section