### PR TITLE
Align local coverage with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4
 
       - name: Run tests
-        run: go test -race -coverprofile=coverage.out -coverpkg=./... ./...
+        run: mise run test-coverage
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/.mise.toml
+++ b/.mise.toml
@@ -15,11 +15,13 @@ description = "Run tests with race detection"
 run = "go test -race ./..."
 
 [tasks.test-coverage]
-description = "Run tests with coverage report"
-run = [
-  "go test -race -coverprofile=coverage.out ./...",
-  "go tool cover -html=coverage.out -o coverage.html",
-]
+description = "Run tests and write coverage.out"
+run = "go test -race -coverprofile=coverage.out -coverpkg=./... ./..."
+
+[tasks.coverage-html]
+description = "Render coverage.out as a browsable HTML report"
+depends = ["test-coverage"]
+run = "go tool cover -html=coverage.out -o coverage.html"
 
 [tasks.lint]
 description = "Run linters"


### PR DESCRIPTION
Last follow-up from #206 / #207. CI ran `go test` with `-coverpkg=./...` while the `test-coverage` task omitted it, so the two disagreed:

| | total |
|---|---|
| `test-coverage` (local, before) | 92.9% |
| CI → codecov | 94.6% |

`-coverpkg=./...` attributes coverage from `integration_test.go` and the `cmd/preflight` tests back to the `pkg/*` packages. Without it that exercise looks uncovered. Since codecov gates at 75% project / 70% patch, the number you saw locally wasn't the number being gated on.

`test-coverage` now carries the flag and CI calls the task, so both produce an identical profile — verified locally at 94.6%.

HTML rendering moved out to a new `coverage-html` task that `depends = ["test-coverage"]`. CI only needs `coverage.out`, and this keeps the report a local convenience instead of work CI does and throws away. `mise run coverage-html` does what `mise run test-coverage` used to.