### PR TITLE
Make the cross-platform CI gate able to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,15 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-        run: go build -o bin/preflight-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/preflight || echo "Build skipped for ${{ matrix.goos }}/${{ matrix.goarch }}"
+        run: go build ./...
+
+      # go build skips _test.go, so it cannot see a mock behind the wrong build
+      # tag. go vet type-checks the tests too.
+      - name: Vet
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: go vet ./...
 
   upx-test:
     name: UPX Compression Test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,8 @@ When using syscalls/OS APIs:
 - Platform methods in `*_unix.go`, `*_windows.go`
 - Use `//go:build unix` for darwin/linux shared code
 - Unsupported features return errors, not panic
-- Test with: `GOOS=windows go build ./...`
+- Test with: `GOOS=windows go vet ./...` — `go build` skips `_test.go`, so it
+  won't catch a helper stranded behind the wrong build tag
 
 ## Adding New Commands
 

--- a/pkg/resourcecheck/check_test.go
+++ b/pkg/resourcecheck/check_test.go
@@ -9,6 +9,29 @@ import (
 	"github.com/vertti/preflight/pkg/check"
 )
 
+// Lives here rather than in resource_test.go, which is //go:build unix: the
+// mock has no platform dependency, and tagging it broke `GOOS=windows go vet`
+// for every test in this package.
+type mockResourceChecker struct {
+	freeDiskSpace   uint64
+	freeDiskErr     error
+	availableMemory uint64
+	availableMemErr error
+	numCPUs         int
+}
+
+func (m *mockResourceChecker) FreeDiskSpace(path string) (uint64, error) {
+	return m.freeDiskSpace, m.freeDiskErr
+}
+
+func (m *mockResourceChecker) AvailableMemory() (uint64, error) {
+	return m.availableMemory, m.availableMemErr
+}
+
+func (m *mockResourceChecker) NumCPUs() int {
+	return m.numCPUs
+}
+
 func TestResourceCheck_Run(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/resourcecheck/resource_test.go
+++ b/pkg/resourcecheck/resource_test.go
@@ -79,23 +79,3 @@ func writeTempFile(t *testing.T, content string) string {
 	require.NoError(t, tmpFile.Close())
 	return tmpFile.Name()
 }
-
-type mockResourceChecker struct {
-	freeDiskSpace   uint64
-	freeDiskErr     error
-	availableMemory uint64
-	availableMemErr error
-	numCPUs         int
-}
-
-func (m *mockResourceChecker) FreeDiskSpace(path string) (uint64, error) {
-	return m.freeDiskSpace, m.freeDiskErr
-}
-
-func (m *mockResourceChecker) AvailableMemory() (uint64, error) {
-	return m.availableMemory, m.availableMemErr
-}
-
-func (m *mockResourceChecker) NumCPUs() int {
-	return m.numCPUs
-}


### PR DESCRIPTION
The six `Build (os, arch)` contexts are **required** branch-protection checks that could not fail, and there was already a defect sitting behind them.

### The gate

```yaml
run: go build -o bin/preflight-${{ matrix.goos }}-${{ matrix.goarch }} ./cmd/preflight || echo "Build skipped for ${{ matrix.goos }}/${{ matrix.goarch }}"
```

Verified by adding a deliberate type error to `fs_windows.go`:

```
$ GOOS=windows go build -o bin/x ./cmd/preflight || echo "Build skipped for windows/amd64"
pkg/filecheck/fs_windows.go:36:38: cannot use "not an int" ... as int value
Build skipped for windows/amd64
exit=0                                    # ← required check goes green
```

### The defect it was hiding

`mockResourceChecker` was defined in `resource_test.go` (`//go:build unix`) but used from the untagged `check_test.go`. So the Windows *test* build has been broken:

```
$ GOOS=windows go build ./...     # what CLAUDE.md tells you to run
exit 0
$ GOOS=windows go vet ./...
vet: pkg/resourcecheck/check_test.go:18:59: undefined: mockResourceChecker
```

`go build` skips `_test.go` files, so the documented verification step is structurally incapable of catching this class of bug. Three layers — the documented check, the CI matrix, and lint/test — and none could see it.

### Changes

- Matrix runs `go build ./...` (all packages, not just `cmd/preflight`) and, critically, **`go vet ./...`**, which type-checks tests. No `|| echo`.
- `mockResourceChecker` moves to `check_test.go`. It has no platform dependency, and CLAUDE.md's own convention puts mocks there. Comment explains why it must stay untagged.
- CLAUDE.md's platform check becomes `GOOS=windows go vet ./...`, with the reason.

The dropped `-o bin/preflight-<goos>-<goarch>` output went nowhere — nothing in `ci.yml` uploaded or consumed it.

### Verified

All six targets vet clean after the move:

```
linux/amd64 ok   linux/arm64 ok   darwin/amd64 ok
darwin/arm64 ok  windows/amd64 ok windows/arm64 ok
```

And the new gate fails closed — re-introducing the type error gives `go build ./...` exit 1 and `go vet ./...` exit 1, where the old form gave exit 0.

### Follow-up

The `Security` (govulncheck) job is still not in the required-checks list, so a vulnerable dependency can merge. That's a repo setting rather than a file change, so it isn't in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation across supported platforms by checking both builds and test-aware static analysis.
  * Added platform-independent resource-checking test coverage, including configurable disk, memory, and CPU results and error scenarios.

* **Documentation**
  * Updated platform-specific testing guidance to use test-aware validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->