### PR TITLE
Fix documented flags that don't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ COPY --from=ghcr.io/vertti/preflight:latest /preflight /usr/local/bin/preflight
 RUN preflight cmd node --min 18.0        # verify binary + version
 RUN preflight env DATABASE_URL           # env var exists
 RUN preflight file /app/config.yaml      # file exists
-RUN preflight tcp postgres:5432 --retry 5 --retry-interval 2s  # wait for DB
+RUN preflight tcp postgres:5432 --timeout 5s  # reachable?
 
 HEALTHCHECK CMD ["/preflight", "http", "http://localhost:8080/health"]
 ```
@@ -30,7 +30,7 @@ Pre-flight checks for containers: verify services, environment, dependencies. Ea
 - **One command, multiple checks** — `preflight cmd node --min 18.0` verifies: on PATH, actually runs, returns version, meets constraint
 - **Works without a shell** — Runs in distroless/scratch, no shell required
 - **Container-aware** — Reads cgroup limits, not just host /proc/meminfo
-- **Version constraints** — `--min ^1.0` uses semver, not string comparison
+- **Version constraints** — `--min 1.0` and `--range '^1.0'` use semver, not string comparison
 
 ```
 [OK] cmd: node
@@ -83,8 +83,8 @@ Preflight also helps when you need:
 <details>
 <summary><b>Does this add bloat/attack surface?</b></summary>
 
-- 2MB binary (Linux), no C dependencies
-- 3 direct dependencies (cobra, semver, x/term)
+- 2.5MB binary (Linux, UPX-compressed), no C dependencies
+- 5 runtime dependencies (cobra, pflag, semver, x/sys, x/term)
 - Security scans on every commit (govulncheck, gosec)
 - Auto-updated via Renovate
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,19 +6,21 @@ This roadmap is organized by **real-world frequency** based on analysis of ~500 
 
 These commands replace extremely common shell patterns found in virtually every production setup.
 
