### PR TITLE
Enforce --timeout when a command leaves a child running

### DIFF
--- a/pkg/cmdcheck/runner.go
+++ b/pkg/cmdcheck/runner.go
@@ -23,11 +23,19 @@ func (r *RealCmdRunner) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
 }
 
+// waitDelay bounds how long Wait blocks after the context is cancelled. Because
+// Stdout and Stderr are buffers rather than files, os/exec pipes them and waits
+// for EOF, but CommandContext kills only the direct child — a grandchild holding
+// the write end keeps the pipe open, so without this the timeout is
+// unenforceable and a version command that daemonizes hangs the check forever.
+const waitDelay = time.Second
+
 func (r *RealCmdRunner) RunCommandContext(ctx context.Context, name string, args ...string) (stdout, stderr string, err error) {
 	cmd := exec.CommandContext(ctx, name, args...) //nolint:gosec // intentional: executing user-specified version check commands
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
 	cmd.Stderr = &errBuf
+	cmd.WaitDelay = waitDelay
 	err = cmd.Run()
 	return outBuf.String(), errBuf.String(), err
 }

--- a/pkg/cmdcheck/runner_unix_test.go
+++ b/pkg/cmdcheck/runner_unix_test.go
@@ -1,0 +1,50 @@
+//go:build unix
+
+package cmdcheck
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A command that exits while a background child still holds the stdout pipe.
+// os/exec waits for the pipe to reach EOF, and CommandContext kills only the
+// direct child, so without WaitDelay the context deadline is unenforceable and
+// RunCommandContext blocks for as long as the grandchild lives.
+func TestRunCommandContext_ReturnsWhenGrandchildHoldsThePipe(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "daemonize.sh")
+	require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\nsleep 60 &\necho v1.0.0\n"), 0o700)) //nolint:gosec // the script must be executable to run
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		r := &RealCmdRunner{}
+		_, _, _ = r.RunCommandContext(ctx, script)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("RunCommandContext did not return; the 200ms timeout was not enforced")
+	}
+}
+
+// The ordinary path must be unaffected: a command that finishes normally still
+// returns its output rather than being cut off by WaitDelay.
+func TestRunCommandContext_NormalCommandStillReturnsOutput(t *testing.T) {
+	script := filepath.Join(t.TempDir(), "version.sh")
+	require.NoError(t, os.WriteFile(script, []byte("#!/bin/sh\necho v1.2.3\n"), 0o700)) //nolint:gosec // the script must be executable to run
+
+	r := &RealCmdRunner{}
+	stdout, _, err := r.RunCommandContext(context.Background(), script)
+	require.NoError(t, err)
+	require.Contains(t, stdout, "v1.2.3")
+}


### PR DESCRIPTION
`--timeout` was unenforceable against any version command that leaves a background child holding stdout. Measured with a script that backgrounds a `sleep` before exiting:

```
$ cat slowchild
#!/bin/sh
sleep 30 &
echo "v1.0.0"

$ time preflight cmd ./slowchild --timeout 2s
elapsed: 31s          # timeout was 2s
```

### Why

`Stdout`/`Stderr` are `bytes.Buffer`, not `*os.File`, so `os/exec` creates pipes and a copying goroutine, and `Wait` blocks until the pipe reaches EOF. `CommandContext` kills only the **direct** child — a grandchild holding the write end keeps the pipe open, so the deadline never takes effect.

In a container entrypoint this is worse than a failed check: a failure is reported and the container stops; a hang just sits there. Realistic triggers are version commands that daemonize — a service wrapper, a monitoring agent, a `docker` shim.

### Fix

`cmd.WaitDelay = time.Second`, which bounds how long `Wait` blocks after cancellation. Two lines including the constant.

```
before:  31s elapsed for a 2s timeout
after:    1s elapsed  (200ms deadline + 1s WaitDelay in the test; 2s + 1s via the CLI)
```

### Tests

`runner_unix_test.go`, written first and confirmed red — it hit the 15s bound and reported *"the 200ms timeout was not enforced"*, then passed in 1.11s after the fix.

Two cases:
- the grandchild-holds-the-pipe scenario, asserted via a generous 15s bound against a 60s child so it isn't timing-fragile
- a normal command still returns its output, so `WaitDelay` doesn't truncate healthy runs

Unix-tagged, since it needs a shell script. It's self-contained — no shared helpers cross the build tag, which is the mistake #213 fixed in `resourcecheck`.

### Note

`TestTCPCommand` fails on this branch. That's the `127.0.0.1:1` flake fixed in #217, which isn't merged yet — unrelated to this change, and this branch only touches `pkg/cmdcheck`.