### PR TITLE
Fix file checks that silently passed

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -167,7 +167,7 @@ preflight file <path> [flags]
 | `--dir`                   | Expect a directory (fail if it's a file)             |
 | `--socket`                | Expect a Unix socket (e.g., docker.sock)             |
 | `--symlink`               | Expect a symbolic link                               |
-| `--symlink-target <path>` | Expected symlink target path                         |
+| `--symlink-target <path>` | Expected symlink target path (implies `--symlink`)   |
 | `--writable`              | Check write permission                               |
 | `--executable`            | Check execute permission                             |
 | `--not-empty`             | File must have size > 0                              |

--- a/pkg/filecheck/check.go
+++ b/pkg/filecheck/check.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/vertti/preflight/pkg/check"
@@ -31,6 +32,13 @@ type Check struct {
 	FS            FileSystem // injected for testing
 }
 
+// expectsSymlink reports whether the path should be checked as a symlink.
+// --symlink-target implies --symlink: without this the target was parsed and
+// then never compared, so the flag silently validated nothing.
+func (c *Check) expectsSymlink() bool {
+	return c.ExpectSymlink || c.SymlinkTarget != ""
+}
+
 // Run executes the file check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
@@ -40,7 +48,7 @@ func (c *Check) Run() check.Result {
 	// Use Lstat for symlink checks (doesn't follow symlinks), Stat otherwise
 	var info fs.FileInfo
 	var err error
-	if c.ExpectSymlink {
+	if c.expectsSymlink() {
 		info, err = c.FS.Lstat(c.Path)
 	} else {
 		info, err = c.FS.Stat(c.Path)
@@ -153,7 +161,7 @@ func (c *Check) checkModeExact(mode fs.FileMode, result *check.Result) error {
 func (c *Check) checkTypeConstraint(info fs.FileInfo, result *check.Result) error {
 	mode := info.Mode()
 
-	if c.ExpectSymlink {
+	if c.expectsSymlink() {
 		if !isSymlink(mode) {
 			err := errors.New("expected symlink, got file/directory")
 			result.Fail("expected symlink, got file/directory", err)
@@ -277,12 +285,13 @@ func (c *Check) checkOwner(result *check.Result) error {
 	return nil
 }
 
-// parseOctalMode parses an octal permission string like "0644" or "644"
+// parseOctalMode parses an octal permission string like "0644" or "644".
+// ParseUint rejects trailing garbage, which Sscanf("%o") accepted: "0o600"
+// consumed a single 0 and yielded mode 0, silently disabling the check.
 func parseOctalMode(s string) (fs.FileMode, error) {
-	var mode uint32
-	_, err := fmt.Sscanf(s, "%o", &mode)
+	mode, err := strconv.ParseUint(s, 8, 32)
 	if err != nil {
-		return 0, fmt.Errorf("invalid octal mode %q: %w", s, err)
+		return 0, fmt.Errorf("invalid octal mode %q: expected octal digits like 0644", s)
 	}
 	return fs.FileMode(mode), nil
 }

--- a/pkg/filecheck/check_test.go
+++ b/pkg/filecheck/check_test.go
@@ -177,6 +177,15 @@ func TestParseOctalMode(t *testing.T) {
 		{"0755", 0o755, false},
 		{"0600", 0o600, false},
 		{"invalid", 0, true},
+		// Trailing garbage must not be silently truncated: "0o600" is the Go
+		// and Python spelling and previously parsed as 0, which disables the
+		// permission check entirely.
+		{"0o600", 0, true},
+		{"0644xyz", 0, true},
+		{"600,", 0, true},
+		{"", 0, true},
+		{"999", 0, true},
+		{"-644", 0, true},
 	}
 
 	for _, tt := range tests {
@@ -188,6 +197,37 @@ func TestParseOctalMode(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.want, got)
 			}
+		})
+	}
+}
+
+func TestSymlinkTargetImpliesSymlinkCheck(t *testing.T) {
+	symlinkInfo := &mockFileInfo{NameValue: "link", ModeValue: fs.ModeSymlink | 0o777}
+	regularInfo := &mockFileInfo{NameValue: "f", ModeValue: 0o644}
+
+	tests := []struct {
+		name   string
+		info   fs.FileInfo
+		target string
+		want   check.Status
+	}{
+		{"target matches", symlinkInfo, "/real/target", check.StatusOK},
+		{"target differs", symlinkInfo, "/wrong/target", check.StatusFail},
+		{"not a symlink at all", regularInfo, "/real/target", check.StatusFail},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Check{
+				Path:          "link",
+				SymlinkTarget: tt.target,
+				FS: &mockFileSystem{
+					LstatFunc:    func(string) (fs.FileInfo, error) { return tt.info, nil },
+					StatFunc:     func(string) (fs.FileInfo, error) { return tt.info, nil },
+					ReadlinkFunc: func(string) (string, error) { return "/real/target", nil },
+				},
+			}
+			assert.Equal(t, tt.want, c.Run().Status)
 		})
 	}
 }


### PR DESCRIPTION
Two `file` flags returned `[OK]` on inputs they were supposed to reject. Both are silent fail-opens: the check reports success while validating nothing.

### `--mode` with a malformed octal string

`parseOctalMode` used `fmt.Sscanf(s, "%o", &mode)`, which stops at the first non-octal character and returns **no error** as long as one digit was consumed. `0o600` — the Go and Python spelling, and an easy thing to type — parsed to `0`. The minimum-permission test is then `actual & 0 != 0`, false for every file that has ever existed.

```
$ chmod 0000 key.pem
$ preflight file key.pem --mode 0o600
[OK] file: key.pem
     permissions: ----------
```

`docs/usage.md:197` recommends exactly this check for TLS private keys. `strconv.ParseUint(s, 8, 32)` rejects trailing garbage, empty input, non-octal digits and negatives.

After:
```
$ preflight file key.pem --mode 0o600
[FAIL] invalid mode: invalid octal mode "0o600": expected octal digits like 0644
$ preflight file key.pem --mode 600      # valid octal, still works
[OK] file: key.pem
```

### `--symlink-target` without `--symlink`

`SymlinkTarget` was only consulted inside the `if c.ExpectSymlink` branch, so on its own the flag parsed a target and never compared it:

```
$ ls -l link          # link -> f.txt
$ preflight file link --symlink-target /totally/wrong
[OK] file: link
```

It now implies `--symlink` — which is what the flag name claims — so the path is `Lstat`ed and the target compared. Nobody can be depending on the old behavior except by accident, since the old behavior was "do nothing".

### Tests

Added the failing cases first, confirmed red, then fixed:
- `TestParseOctalMode` gains `0o600`, `0644xyz`, `600,`, `""`, `999`, `-644`
- `TestSymlinkTargetImpliesSymlinkCheck` covers matching target, differing target, and a non-symlink

### Follow-up, not in this PR

`--mode` is a *minimum* check, so `--mode 0600` passes on a `0777` file. That is documented (`usage.md:179`) but it means the TLS-key example at `:197` cannot detect a world-readable key. Worth deciding separately whether that example should use `--mode-exact`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Specifying a symlink target now automatically validates that the target path is a symlink.
  * Symlink validation reports mismatched or non-symlink targets more reliably.

* **Bug Fixes**
  * Octal file mode values are now strictly validated, rejecting empty, negative, out-of-range, or malformed values.

* **Documentation**
  * Updated usage guidance to explain that `--symlink-target` enables symlink validation automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->