-| Command              | Tools/Patterns Replaced                                       | Frequency  |
-| -------------------- | ------------------------------------------------------------- | ---------- |
-| `preflight tcp`      | wait-for-it.sh (9.7k stars), dockerize (4.8k stars), `nc -z`  | ⭐⭐⭐⭐⭐ |
-| `preflight user`     | `id -u` checks, gosu privilege dropping, every official image | ⭐⭐⭐⭐⭐ |
-| `preflight sys`      | `uname -m \| sed`, `dpkg --print-architecture`, TARGETARCH    | ⭐⭐⭐⭐⭐ |
-| `preflight cmd`      | `which`, `command -v`, version parsing scripts                | ⭐⭐⭐⭐⭐ |
-| `preflight env`      | `test -z "$VAR"`, parameter expansion checks                  | ⭐⭐⭐⭐⭐ |
-| `preflight file`     | `test -f`, `-d`, `-r`, `-S` socket, `-L` symlink, ownership   | ⭐⭐⭐⭐⭐ |
-| `preflight http`     | `curl --fail`, `wget --spider`, healthcheck scripts           | ⭐⭐⭐⭐   |
-| `preflight hash`     | `sha256sum -c`, GPG verification scripts                      | ⭐⭐⭐⭐   |
-| `preflight git`      | `git status --porcelain`, `git diff --exit-code`, CI checks   | ⭐⭐⭐⭐   |
-| `preflight resource` | `df`, cgroup memory limits, `nproc`                           | ⭐⭐⭐⭐   |
-| `preflight json`     | `jq empty`, JSON validation, key extraction                   | ⭐⭐⭐⭐   |
+| Command                | Tools/Patterns Replaced                                       | Frequency  |
+| ---------------------- | ------------------------------------------------------------- | ---------- |
+| `preflight tcp`        | wait-for-it.sh (9.7k stars), dockerize (4.8k stars), `nc -z`  | ⭐⭐⭐⭐⭐ |
+| `preflight user`       | `id -u` checks, gosu privilege dropping, every official image | ⭐⭐⭐⭐⭐ |
+| `preflight sys`        | `uname -m \| sed`, `dpkg --print-architecture`, TARGETARCH    | ⭐⭐⭐⭐⭐ |
+| `preflight cmd`        | `which`, `command -v`, version parsing scripts                | ⭐⭐⭐⭐⭐ |
+| `preflight env`        | `test -z "$VAR"`, parameter expansion checks                  | ⭐⭐⭐⭐⭐ |
+| `preflight file`       | `test -f`, `-d`, `-r`, `-S` socket, `-L` symlink, ownership   | ⭐⭐⭐⭐⭐ |
+| `preflight http`       | `curl --fail`, `wget --spider`, healthcheck scripts           | ⭐⭐⭐⭐   |
+| `preflight hash`       | `sha256sum -c`, GPG verification scripts                      | ⭐⭐⭐⭐   |
+| `preflight git`        | `git status --porcelain`, `git diff --exit-code`, CI checks   | ⭐⭐⭐⭐   |
+| `preflight resource`   | `df`, cgroup memory limits, `nproc`                           | ⭐⭐⭐⭐   |
+| `preflight json`       | `jq empty`, JSON validation, key extraction                   | ⭐⭐⭐⭐   |
+| `preflight prometheus` | `curl /metrics \| grep`, PromQL smoke checks                  | ⭐⭐⭐     |
+| `preflight run`        | shell scripts chaining many checks                            | ⭐⭐⭐     |
 
 ---
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -30,13 +30,17 @@ Run `mise tasks` to list all available tasks.
 
 ```
 preflight/
-  cmd/preflight/     # CLI entrypoint
+  cmd/preflight/     # CLI entrypoint, one cmd_<name>.go per subcommand
   pkg/
-    check/           # Core types (Result, Status)
-    cmdcheck/        # Command/binary checks
-    envcheck/        # Environment variable checks
-    filecheck/       # File and directory checks
+    check/           # Core types (Result, Status) shared by every check
+    <name>check/     # One package per subcommand: cmd, env, file, git, hash,
+                     # http, json, prom, resource, sys, tcp, user
+    exec/            # exec() passthrough for entrypoint mode
+    jsonpath/        # Minimal JSON path lookup used by json and http
+    output/          # Result rendering, colour and CI detection
+    preflightfile/   # .preflight file discovery and parsing
     version/         # Version parsing and comparison
+    testutil/        # Shared test helpers
 ```
 
 ## Workflow

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -101,20 +101,29 @@ preflight env <variable> [flags]
 
 ### Flags
 
-| Flag                  | Description                                      |
-| --------------------- | ------------------------------------------------ |
-| `--required`          | Fail if not set (allows empty values)            |
-| `--match <pattern>`   | Regex pattern to match against value             |
-| `--exact <value>`     | Exact value required                             |
-| `--one-of <values>`   | Value must be one of these (comma-separated)     |
-| `--starts-with <str>` | Value must start with string                     |
-| `--ends-with <str>`   | Value must end with string                       |
-| `--contains <str>`    | Value must contain substring                     |
-| `--is-numeric`        | Value must be a valid number                     |
-| `--min-len <n>`       | Minimum string length                            |
-| `--max-len <n>`       | Maximum string length                            |
-| `--hide-value`        | Don't show value in output                       |
-| `--mask-value`        | Show first/last 3 chars only (e.g., `sk-•••xyz`) |
+| Flag                  | Description                                            |
+| --------------------- | ------------------------------------------------------ |
+| `--allow-empty`       | Pass if the variable is defined but empty              |
+| `--not-set`           | Variable must not be set                               |
+| `--match <pattern>`   | Regex pattern to match against value                   |
+| `--exact <value>`     | Exact value required                                   |
+| `--one-of <values>`   | Value must be one of these (comma-separated)           |
+| `--starts-with <str>` | Value must start with string                           |
+| `--ends-with <str>`   | Value must end with string                             |
+| `--contains <str>`    | Value must contain substring                           |
+| `--is-numeric`        | Value must be a valid number                           |
+| `--is-bool`           | Boolean (`true`/`false`/`1`/`0`/`yes`/`no`/`on`/`off`) |
+| `--is-port`           | Valid TCP port (1-65535)                               |
+| `--is-url`            | Valid URL                                              |
+| `--is-json`           | Valid JSON                                             |
+| `--is-file`           | Path to an existing file                               |
+| `--is-dir`            | Path to an existing directory                          |
+| `--min-value <n>`     | Minimum numeric value (use with `--is-numeric`)        |
+| `--max-value <n>`     | Maximum numeric value (use with `--is-numeric`)        |
+| `--min-len <n>`       | Minimum string length                                  |
+| `--max-len <n>`       | Maximum string length                                  |
+| `--hide-value`        | Don't show value in output                             |
+| `--mask-value`        | Show first/last 3 chars only (e.g., `sk-•••xyz`)       |
 
 ### Examples
 
