### PR TITLE
Add exec mode for shell-less entrypoints

### DIFF
--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -73,6 +73,15 @@ func extractExecArgs(args *[]string) []string {
 // executor is the default exec implementation, can be overridden for testing.
 var executor exec.Executor = &exec.RealExecutor{}
 
+// runExec executes the command specified in execArgs.
+// Returns an error if the exec fails.
+func runExec(execArgs []string) error {
+	if len(execArgs) == 0 {
+		return nil
+	}
+	return executor.Exec(execArgs[0], execArgs[1:])
+}
+
 func main() {
 	var file string
 	os.Args, file = transformArgsForHashbang(os.Args, realFileChecker)
@@ -88,11 +97,9 @@ func main() {
 	}
 
 	// Checks passed - exec into command if args were provided
-	if len(execArgs) > 0 {
-		if err := executor.Exec(execArgs[0], execArgs[1:]); err != nil {
-			fmt.Fprintf(os.Stderr, "exec: %v\n", err)
-			os.Exit(1)
-		}
+	if err := runExec(execArgs); err != nil {
+		fmt.Fprintf(os.Stderr, "exec: %v\n", err)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -1,11 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/vertti/preflight/pkg/exec"
 )
 
 // Version is set at build time via ldflags
@@ -53,6 +56,23 @@ func transformArgsForHashbang(args []string, checkFile fileChecker) (newArgs []s
 	return args, ""
 }
 
+// extractExecArgs finds "--" in args and returns everything after it.
+// It modifies the input slice to remove the "--" and everything after.
+// This allows syntax like: preflight tcp postgres:5432 -- ./myapp
+func extractExecArgs(args *[]string) []string {
+	for i, arg := range *args {
+		if arg == "--" {
+			execArgs := (*args)[i+1:]
+			*args = (*args)[:i]
+			return execArgs
+		}
+	}
+	return nil
+}
+
+// executor is the default exec implementation, can be overridden for testing.
+var executor exec.Executor = &exec.RealExecutor{}
+
 func main() {
 	var file string
 	os.Args, file = transformArgsForHashbang(os.Args, realFileChecker)
@@ -60,8 +80,19 @@ func main() {
 		runFile = file
 	}
 
+	// Extract exec args (everything after "--")
+	execArgs := extractExecArgs(&os.Args)
+
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(1)
+	}
+
+	// Checks passed - exec into command if args were provided
+	if len(execArgs) > 0 {
+		if err := executor.Exec(execArgs[0], execArgs[1:]); err != nil {
+			fmt.Fprintf(os.Stderr, "exec: %v\n", err)
+			os.Exit(1)
+		}
 	}
 }
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -611,6 +611,7 @@ func TestIntegration_ExecMode(t *testing.T) {
 	t.Run("exec after successful check", func(t *testing.T) {
 		// Run: preflight env PATH -- echo "success"
 		cmd := exec.Command(binaryPath, "env", "PATH", "--", "echo", "exec-success-marker") //nolint:gosec // intentional: testing exec mode
+		cmd.Env = append(os.Environ(), "NO_COLOR=1")
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("command failed: %v\n%s", err, output)
@@ -629,6 +630,7 @@ func TestIntegration_ExecMode(t *testing.T) {
 	t.Run("no exec after failed check", func(t *testing.T) {
 		// Run: preflight env NONEXISTENT_VAR_12345 -- echo "should-not-print"
 		cmd := exec.Command(binaryPath, "env", "NONEXISTENT_VAR_12345", "--", "echo", "should-not-print") //nolint:gosec // intentional: testing exec mode
+		cmd.Env = append(os.Environ(), "NO_COLOR=1")
 		output, err := cmd.CombinedOutput()
 
 		// Command should fail
@@ -649,6 +651,7 @@ func TestIntegration_ExecMode(t *testing.T) {
 	t.Run("exec with arguments", func(t *testing.T) {
 		// Run: preflight env PATH -- echo arg1 arg2 arg3
 		cmd := exec.Command(binaryPath, "env", "PATH", "--", "echo", "arg1", "arg2", "arg3") //nolint:gosec // intentional: testing exec mode
+		cmd.Env = append(os.Environ(), "NO_COLOR=1")
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			t.Fatalf("command failed: %v\n%s", err, output)
@@ -664,6 +667,7 @@ func TestIntegration_ExecMode(t *testing.T) {
 	t.Run("exec command not found", func(t *testing.T) {
 		// Run: preflight env PATH -- nonexistent-command-xyz-12345
 		cmd := exec.Command(binaryPath, "env", "PATH", "--", "nonexistent-command-xyz-12345") //nolint:gosec // intentional: testing exec mode
+		cmd.Env = append(os.Environ(), "NO_COLOR=1")
 		output, err := cmd.CombinedOutput()
 
 		// Command should fail because exec'd command doesn't exist

--- a/integration_test.go
+++ b/integration_test.go
@@ -597,3 +597,87 @@ func TestIntegration_ExamplesShellSyntax(t *testing.T) {
 		})
 	}
 }
+
+func TestIntegration_ExecMode(t *testing.T) {
+	// Build preflight binary for testing
+	tmpDir := t.TempDir()
+	binaryPath := tmpDir + "/preflight"
+
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, "./cmd/preflight") //nolint:gosec // intentional: building test binary
+	if output, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build preflight: %v\n%s", err, output)
+	}
+
+	t.Run("exec after successful check", func(t *testing.T) {
+		// Run: preflight env PATH -- echo "success"
+		cmd := exec.Command(binaryPath, "env", "PATH", "--", "echo", "exec-success-marker") //nolint:gosec // intentional: testing exec mode
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command failed: %v\n%s", err, output)
+		}
+
+		// Should see both the check output and the exec'd command output
+		outputStr := string(output)
+		if !strings.Contains(outputStr, "[OK] env: PATH") {
+			t.Errorf("expected check output, got: %s", outputStr)
+		}
+		if !strings.Contains(outputStr, "exec-success-marker") {
+			t.Errorf("expected exec'd command output, got: %s", outputStr)
+		}
+	})
+
+	t.Run("no exec after failed check", func(t *testing.T) {
+		// Run: preflight env NONEXISTENT_VAR_12345 -- echo "should-not-print"
+		cmd := exec.Command(binaryPath, "env", "NONEXISTENT_VAR_12345", "--", "echo", "should-not-print") //nolint:gosec // intentional: testing exec mode
+		output, err := cmd.CombinedOutput()
+
+		// Command should fail
+		if err == nil {
+			t.Fatal("expected command to fail")
+		}
+
+		// Should see the failure output but NOT the exec'd command
+		outputStr := string(output)
+		if !strings.Contains(outputStr, "[FAIL]") {
+			t.Errorf("expected failure output, got: %s", outputStr)
+		}
+		if strings.Contains(outputStr, "should-not-print") {
+			t.Errorf("exec'd command should not have run, got: %s", outputStr)
+		}
+	})
+
+	t.Run("exec with arguments", func(t *testing.T) {
+		// Run: preflight env PATH -- echo arg1 arg2 arg3
+		cmd := exec.Command(binaryPath, "env", "PATH", "--", "echo", "arg1", "arg2", "arg3") //nolint:gosec // intentional: testing exec mode
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("command failed: %v\n%s", err, output)
+		}
+
+		// Should see all arguments passed through
+		outputStr := string(output)
+		if !strings.Contains(outputStr, "arg1 arg2 arg3") {
+			t.Errorf("expected arguments to be passed through, got: %s", outputStr)
+		}
+	})
+
+	t.Run("exec command not found", func(t *testing.T) {
+		// Run: preflight env PATH -- nonexistent-command-xyz-12345
+		cmd := exec.Command(binaryPath, "env", "PATH", "--", "nonexistent-command-xyz-12345") //nolint:gosec // intentional: testing exec mode
+		output, err := cmd.CombinedOutput()
+
+		// Command should fail because exec'd command doesn't exist
+		if err == nil {
+			t.Fatal("expected command to fail")
+		}
+
+		// Should see the check pass but exec fail
+		outputStr := string(output)
+		if !strings.Contains(outputStr, "[OK] env: PATH") {
+			t.Errorf("expected check to pass, got: %s", outputStr)
+		}
+		if !strings.Contains(outputStr, "exec:") {
+			t.Errorf("expected exec error message, got: %s", outputStr)
+		}
+	})
+}

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -1,0 +1,27 @@
+// Package exec provides process replacement functionality for entrypoint mode.
+package exec
+
+import (
+	"os"
+	"os/exec"
+)
+
+// Executor handles process replacement after successful checks.
+type Executor interface {
+	// Exec replaces the current process with the specified command.
+	// On Unix, this uses syscall.Exec. On Windows, returns an error.
+	Exec(name string, args []string) error
+}
+
+// RealExecutor is the production implementation.
+type RealExecutor struct{}
+
+// lookPath finds the executable in PATH.
+func lookPath(name string) (string, error) {
+	return exec.LookPath(name)
+}
+
+// environ returns the current environment.
+func environ() []string {
+	return os.Environ()
+}

--- a/pkg/exec/exec_test.go
+++ b/pkg/exec/exec_test.go
@@ -1,0 +1,112 @@
+package exec
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+)
+
+// MockExecutor is a test implementation of Executor.
+type MockExecutor struct {
+	ExecFunc func(name string, args []string) error
+}
+
+func (m *MockExecutor) Exec(name string, args []string) error {
+	if m.ExecFunc != nil {
+		return m.ExecFunc(name, args)
+	}
+	return nil
+}
+
+func TestExecutorInterface(t *testing.T) {
+	// Verify MockExecutor implements Executor interface
+	var _ Executor = &MockExecutor{}
+	var _ Executor = &RealExecutor{}
+}
+
+func TestMockExecutor(t *testing.T) {
+	tests := []struct {
+		name     string
+		execFunc func(string, []string) error
+		wantErr  bool
+	}{
+		{
+			name: "successful exec",
+			execFunc: func(name string, args []string) error {
+				return nil
+			},
+			wantErr: false,
+		},
+		{
+			name: "exec returns error",
+			execFunc: func(name string, args []string) error {
+				return errors.New("exec failed")
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &MockExecutor{ExecFunc: tt.execFunc}
+			err := m.Exec("test", []string{"arg1", "arg2"})
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Exec() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMockExecutor_NilFunc(t *testing.T) {
+	m := &MockExecutor{}
+	err := m.Exec("test", []string{"arg1"})
+	if err != nil {
+		t.Errorf("expected nil error when ExecFunc is nil, got %v", err)
+	}
+}
+
+func TestRealExecutor_CommandNotFound(t *testing.T) {
+	e := &RealExecutor{}
+	err := e.Exec("nonexistent-command-that-does-not-exist-12345", []string{})
+	if err == nil {
+		t.Error("expected error for nonexistent command")
+	}
+}
+
+func TestLookPath(t *testing.T) {
+	// Test with a command that should exist on all systems
+	path, err := lookPath("echo")
+	if err != nil {
+		t.Skipf("echo not found in PATH, skipping: %v", err)
+	}
+	if path == "" {
+		t.Error("expected non-empty path for echo")
+	}
+}
+
+func TestLookPath_NotFound(t *testing.T) {
+	_, err := lookPath("nonexistent-command-xyz-12345")
+	if err == nil {
+		t.Error("expected error for nonexistent command")
+	}
+}
+
+func TestEnviron(t *testing.T) {
+	env := environ()
+	if len(env) == 0 {
+		t.Error("expected non-empty environment")
+	}
+
+	// Check that PATH is in the environment
+	hasPath := false
+	for _, e := range env {
+		if strings.HasPrefix(e, "PATH=") {
+			hasPath = true
+			break
+		}
+	}
+	if !hasPath && os.Getenv("PATH") != "" {
+		t.Error("expected PATH in environment")
+	}
+}

--- a/pkg/exec/exec_unix.go
+++ b/pkg/exec/exec_unix.go
@@ -1,0 +1,23 @@
+//go:build unix
+
+package exec
+
+import (
+	"syscall"
+)
+
+// Exec replaces the current process with the specified command.
+// This is the Unix implementation using syscall.Exec.
+func (e *RealExecutor) Exec(name string, args []string) error {
+	binary, err := lookPath(name)
+	if err != nil {
+		return err
+	}
+
+	// syscall.Exec replaces the current process.
+	// argv[0] must be the program name by convention.
+	argv := append([]string{name}, args...)
+	// #nosec G204 -- This is intentional: exec mode allows users to specify the command to run after checks pass.
+	// The command comes from CLI args which are under user control.
+	return syscall.Exec(binary, argv, environ())
+}

--- a/pkg/exec/exec_unix.go
+++ b/pkg/exec/exec_unix.go
@@ -6,6 +6,10 @@ import (
 	"syscall"
 )
 
+// execFunc is the function used to exec into a new process.
+// Can be overridden for testing.
+var execFunc = syscall.Exec
+
 // Exec replaces the current process with the specified command.
 // This is the Unix implementation using syscall.Exec.
 func (e *RealExecutor) Exec(name string, args []string) error {
@@ -17,7 +21,9 @@ func (e *RealExecutor) Exec(name string, args []string) error {
 	// syscall.Exec replaces the current process.
 	// argv[0] must be the program name by convention.
 	argv := append([]string{name}, args...)
+	env := environ()
+
 	// #nosec G204 -- This is intentional: exec mode allows users to specify the command to run after checks pass.
 	// The command comes from CLI args which are under user control.
-	return syscall.Exec(binary, argv, environ())
+	return execFunc(binary, argv, env)
 }

--- a/pkg/exec/exec_unix_test.go
+++ b/pkg/exec/exec_unix_test.go
@@ -1,0 +1,118 @@
+//go:build unix
+
+package exec
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestRealExecutor_Exec_Success(t *testing.T) {
+	// Save original and restore after test
+	originalExecFunc := execFunc
+	defer func() { execFunc = originalExecFunc }()
+
+	var capturedBinary string
+	var capturedArgv []string
+	var capturedEnv []string
+
+	// Mock execFunc to capture arguments
+	execFunc = func(binary string, argv []string, env []string) error {
+		capturedBinary = binary
+		capturedArgv = argv
+		capturedEnv = env
+		return nil
+	}
+
+	e := &RealExecutor{}
+	err := e.Exec("echo", []string{"hello", "world"})
+
+	if err != nil {
+		t.Errorf("Exec() error = %v, want nil", err)
+	}
+
+	// Verify binary path was resolved (should be absolute path to echo)
+	if capturedBinary == "" {
+		t.Error("expected binary path to be set")
+	}
+
+	// Verify argv[0] is the command name
+	if len(capturedArgv) < 1 || capturedArgv[0] != "echo" {
+		t.Errorf("argv[0] = %v, want 'echo'", capturedArgv)
+	}
+
+	// Verify arguments were passed
+	if len(capturedArgv) != 3 || capturedArgv[1] != "hello" || capturedArgv[2] != "world" {
+		t.Errorf("argv = %v, want ['echo', 'hello', 'world']", capturedArgv)
+	}
+
+	// Verify environment was passed
+	if len(capturedEnv) == 0 {
+		t.Error("expected environment to be passed")
+	}
+}
+
+func TestRealExecutor_Exec_ExecFuncError(t *testing.T) {
+	// Save original and restore after test
+	originalExecFunc := execFunc
+	defer func() { execFunc = originalExecFunc }()
+
+	expectedErr := errors.New("exec failed")
+	execFunc = func(binary string, argv []string, env []string) error {
+		return expectedErr
+	}
+
+	e := &RealExecutor{}
+	err := e.Exec("echo", []string{})
+
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("Exec() error = %v, want %v", err, expectedErr)
+	}
+}
+
+func TestRealExecutor_Exec_EmptyArgs(t *testing.T) {
+	// Save original and restore after test
+	originalExecFunc := execFunc
+	defer func() { execFunc = originalExecFunc }()
+
+	var capturedArgv []string
+	execFunc = func(binary string, argv []string, env []string) error {
+		capturedArgv = argv
+		return nil
+	}
+
+	e := &RealExecutor{}
+	err := e.Exec("echo", []string{})
+
+	if err != nil {
+		t.Errorf("Exec() error = %v, want nil", err)
+	}
+
+	// argv should just be ["echo"] when no args provided
+	if len(capturedArgv) != 1 || capturedArgv[0] != "echo" {
+		t.Errorf("argv = %v, want ['echo']", capturedArgv)
+	}
+}
+
+func TestRealExecutor_Exec_BinaryPathResolution(t *testing.T) {
+	// Save original and restore after test
+	originalExecFunc := execFunc
+	defer func() { execFunc = originalExecFunc }()
+
+	var capturedBinary string
+	execFunc = func(binary string, argv []string, env []string) error {
+		capturedBinary = binary
+		return nil
+	}
+
+	e := &RealExecutor{}
+	_ = e.Exec("sh", []string{"-c", "true"})
+
+	// Binary should be resolved to absolute path
+	if capturedBinary == "sh" {
+		t.Error("expected binary to be resolved to absolute path")
+	}
+	if capturedBinary == "" {
+		t.Error("expected binary path to be set")
+	}
+}

--- a/pkg/exec/exec_windows.go
+++ b/pkg/exec/exec_windows.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package exec
+
+import "errors"
+
+// ErrExecNotSupported indicates exec mode is not available on Windows.
+var ErrExecNotSupported = errors.New("exec mode not supported on Windows; use a shell script instead")
+
+// Exec is not supported on Windows.
+// Windows does not have a true exec syscall that replaces the current process.
+func (e *RealExecutor) Exec(name string, args []string) error {
+	return ErrExecNotSupported
+}


### PR DESCRIPTION
## Summary

- Add `-- command` syntax that runs checks, then execs into the command
- Enables preflight as ENTRYPOINT in distroless/scratch images (no shell needed)
- Uses `syscall.Exec` on Unix to properly replace the process (correct PID 1 behavior)

## Usage

```dockerfile
# Wait for postgres, then start app (no shell required)
ENTRYPOINT ["/preflight", "tcp", "postgres:5432", "--retry", "10", "--"]
CMD ["/myapp"]
```

Works with any preflight command:

```sh
preflight tcp postgres:5432 --retry 10 -- ./myapp
preflight env DATABASE_URL -- ./myapp
preflight http localhost:8080/health -- ./myapp
preflight run -- ./myapp
```

## Implementation

- New `pkg/exec` package with platform-specific implementations
- `exec_unix.go`: Uses `syscall.Exec` to replace current process
- `exec_windows.go`: Returns error (not supported)
- Main extracts `--` args before Cobra parsing, execs after checks pass

## Tests

- Unit tests for extractExecArgs function
- Unit tests for exec package
- Integration tests that build preflight and verify exec mode works end-to-end