### PR TITLE
Share one HTTP client and stop promcheck following redirects

### DIFF
--- a/cmd/preflight/cmd_http.go
+++ b/cmd/preflight/cmd_http.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/vertti/preflight/pkg/httpcheck"
+	"github.com/vertti/preflight/pkg/httpclient"
 )
 
 var (
@@ -70,7 +71,7 @@ func runHTTPCheck(_ *cobra.Command, args []string) error {
 		Contains:        httpContains,
 		FollowRedirects: httpFollowRedirects,
 		JSONPath:        httpJSONPath,
-		Client:          &httpcheck.RealHTTPClient{Timeout: httpTimeout, Insecure: httpInsecure, FollowRedirects: httpFollowRedirects},
+		Client:          &httpclient.Real{Timeout: httpTimeout, Insecure: httpInsecure, FollowRedirects: httpFollowRedirects},
 	}
 
 	return runCheck(c)

--- a/cmd/preflight/cmd_prometheus.go
+++ b/cmd/preflight/cmd_prometheus.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/vertti/preflight/pkg/httpclient"
 	"github.com/vertti/preflight/pkg/promcheck"
 )
 
@@ -71,7 +72,7 @@ func runPrometheusCheck(cmd *cobra.Command, args []string) error {
 		RetryDelay: promRetryDelay,
 		Insecure:   promInsecure,
 		Headers:    headers,
-		Client:     &promcheck.RealHTTPClient{Timeout: promTimeout, Insecure: promInsecure},
+		Client:     &httpclient.Real{Timeout: promTimeout, Insecure: promInsecure},
 	}
 
 	// Only set threshold pointers if flags were explicitly provided

--- a/integration_test.go
+++ b/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/vertti/preflight/pkg/gitcheck"
 	"github.com/vertti/preflight/pkg/hashcheck"
 	"github.com/vertti/preflight/pkg/httpcheck"
+	"github.com/vertti/preflight/pkg/httpclient"
 	"github.com/vertti/preflight/pkg/jsoncheck"
 	"github.com/vertti/preflight/pkg/resourcecheck"
 	"github.com/vertti/preflight/pkg/syscheck"