@@ -123,7 +132,10 @@ preflight env <variable> [flags]
 preflight env MODEL_PATH
 
 # Allow empty values (just check if defined)
-preflight env OPTIONAL_CONFIG --required
+preflight env OPTIONAL_CONFIG --allow-empty
+
+# Assert a variable is absent
+preflight env AWS_ACCESS_KEY_ID --not-set
 
 # Pattern matching
 preflight env MODEL_PATH --match '^/models/'
@@ -653,15 +665,20 @@ preflight http <url> [flags]
 
 ### Flags
 
-| Flag                   | Description                         |
-| ---------------------- | ----------------------------------- |
-| `--status <code>`      | Expected HTTP status (default: 200) |
-| `--timeout <duration>` | Request timeout (default: 5s)       |
-| `--retry <n>`          | Retry count on failure              |
-| `--retry-delay <dur>`  | Delay between retries (default: 1s) |
-| `--method <method>`    | HTTP method: GET or HEAD            |
-| `--header <key:value>` | Custom header (can be repeated)     |
-| `--insecure`           | Skip TLS certificate verification   |
+| Flag                   | Description                             |
+| ---------------------- | --------------------------------------- |
+| `--status <code>`      | Expected HTTP status (default: 200)     |
+| `--timeout <duration>` | Request timeout (default: 5s)           |
+| `--retry <n>`          | Retry count on failure                  |
+| `--retry-delay <dur>`  | Delay between retries (default: 1s)     |
+| `--method <method>`    | HTTP method (GET, POST, PUT, etc.)      |
+| `--header <key:value>` | Custom header (can be repeated)         |
+| `--body <string>`      | Request body                            |
+| `--body-file <path>`   | Read request body from a file           |
+| `--contains <string>`  | Response body must contain string       |
+| `--json-path <expr>`   | JSON assertion (`path` or `path=value`) |
+| `--follow-redirects`   | Follow HTTP redirects (3xx)             |
+| `--insecure`           | Skip TLS certificate verification       |
 
 ### Examples
 
@@ -691,7 +708,7 @@ preflight http https://internal-service/health --insecure
 
 ### Redirect Handling
 
-Redirects are **not followed** automatically. If the server returns a 3xx status, that status is checked against `--status`. This matches `curl --fail` behavior.
+Redirects are **not followed** by default. If the server returns a 3xx status, that status is checked against `--status`. This matches `curl --fail` behavior. Pass `--follow-redirects` to follow them instead.
 
 ```sh
 # This fails if server returns 302
@@ -763,8 +780,11 @@ preflight hash <file> [flags]
 | Flag                     | Description                                      |
 | ------------------------ | ------------------------------------------------ |
 | `--sha256 <hash>`        | Expected SHA256 hash (64 hex characters)         |
+| `--sha384 <hash>`        | Expected SHA384 hash (96 hex characters)         |
 | `--sha512 <hash>`        | Expected SHA512 hash (128 hex characters)        |
-| `--md5 <hash>`           | Expected MD5 hash (32 hex characters)            |
+| `--sha1 <hash>`          | Expected SHA1 hash (legacy, weak)                |
+| `--md5 <hash>`           | Expected MD5 hash (32 hex characters, weak)      |
+| `--auto <hash>`          | Expected hash, algorithm detected by length      |
 | `--checksum-file <path>` | Verify against checksum file (GNU or BSD format) |
 
 ### Examples
@@ -1232,7 +1252,7 @@ docker run myapp:latest sh -c '
 
 ## Keeping Containers Clean
 
-The examples above copy preflight into your final image, which adds ~6MB. Here are two patterns to keep your production images lean.
+The examples above copy preflight into your final image, which adds ~2.5MB. Here are two patterns to keep your production images lean.
 
 ### External Validation
 
@@ -1284,7 +1304,7 @@ COPY --from=ghcr.io/vertti/preflight:latest /preflight /preflight
 COPY myapp /myapp
 
 # Wait for postgres, then start app (no shell needed)
-ENTRYPOINT ["/preflight", "tcp", "postgres:5432", "--retry", "10", "--"]
+ENTRYPOINT ["/preflight", "tcp", "postgres:5432", "--timeout", "10s", "--"]
 CMD ["/myapp"]
 ```
 
