### PR TITLE
Add automerge for CI-covered dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,5 +4,22 @@
   "ignorePresets": ["helpers:pinGitHubActionDigests"],
   "mode": "full",
   "prHourlyLimit": 10,
-  "labels": ["dependencies"]
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Automerge GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge linters, formatters, test tools, and Go",
+      "matchPackageNames": [
+        "golangci-lint",
+        "dprint",
+        "go",
+        "github.com/stretchr/testify"
+      ],
+      "automerge": true
+    }
+  ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,7 @@
     {
       "description": "Automerge GitHub Actions updates",
       "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true
     },
     {
@@ -19,6 +20,7 @@
         "go",
         "github.com/stretchr/testify"
       ],
+      "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }
   ]


### PR DESCRIPTION
## Summary
- Automerge GitHub Actions updates (all)
- Automerge linters (`golangci-lint`), formatters (`dprint`), test tools (`testify`), and Go version updates
- These are all well-covered by CI — lint, test, build, and container tests will catch breakage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update configuration to speed routine maintenance.
  * Added targeted auto-merge rules for minor/patch updates to development tools and CI-related packages, reducing manual PR handling.
  * Retained existing labels and rate limits so update visibility and cadence remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->