### PR TITLE
Refuse to exec when no check ran

### DIFF
--- a/cmd/preflight/cmd_run.go
+++ b/cmd/preflight/cmd_run.go
@@ -69,6 +69,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 			}
 			return fmt.Errorf("failed to execute command %q: %w", command, err)
 		}
+		checkRan = true
 	}
 
 	return nil

--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"slices"
 	"strings"
@@ -73,10 +74,15 @@ func extractExecArgs(args *[]string) []string {
 var executor exec.Executor = &exec.RealExecutor{}
 
 // runExec executes the command specified in execArgs.
-// Returns an error if the exec fails.
+// Returns an error if the exec fails, or if no check ran — handing control to
+// the target when nothing was verified would turn the gate into a no-op that
+// reports success.
 func runExec(execArgs []string) error {
 	if len(execArgs) == 0 {
 		return nil
+	}
+	if !checkRan {
+		return errors.New("refusing to exec: no check ran before --")
 	}
 	return executor.Exec(execArgs[0], execArgs[1:])
 }

--- a/cmd/preflight/main_test.go
+++ b/cmd/preflight/main_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/vertti/preflight/pkg/check"
 )
 
 func TestTransformArgsForHashbang(t *testing.T) {
@@ -113,10 +115,87 @@ func (m *mockExecutor) Exec(name string, args []string) error {
 	return nil
 }
 
+type passingChecker struct{}
+
+func (passingChecker) Run() check.Result {
+	return check.Result{Name: "stub", Status: check.StatusOK}
+}
+
+type failingChecker struct{}
+
+func (failingChecker) Run() check.Result {
+	return check.Result{Name: "stub", Status: check.StatusFail}
+}
+
+func TestRunExec_RequiresACheckToHaveRun(t *testing.T) {
+	originalExecutor := executor
+	originalCheckRan := checkRan
+	defer func() { executor = originalExecutor; checkRan = originalCheckRan }()
+
+	t.Run("refuses to exec when no check ran", func(t *testing.T) {
+		execCalled := false
+		executor = &mockExecutor{execFunc: func(string, []string) error {
+			execCalled = true
+			return nil
+		}}
+		checkRan = false
+
+		err := runExec([]string{"./myapp"})
+		if err == nil {
+			t.Fatal("runExec() = nil, want error when no check ran")
+		}
+		if execCalled {
+			t.Error("executor was called despite no check having run")
+		}
+	})
+
+	t.Run("execs when a check ran", func(t *testing.T) {
+		execCalled := false
+		executor = &mockExecutor{execFunc: func(string, []string) error {
+			execCalled = true
+			return nil
+		}}
+		checkRan = true
+
+		if err := runExec([]string{"./myapp"}); err != nil {
+			t.Fatalf("runExec() = %v, want nil", err)
+		}
+		if !execCalled {
+			t.Error("executor was not called after a successful check")
+		}
+	})
+
+	t.Run("no exec args is not an error even without a check", func(t *testing.T) {
+		checkRan = false
+		if err := runExec(nil); err != nil {
+			t.Errorf("runExec(nil) = %v, want nil", err)
+		}
+	})
+}
+
+func TestRunCheckRecordsThatItRan(t *testing.T) {
+	original := checkRan
+	defer func() { checkRan = original }()
+
+	checkRan = false
+	_ = runCheck(passingChecker{})
+	if !checkRan {
+		t.Error("runCheck did not record that a check ran")
+	}
+
+	checkRan = false
+	_ = runCheck(failingChecker{})
+	if !checkRan {
+		t.Error("runCheck did not record a failing check as having run")
+	}
+}
+
 func TestRunExec(t *testing.T) {
 	// Save original executor and restore after test
 	originalExecutor := executor
-	defer func() { executor = originalExecutor }()
+	originalCheckRan := checkRan
+	checkRan = true
+	defer func() { executor = originalExecutor; checkRan = originalCheckRan }()
 
 	t.Run("empty args returns nil", func(t *testing.T) {
 		err := runExec([]string{})

--- a/cmd/preflight/run.go
+++ b/cmd/preflight/run.go
@@ -15,9 +15,16 @@ type Checker interface {
 // ErrCheckFailed is returned when a check fails.
 var ErrCheckFailed = errors.New("check failed")
 
+// checkRan records that a check actually executed. Exec mode is gated on it:
+// the root command has no RunE, so `preflight -- ./app` and
+// `preflight --help -- ./app` reach the end of Execute() with a nil error,
+// which would otherwise be indistinguishable from "every check passed".
+var checkRan bool
+
 // runCheck executes a check, prints the result, and returns an error if failed.
 // The returned error causes Cobra to exit with code 1.
 func runCheck(c Checker) error {
+	checkRan = true
 	result := c.Run()
 	output.PrintResult(result)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1298,6 +1298,11 @@ CMD ["/myapp"]
 1. Preflight runs the check(s)
 2. If all checks pass, it execs into the command after `--`
 3. If any check fails, it exits with code 1 (command never runs)
+4. If no check ran at all, it exits with code 1 (command never runs)
+
+Step 4 matters when the check arguments are templated. `preflight -- /myapp` and
+`preflight --help -- /myapp` run no check, so preflight refuses to exec rather
+than starting the command with nothing verified.
 
 This works with any preflight command:
 


### PR DESCRIPTION
Exec mode fired even when no check had been performed, so a gate that verified nothing reported success and handed control to the target.

The root command has no `RunE`. Invoking it with no subcommand prints help and returns `nil`, which `runExec` read as "checks passed":

```
$ preflight -- ./payload.sh
<usage text>
PAYLOAD RAN
exit=0

$ preflight --help -- ./payload.sh
PAYLOAD RAN
exit=0
```

This bites when the check arguments are templated. An entrypoint like `ENTRYPOINT ["preflight", "tcp", "$DB:5432", "--", "/app/server"]` whose variable resolves empty starts the app with nothing verified, and the container reports healthy. "No checks ran" and "all checks passed" were indistinguishable.

### Fix

`runCheck` — the shared helper behind all 13 check commands — and the per-command loop in `preflight run` now record that a check actually executed. `runExec` requires it:

```
$ preflight -- ./payload.sh
exec: refusing to exec: no check ran before --
exit=1
```

Recording it per-command inside `run`'s loop rather than once at entry means an **empty or comments-only `.preflight` file also refuses to exec**, since no check ran there either. That was a separate silent no-op found in the review and it falls out of implementing the invariant honestly.

### Verified unchanged

| Invocation | Behavior |
|---|---|
| `preflight env HOME -- ./payload.sh` | execs, exit 0 |
| `preflight run -- ./payload.sh` | execs, exit 0 — the documented entrypoint at `usage.md:1291` |
| `preflight env NOPE -- ./payload.sh` | no exec, exit 1 (already correct) |
| `preflight -- ./payload.sh` | **no exec, exit 1** (was: exec, exit 0) |
| `preflight --help -- ./payload.sh` | **no exec, exit 1** (was: exec, exit 0) |
| empty `.preflight` + `run --` | **no exec, exit 1** (was: exec, exit 0) |

### Tests

Written first and confirmed red: `TestRunExec_RequiresACheckToHaveRun` asserts the executor is not called when no check ran, is called when one did, and that bare `runExec(nil)` is still not an error. `TestRunCheckRecordsThatItRan` pins that both passing and failing checks count as having run — a failing check must still block exec via its own path, not by looking like it never happened.