### PR TITLE
Stop dumping usage on every failed check

### DIFF
--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strings"
@@ -87,9 +89,32 @@ func runExec(execArgs []string) error {
 	return executor.Exec(execArgs[0], execArgs[1:])
 }
 
+// SilenceUsage and SilenceErrors are set because a failing check is the tool's
+// normal operating mode, not a usage mistake. Cobra treats any error from RunE
+// as a usage error and dumps the full flag list, which buried the one line that
+// mattered. reportExecuteError puts the usage output back for real usage errors.
 var rootCmd = &cobra.Command{
-	Use:     "preflight",
-	Short:   "Docker preflight checks for your runtime environment",
-	Long:    "Preflight is a CLI tool for running sanity checks on container and CI environments.",
-	Version: Version,
+	Use:           "preflight",
+	Short:         "Docker preflight checks for your runtime environment",
+	Long:          "Preflight is a CLI tool for running sanity checks on container and CI environments.",
+	Version:       Version,
+	SilenceUsage:  true,
+	SilenceErrors: true,
+}
+
+// reportExecuteError writes diagnostics for a failed Execute. A failed check has
+// already printed its [FAIL] line and needs nothing further; anything else is
+// the user getting the invocation wrong, where usage is what helps.
+func reportExecuteError(cmd *cobra.Command, err error, w io.Writer) {
+	if errors.Is(err, ErrCheckFailed) {
+		return
+	}
+
+	_, _ = fmt.Fprintln(w, "Error:", err)
+	if cmd == nil {
+		return
+	}
+	cmd.SetOut(w)
+	cmd.SetErr(w)
+	_ = cmd.Usage()
 }

--- a/cmd/preflight/main_entry.go
+++ b/cmd/preflight/main_entry.go
@@ -15,7 +15,11 @@ func main() {
 	// Extract exec args (everything after "--")
 	execArgs := extractExecArgs(&os.Args)
 
-	if err := rootCmd.Execute(); err != nil {
+	// ExecuteC returns the command that actually ran, so usage errors can show
+	// that command's usage rather than the root's.
+	cmd, err := rootCmd.ExecuteC()
+	if err != nil {
+		reportExecuteError(cmd, err, os.Stderr)
 		os.Exit(1)
 	}
 

--- a/cmd/preflight/main_test.go
+++ b/cmd/preflight/main_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 
 	"github.com/vertti/preflight/pkg/check"
 )
@@ -270,6 +275,48 @@ func TestRunExec(t *testing.T) {
 		err := runExec([]string{"./myapp"})
 		if !errors.Is(err, expectedErr) {
 			t.Errorf("runExec() = %v, want %v", err, expectedErr)
+		}
+	})
+}
+
+func TestReportExecuteError(t *testing.T) {
+	newCmd := func() *cobra.Command {
+		return &cobra.Command{Use: "demo", Short: "a demo", Run: func(*cobra.Command, []string) {}}
+	}
+
+	t.Run("a failed check prints nothing extra", func(t *testing.T) {
+		var buf bytes.Buffer
+		reportExecuteError(newCmd(), ErrCheckFailed, &buf)
+		if buf.Len() != 0 {
+			t.Errorf("got %q, want no output: [FAIL] was already printed", buf.String())
+		}
+	})
+
+	t.Run("a wrapped check failure also prints nothing", func(t *testing.T) {
+		var buf bytes.Buffer
+		reportExecuteError(newCmd(), fmt.Errorf("running check: %w", ErrCheckFailed), &buf)
+		if buf.Len() != 0 {
+			t.Errorf("got %q, want no output", buf.String())
+		}
+	})
+
+	t.Run("a usage error prints the message and the usage", func(t *testing.T) {
+		var buf bytes.Buffer
+		reportExecuteError(newCmd(), errors.New("unknown flag: --nope"), &buf)
+		out := buf.String()
+		if !strings.Contains(out, "unknown flag: --nope") {
+			t.Errorf("got %q, want the error message", out)
+		}
+		if !strings.Contains(out, "Usage:") {
+			t.Errorf("got %q, want usage for a usage error", out)
+		}
+	})
+
+	t.Run("survives a nil command", func(t *testing.T) {
+		var buf bytes.Buffer
+		reportExecuteError(nil, errors.New("boom"), &buf)
+		if !strings.Contains(buf.String(), "boom") {
+			t.Errorf("got %q, want the error message", buf.String())
 		}
 	})
 }


### PR DESCRIPTION
A failing check is preflight's normal operating mode. Cobra treats any error from `RunE` as a usage mistake, so every failure printed `Error: check failed` plus the command's entire flag list:

```
$ preflight env NOPE_XYZ
[FAIL] env: NOPE_XYZ
       not set
Error: check failed
Usage:
  preflight env <variable> [flags]
Flags:
      --allow-empty          pass if defined but empty
      ... 23 more flag lines ...
```

30 lines to say one thing. In a Docker `RUN` layer or a CI log — where stdout and stderr are merged — five failing checks bury the messages under ~150 lines of flag reference. The `Error: check failed` line is also pure redundancy; `[FAIL]` and exit 1 already said it.

### Change

`rootCmd` sets `SilenceUsage` and `SilenceErrors`. `main` routes the error through `reportExecuteError`, which distinguishes the two cases:

- **`ErrCheckFailed`** → nothing further. The `[FAIL]` line and exit 1 are the complete signal.
- **anything else** → message plus usage. Unknown flag, missing argument, bad flag combination — these are the user getting the invocation wrong, and usage is exactly what helps.

It uses `ExecuteC` rather than `Execute` so a usage error shows the *failing subcommand's* usage, not the root command's.

### Result

| Invocation | Before | After |
|---|---|---|
| `env NOPE_XYZ` | 30 lines | **2 lines** |
| `file /nonexistent` | 22 lines | **2 lines** |
| `cmd definitelynotreal` | 17 lines | **2 lines** |
| `env PATH --nope` (unknown flag) | 27 lines | 27 lines — unchanged |

Verified unaffected: `--version`, `--help`, unknown command, `run` with a missing `.preflight`, the exec refusal from #210, and the flag-combination error in `cmd_json.go` — which now correctly shows the `json` command's usage.

### No doc change needed

`docs/usage.md`'s "Output Format" section already showed clean `[OK]`/`[FAIL]` blocks with no usage dump. The docs described the intended behavior all along; this makes the binary match them.

### Tests

`TestReportExecuteError`, written first and confirmed red, covers: a bare `ErrCheckFailed` prints nothing; a **wrapped** `ErrCheckFailed` also prints nothing (so the behavior survives future `%w` wrapping); a usage error prints both message and usage; and a nil command doesn't panic.