@@ -1313,7 +1333,7 @@ This works with any preflight command:
 
 ```sh
 # Wait for database
-preflight tcp postgres:5432 --retry 10 -- ./myapp
+preflight tcp postgres:5432 --timeout 10s -- ./myapp
 
 # Check environment then start
 preflight env DATABASE_URL -- ./myapp


### PR DESCRIPTION
Every flag in `README.md` and `docs/usage.md` is now verified against the binary's `--help`. Four documented invocations failed outright.

### Broken copy-paste

| Location | Documented | Reality |
|---|---|---|
| `README.md:21` (Quick Start) | `tcp postgres:5432 --retry 5 --retry-interval 2s` | `unknown flag: --retry`. `tcp` has only `--timeout`; neither name exists on any command (`http`/`prometheus` use `--retry-delay`) |
| `README.md:33` (feature bullet) | `--min ^1.0` | `invalid version format: "^1.0"` — ranges need `--range` |
| `usage.md:106,126` | `env --required` | `unknown flag: --required` — it's `--allow-empty` |
| `usage.md:1282,1306` | `tcp ... --retry 10` in the distroless entrypoint recipe | same unknown flag |

The `tcp` examples now use `--timeout`, matching what `examples/runtime-checks-with-entrypoint/entrypoint.sh` already did correctly.

### 16 undocumented flags added

All verified present, with descriptions taken from `--help` rather than invented:

- **env** — `--not-set`, `--is-bool`, `--is-port`, `--is-url`, `--is-json`, `--is-file`, `--is-dir`, `--min-value`, `--max-value`
- **http** — `--body`, `--body-file`, `--contains`, `--json-path`, `--follow-redirects`
- **hash** — `--auto`, `--sha1`, `--sha384`

`--json-path` is pitched in `README.md:98` as a reason to use preflight over `curl | jq`, but was never listed in the http flag table. The "Redirect Handling" section also read as a hard limitation; it now mentions `--follow-redirects`.

### Size claims — corrected in the opposite direction from expected

My review flagged README's "2MB binary" as understated against a 6.9MB build. That was measuring the **uncompressed** binary. The release pipeline UPX-compresses before publishing and before the Docker build, so what users actually get is:

```
preflight-linux-amd64 (published):  2.5 MB
preflight-linux-arm64 (published):  2.2 MB
v0.18.0 image layers:               2.5 MB amd64 / 2.2 MB arm64
uncompressed build (not shipped):   6.9 MB
```

So README's "2MB" was roughly right, and `usage.md:1235`'s "adds ~6MB" was the inaccurate one — it overstated what copying preflight costs you by ~2.5×. Both now say 2.5MB.

Dependency count corrected too: "3 direct dependencies (cobra, semver, x/term)" → 5 runtime deps, since pflag and x/sys are also linked into the binary.

### Also

- `ROADMAP.md` "Already Implemented" was missing `prometheus` and `run`
- `docs/development.md` listed 5 of 18 packages

### Verification

Extracted every `--flag` token from both docs and diffed against the union of all 13 subcommands' `--help` output. The only remaining unmatched token is `--version`, which is a root-level flag and so absent from subcommand flag lists — confirmed working. The examples I changed were each executed against the binary.

Table realignment in the diff is dprint reformatting rows I edited, not separate formatting churn.

### Not fixed here

`tcp` genuinely has no retry, so "block until Postgres is up" still can't be expressed — `--timeout` bounds a single attempt rather than retrying a refused connection. That's a feature gap rather than doc drift, and worth deciding on separately.