@@ -377,7 +378,7 @@ func TestIntegration_HTTP(t *testing.T) {
 
 	c := httpcheck.Check{
 		URL:    server.URL,
-		Client: &httpcheck.RealHTTPClient{Timeout: 5 * time.Second},
+		Client: &httpclient.Real{Timeout: 5 * time.Second},
 	}
 
 	result := c.Run()

--- a/pkg/httpcheck/check.go
+++ b/pkg/httpcheck/check.go
@@ -2,7 +2,6 @@ package httpcheck
 
 import (
 	"bytes"
-	"crypto/tls"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,42 +11,9 @@ import (
 	"time"
 
 	"github.com/vertti/preflight/pkg/check"
+	"github.com/vertti/preflight/pkg/httpclient"
 	"github.com/vertti/preflight/pkg/jsonpath"
 )
-
-// HTTPClient abstracts HTTP requests for testability.
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
-// RealHTTPClient uses the real net/http package.
-type RealHTTPClient struct {
-	Timeout         time.Duration
-	Insecure        bool
-	FollowRedirects bool
-}
-
-// Do executes an HTTP request.
-func (c *RealHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	transport := &http.Transport{}
-	if c.Insecure {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // intentional for --insecure flag
-	}
-
-	client := &http.Client{
-		Timeout:   c.Timeout,
-		Transport: transport,
-	}
-
-	// Disable automatic redirects unless explicitly enabled
-	if !c.FollowRedirects {
-		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
-	}
-
-	return client.Do(req)
-}
 
 // FileReader abstracts file reading for testability.
 type FileReader interface {
@@ -77,7 +43,7 @@ type Check struct {
 	Contains        string            // response body must contain this string
 	FollowRedirects bool              // follow HTTP redirects (3xx)
 	JSONPath        string            // JSON path to check (format: "path=expectedValue" or just "path")
-	Client          HTTPClient        // injected for testing
+	Client          httpclient.Client // injected for testing
 	FileReader      FileReader        // injected for testing
 }
 
@@ -117,7 +83,7 @@ func (c *Check) Run() check.Result {
 	// Initialize client if not injected
 	client := c.Client
 	if client == nil {
-		client = &RealHTTPClient{Timeout: timeout, Insecure: c.Insecure, FollowRedirects: c.FollowRedirects}
+		client = &httpclient.Real{Timeout: timeout, Insecure: c.Insecure, FollowRedirects: c.FollowRedirects}
 	}
 
 	// Resolve request body

--- a/pkg/httpcheck/check_test.go
+++ b/pkg/httpcheck/check_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -273,81 +272,6 @@ func TestHTTPCheckJSONPathRetry(t *testing.T) {
 		assert.Equal(t, check.StatusFail, result.Status)
 		assert.Equal(t, 2, attempts)
 		assert.Contains(t, strings.Join(result.Details, " "), "2 attempts")
-	})
-}
-
-func TestRealHTTPClient(t *testing.T) {
-	t.Run("basic request", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte("OK"))
-		}))
-		defer ts.Close()
-
-		client := &RealHTTPClient{Timeout: 5 * time.Second}
-		req, err := http.NewRequest(http.MethodGet, ts.URL, http.NoBody)
-		require.NoError(t, err)
-
-		resp, err := client.Do(req)
-		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
-		assert.Equal(t, 200, resp.StatusCode)
-	})
-
-	t.Run("insecure TLS", func(t *testing.T) {
-		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusOK)
-		}))
-		defer ts.Close()
-
-		client := &RealHTTPClient{Timeout: 5 * time.Second, Insecure: true}
-		req, err := http.NewRequest(http.MethodGet, ts.URL, http.NoBody)
-		require.NoError(t, err)
-
-		resp, err := client.Do(req)
-		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
-		assert.Equal(t, 200, resp.StatusCode)
-	})
-
-	t.Run("redirects disabled", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/redirect" {
-				http.Redirect(w, r, "/target", http.StatusFound)
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-		}))
-		defer ts.Close()
-
-		client := &RealHTTPClient{Timeout: 5 * time.Second, FollowRedirects: false}
-		req, err := http.NewRequest(http.MethodGet, ts.URL+"/redirect", http.NoBody)
-		require.NoError(t, err)
-
-		resp, err := client.Do(req)
-		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
-		assert.Equal(t, 302, resp.StatusCode)
-	})
-
-	t.Run("redirects enabled", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/redirect" {
-				http.Redirect(w, r, "/target", http.StatusFound)
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-		}))
-		defer ts.Close()
-
-		client := &RealHTTPClient{Timeout: 5 * time.Second, FollowRedirects: true}
-		req, err := http.NewRequest(http.MethodGet, ts.URL+"/redirect", http.NoBody)
-		require.NoError(t, err)
-
-		resp, err := client.Do(req)
-		require.NoError(t, err)
-		defer func() { _ = resp.Body.Close() }()
-		assert.Equal(t, 200, resp.StatusCode)
 	})
 }
 

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -1,0 +1,49 @@
+// Package httpclient provides the HTTP client shared by the checks that make
+// requests. It exists because httpcheck and promcheck each had their own copy:
+// the copies drifted, promcheck's never gained redirect protection, and it
+// forwarded custom auth headers to whatever host a 3xx named.
+package httpclient
+
+import (
+	"crypto/tls"
+	"net/http"
+	"time"
+)
+
+// Client abstracts HTTP requests for testability.
+type Client interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Real is a Client backed by net/http.
+type Real struct {
+	Timeout         time.Duration
+	Insecure        bool
+	FollowRedirects bool
+}
+
+// Do executes an HTTP request.
+//
+// Redirects are not followed unless FollowRedirects is set. Go strips
+// Authorization and Cookie when a redirect crosses hosts, but not custom
+// headers — and tenancy headers like X-Scope-OrgID are custom. Following a
+// redirect would also let the destination decide the check's verdict.
+func (c *Real) Do(req *http.Request) (*http.Response, error) {
+	transport := &http.Transport{}
+	if c.Insecure {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // intentional for --insecure flag
+	}
+
+	client := &http.Client{
+		Timeout:   c.Timeout,
+		Transport: transport,
+	}
+
+	if !c.FollowRedirects {
+		client.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+
+	return client.Do(req)
+}

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -1,0 +1,86 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReal(t *testing.T) {
+	t.Run("basic request", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+		}))
+		defer ts.Close()
+
+		client := &Real{Timeout: 5 * time.Second}
+		req, err := http.NewRequest(http.MethodGet, ts.URL, http.NoBody)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, 200, resp.StatusCode)
+	})
+
+	t.Run("insecure TLS", func(t *testing.T) {
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		client := &Real{Timeout: 5 * time.Second, Insecure: true}
+		req, err := http.NewRequest(http.MethodGet, ts.URL, http.NoBody)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, 200, resp.StatusCode)
+	})
+
+	t.Run("redirects disabled", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/redirect" {
+				http.Redirect(w, r, "/target", http.StatusFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		client := &Real{Timeout: 5 * time.Second, FollowRedirects: false}
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/redirect", http.NoBody)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, 302, resp.StatusCode)
+	})
+
+	t.Run("redirects enabled", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/redirect" {
+				http.Redirect(w, r, "/target", http.StatusFound)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		client := &Real{Timeout: 5 * time.Second, FollowRedirects: true}
+		req, err := http.NewRequest(http.MethodGet, ts.URL+"/redirect", http.NoBody)
+		require.NoError(t, err)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, 200, resp.StatusCode)
+	})
+}

