### PR TITLE
Pin govulncheck and drop the goimports dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
 
       - name: Check formatting (dprint)
-        run: dprint check
+        run: mise run check-md
 
       - name: Run golangci-lint
-        run: golangci-lint run
+        run: mise run lint
 
   test:
     name: Test
@@ -99,9 +99,7 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
 
       - name: Run govulncheck
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+        run: mise run security
 
   container-test:
     name: Container Test

--- a/.mise.toml
+++ b/.mise.toml
@@ -4,6 +4,7 @@ golangci-lint = "2.12.2"
 dprint = "0.55.2"
 hk = "1.54.1"
 pkl = "0.32.1"
+"go:golang.org/x/vuln/cmd/govulncheck" = "1.6.0"
 
 [tasks.build]
 description = "Build the preflight binary"
@@ -26,7 +27,7 @@ run = "golangci-lint run"
 
 [tasks.fmt]
 description = "Format code"
-run = "goimports -w ."
+run = "golangci-lint fmt"
 
 [tasks.fmt-md]
 description = "Format markdown files"


### PR DESCRIPTION
Follow-up to #206. Neither `goimports` nor `govulncheck` was declared anywhere, so `mise run fmt` and `mise run security` both failed with command-not-found on a clean checkout. CI papered over the second one with `go install golang.org/x/vuln/cmd/govulncheck@latest`, which pinned nothing.

**govulncheck** — now a pinned mise tool (`go:` backend, 1.6.0). CI and local runs get the same version, and Renovate's mise manager can track it.

**goimports** — dropped rather than pinned. `.golangci.yml` already declares `gofmt` and `goimports` under `formatters` with `local-prefixes: github.com/vertti/preflight`, so `golangci-lint fmt` does the same work using a tool that's already pinned at 2.12.2. The standalone binary was additionally ignoring `local-prefixes`, so it would have grouped imports differently from what the config asks for.

`golangci-lint fmt --diff` is empty against the current tree, so this is behavior-preserving here.

CI's lint and security jobs now call the mise tasks rather than repeating the commands. The test job is left alone — it uses `-coverpkg=./...`, which neither `test` nor `test-coverage` currently does, so reconciling those is a separate decision.