### PR TITLE
Add CI tests for distroless and scratch images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,10 @@ jobs:
           docker run --rm preflight-distroless --version
           docker run --rm preflight-distroless env PATH
 
+          # Test exec mode (the key feature for distroless - no shell needed)
+          # This runs a check, then execs into preflight --version
+          docker run --rm --entrypoint /preflight preflight-distroless env PATH -- /preflight --version
+
       - name: Test in scratch
         run: |
           echo 'FROM scratch
@@ -178,3 +182,6 @@ jobs:
           docker build -f Dockerfile.scratch -t preflight-scratch .
 
           docker run --rm preflight-scratch --version
+
+          # Test exec mode in scratch too
+          docker run --rm --entrypoint /preflight preflight-scratch env PATH -- /preflight --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
           docker build -f Dockerfile.distroless -t preflight-distroless .
 
           # Test basic commands (no shell available)
-          docker run --rm preflight-distroless version
+          docker run --rm preflight-distroless --version
           docker run --rm preflight-distroless env PATH
 
       - name: Test in scratch
@@ -177,4 +177,4 @@ jobs:
           ENTRYPOINT ["/preflight"]' > Dockerfile.scratch
           docker build -f Dockerfile.scratch -t preflight-scratch .
 
-          docker run --rm preflight-scratch version
+          docker run --rm preflight-scratch --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,47 @@ jobs:
             preflight cmd ${{ matrix.cmd }} &&
             echo "Container test passed: ${{ matrix.image }}"
           '
+
+  distroless-test:
+    name: Distroless Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+
+      - name: Build static binary
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o preflight ./cmd/preflight
+
+      - name: Verify binary is static
+        run: |
+          file preflight
+          # Check that ldd reports it as not dynamic or statically linked
+          if ldd preflight 2>&1 | grep -qE "(not a dynamic executable|statically linked)"; then
+            echo "Binary is static"
+          else
+            echo "ERROR: Binary has dynamic dependencies"
+            ldd preflight
+            exit 1
+          fi
+
+      - name: Test in distroless (no shell)
+        run: |
+          echo 'FROM gcr.io/distroless/static-debian12
+          COPY preflight /preflight
+          ENTRYPOINT ["/preflight"]' > Dockerfile.distroless
+          docker build -f Dockerfile.distroless -t preflight-distroless .
+
+          # Test basic commands (no shell available)
+          docker run --rm preflight-distroless version
+          docker run --rm preflight-distroless env PATH
+
+      - name: Test in scratch
+        run: |
+          echo 'FROM scratch
+          COPY preflight /preflight
+          ENTRYPOINT ["/preflight"]' > Dockerfile.scratch
+          docker build -f Dockerfile.scratch -t preflight-scratch .
+
+          docker run --rm preflight-scratch version


### PR DESCRIPTION
## Summary

Add a new CI job that verifies the static binary works in minimal container environments.

## Tests Added

1. **Binary verification**: Check that `ldd` reports the binary as static
2. **Distroless test**: Run preflight in `gcr.io/distroless/static-debian12` (no shell)
3. **Scratch test**: Run preflight in `scratch` image (truly nothing but the binary)

## Why

This ensures our claim of "works in distroless/scratch" is continuously verified. If we accidentally introduce a dynamic dependency, this will catch it.