--- a/pkg/promcheck/check.go
+++ b/pkg/promcheck/check.go
@@ -1,7 +1,6 @@
 package promcheck
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -12,34 +11,9 @@ import (
 	"time"
 
 	"github.com/vertti/preflight/pkg/check"
+	"github.com/vertti/preflight/pkg/httpclient"
 	"github.com/vertti/preflight/pkg/jsonpath"
 )
-
-// HTTPClient abstracts HTTP requests for testability.
-type HTTPClient interface {
-	Do(req *http.Request) (*http.Response, error)
-}
-
-// RealHTTPClient uses the real net/http package.
-type RealHTTPClient struct {
-	Timeout  time.Duration
-	Insecure bool
-}
-
-// Do executes an HTTP request.
-func (c *RealHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	transport := &http.Transport{}
-	if c.Insecure {
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // intentional for --insecure flag
-	}
-
-	client := &http.Client{
-		Timeout:   c.Timeout,
-		Transport: transport,
-	}
-
-	return client.Do(req)
-}
 
 // Check queries Prometheus and validates metric values.
 type Check struct {
@@ -53,7 +27,7 @@ type Check struct {
 	RetryDelay time.Duration     // delay between retries (default: 1s)
 	Insecure   bool              // skip TLS verification
 	Headers    map[string]string // custom headers (for auth)
-	Client     HTTPClient        // injected for testing
+	Client     httpclient.Client // injected for testing
 }
 
 // Run executes the Prometheus query check.
@@ -89,7 +63,7 @@ func (c *Check) Run() check.Result {
 	// Initialize client if not injected
 	client := c.Client
 	if client == nil {
-		client = &RealHTTPClient{Timeout: timeout, Insecure: c.Insecure}
+		client = &httpclient.Real{Timeout: timeout, Insecure: c.Insecure}
 	}
 
 	// Build query URL (trim trailing slash to avoid double slash)

--- a/pkg/promcheck/check_test.go
+++ b/pkg/promcheck/check_test.go
@@ -3,11 +3,14 @@ package promcheck
 import (
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/vertti/preflight/pkg/check"
+	"github.com/vertti/preflight/pkg/httpclient"
 	"github.com/vertti/preflight/pkg/testutil"
 )
 
@@ -150,4 +153,39 @@ func TestPrometheusCheckRetry(t *testing.T) {
 			})
 		}
 	})
