### PR TITLE
Add testifylint for testify best practices

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,8 @@ linters:
     # Consistency
     - recvcheck      # check receiver type consistency
     - nilnil         # check for nil,nil returns (excluding intentional cases)
+    # Testing
+    - testifylint    # check testify best practices
   settings:
     gocritic:
       enabled-tags:

--- a/cmd/preflight/execute_test.go
+++ b/cmd/preflight/execute_test.go
@@ -337,7 +337,7 @@ func TestSubcommandHelp(t *testing.T) {
 	for _, subcmd := range subcommands {
 		t.Run(subcmd, func(t *testing.T) {
 			output, err := executeCommand(subcmd, "--help")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotEmpty(t, output)
 		})
 	}

--- a/pkg/cmdcheck/runner_test.go
+++ b/pkg/cmdcheck/runner_test.go
@@ -57,6 +57,6 @@ func TestMockCmdRunner_RunCommandContext(t *testing.T) {
 	assert.Empty(t, stderr)
 
 	_, stderr, err = mock.RunCommandContext(ctx, "bad")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "command failed", stderr)
 }

--- a/pkg/filecheck/check_test.go
+++ b/pkg/filecheck/check_test.go
@@ -221,7 +221,7 @@ func TestRealFileSystem(t *testing.T) {
 
 		info, err := rfs.Lstat(link)
 		require.NoError(t, err)
-		assert.True(t, info.Mode()&os.ModeSymlink != 0)
+		assert.NotEqual(t, os.FileMode(0), info.Mode()&os.ModeSymlink)
 	})
 
 	t.Run("Readlink", func(t *testing.T) {

--- a/pkg/hashcheck/check_test.go
+++ b/pkg/hashcheck/check_test.go
@@ -210,7 +210,7 @@ func TestRealHashFileOpener(t *testing.T) {
 	if err != nil {
 		require.ErrorIs(t, err, io.EOF, "unexpected read error")
 	}
-	assert.Greater(t, n, 0)
+	assert.Positive(t, n)
 }
 
 func TestDetectAlgorithm(t *testing.T) {

--- a/pkg/httpcheck/check_test.go
+++ b/pkg/httpcheck/check_test.go
@@ -86,12 +86,12 @@ func TestHTTPCheck(t *testing.T) {
 		// Request body
 		{"body string sent", Check{URL: "http://localhost/api", Method: "POST", Body: `{"key": "value"}`, Client: &testutil.MockHTTPClient{DoFunc: func(req *http.Request) (*http.Response, error) {
 			body, _ := io.ReadAll(req.Body)
-			assert.Equal(t, `{"key": "value"}`, string(body))
+			assert.JSONEq(t, `{"key": "value"}`, string(body))
 			return testutil.MockResponse(200, ""), nil
 		}}}, check.StatusOK, ""},
 		{"body-file sent", Check{URL: "http://localhost/api", Method: "POST", BodyFile: "/tmp/request.json", FileReader: &mockFileReader{Files: map[string][]byte{"/tmp/request.json": []byte(`{"from": "file"}`)}}, Client: &testutil.MockHTTPClient{DoFunc: func(req *http.Request) (*http.Response, error) {
 			body, _ := io.ReadAll(req.Body)
-			assert.Equal(t, `{"from": "file"}`, string(body))
+			assert.JSONEq(t, `{"from": "file"}`, string(body))
 			return testutil.MockResponse(200, ""), nil
 		}}}, check.StatusOK, ""},
 		{"body-file not found", Check{URL: "http://localhost/api", Method: "POST", BodyFile: "/nonexistent/file.json", FileReader: &mockFileReader{Files: map[string][]byte{}}}, check.StatusFail, "failed to read body file"},

--- a/pkg/resourcecheck/resource_test.go
+++ b/pkg/resourcecheck/resource_test.go
@@ -15,7 +15,7 @@ func TestRealResourceChecker_FreeDiskSpace(t *testing.T) {
 
 	space, err := r.FreeDiskSpace(".")
 	require.NoError(t, err)
-	assert.Greater(t, space, uint64(0))
+	assert.Positive(t, space)
 
 	_, err = r.FreeDiskSpace("/nonexistent/path/that/does/not/exist")
 	assert.Error(t, err)
@@ -27,7 +27,7 @@ func TestRealResourceChecker_FreeDiskSpace_TempDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	space, err := r.FreeDiskSpace(tmpDir)
 	require.NoError(t, err)
-	assert.Greater(t, space, uint64(0))
+	assert.Positive(t, space)
 }
 
 func TestRealResourceChecker_AvailableMemory(t *testing.T) {
@@ -45,7 +45,7 @@ func TestRealResourceChecker_NumCPUs(t *testing.T) {
 
 func TestReadCgroupMemoryLimit(t *testing.T) {
 	_, err := readCgroupMemoryLimit("/nonexistent/path")
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	t.Run("numeric value", func(t *testing.T) {
 		tmpFile := writeTempFile(t, "8589934592")

--- a/pkg/tcpcheck/check_test.go
+++ b/pkg/tcpcheck/check_test.go
@@ -113,7 +113,7 @@ func TestTCPCheck(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, result.Status)
 			assert.Equal(t, tt.wantName, result.Name)
 			if tt.wantStatus == check.StatusFail {
-				assert.NotNil(t, result.Err)
+				assert.Error(t, result.Err)
 			}
 		})
 	}

--- a/pkg/usercheck/check_test.go
+++ b/pkg/usercheck/check_test.go
@@ -57,7 +57,7 @@ func TestUserCheck(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, result.Status)
 			assert.Equal(t, "user: "+tt.username, result.Name)
 			if tt.wantStatus == check.StatusFail {
-				assert.NotNil(t, result.Err)
+				assert.Error(t, result.Err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add testifylint to golangci-lint config to check for testify best practices
- Fix 11 existing issues detected by testifylint

Fixes include:
- Using `require` for error assertions to fail fast
- Using `assert.Positive` instead of `assert.Greater(x, 0)`
- Using `assert.JSONEq` for JSON string comparisons
- Using `assert.Error` instead of `assert.NotNil` for errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertions for better error validation and faster failure detection.
  * Updated assertion methods for consistency and clarity.
  * Enhanced JSON comparison testing for HTTP body validation.

* **Chores**
  * Added testifylint linter to enforce better testing practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->