+}
+
+// A Prometheus endpoint that redirects must not carry custom headers to the
+// new host. Go strips Authorization across domains but not custom headers, and
+// Mimir/Cortex/Thanos/Grafana Cloud carry tenancy in exactly those. Following
+// the redirect would also let the destination decide the pass/fail verdict.
+func TestRealHTTPClient_DoesNotFollowRedirects(t *testing.T) {
+	var leaked http.Header
+	attacker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		leaked = r.Header.Clone()
+		_, _ = w.Write([]byte(promSuccessVector))
+	}))
+	defer attacker.Close()
+
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		//nolint:gosec // G710: redirecting to another host is the attack being simulated
+		http.Redirect(w, r, attacker.URL+r.URL.Path, http.StatusFound)
+	}))
+	defer prometheus.Close()
+
+	c := Check{
+		URL:     prometheus.URL,
+		Query:   "up",
+		Exact:   testutil.Ptr(1.0),
+		Timeout: 2 * time.Second,
+		Headers: map[string]string{
+			"X-Scope-OrgID": "tenant-42",
+			"X-Api-Key":     "SUPERSECRET",
+		},
+		Client: &httpclient.Real{Timeout: 2 * time.Second},
+	}
+	result := c.Run()
+
+	assert.Nil(t, leaked, "credentials must not reach the redirect destination")
+	assert.Equal(t, check.StatusFail, result.Status, "a 302 is not a successful query")
 }


### PR DESCRIPTION
`httpcheck` and `promcheck` each defined their own `HTTPClient` and `RealHTTPClient`. The copies were identical **except** promcheck's never gained the `CheckRedirect` guard — so `preflight prometheus` followed 3xx responses anywhere, including to another host.

This is the clearest case in the review of duplication *causing* a security bug rather than merely being untidy, so removing the duplication is the fix.

### The leak

Go strips `Authorization` and `Cookie` when a redirect crosses hosts, but **not custom headers** — and Mimir, Cortex, Thanos and Grafana Cloud carry tenancy in exactly those. Reproduced with a Prometheus that 302s to a different server:

```
X-Api-Key: SUPERSECRET      → arrived at the redirect destination
X-Scope-OrgID: tenant-42    → arrived too
[OK]                        → verdict came from the attacker's response body
```

So the destination both harvested the credentials and decided the check passed. `promcheck` has no `--follow-redirects` flag, so there was no way to opt out either.

### Change

`pkg/httpclient` holds the single `Client` interface and `Real` implementation. Redirects are off unless `FollowRedirects` is set — what httpcheck already did, and promcheck did not. `httpcheck`'s `--follow-redirects` still works as an explicit opt-in.

```
-40 lines pkg/httpcheck/check.go
-32 lines pkg/promcheck/check.go
+48 lines pkg/httpclient/client.go   (one definition)
```

`InsecureSkipVerify` now appears exactly once in non-test code, where it previously appeared twice with two separate `//nolint:gosec` justifications.

### Tests

`TestRealHTTPClient_DoesNotFollowRedirects` was written first and confirmed red — it printed the leaked headers verbatim:

```
Expected nil, but got: http.Header{..., "X-Api-Key":[]string{"SUPERSECRET"},
                                       "X-Scope-Orgid":[]string{"tenant-42"}}
```

It asserts both that credentials don't reach the destination *and* that a 302 is not a passing verdict. The existing `RealHTTPClient` tests move to `pkg/httpclient` alongside the type — including the redirects-enabled case, so the opt-in path stays covered.

Suite green, `go vet` clean on linux/darwin/windows.