### PR TITLE
Stop .preflight lines escaping to other binaries

### DIFF
--- a/cmd/preflight/cmd_run.go
+++ b/cmd/preflight/cmd_run.go
@@ -53,9 +53,10 @@ func runRun(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
-		if parts[0] == "preflight" {
-			parts[0] = executable
-		}
+		// ParseFile guarantees the first token is exactly "preflight", so this
+		// always fires. Substituting unconditionally means a parser change can
+		// never turn a .preflight line into a path to some other binary.
+		parts[0] = executable
 
 		execCmd := exec.Command(parts[0], parts[1:]...) //nolint:gosec // intentional: executing commands from .preflight file
 		execCmd.Stdout = os.Stdout

--- a/pkg/preflightfile/preflightfile.go
+++ b/pkg/preflightfile/preflightfile.go
@@ -72,7 +72,11 @@ func ParseFile(path string) ([]string, error) {
 			continue
 		}
 
-		if !strings.HasPrefix(trimmed, "preflight") {
+		// Compare the first token, not the prefix. HasPrefix accepted anything
+		// beginning with "preflight" — including preflight/../evil.sh, a path
+		// that cmd_run then executed directly because its substitution tests
+		// for the exact token.
+		if fields := strings.Fields(trimmed); len(fields) == 0 || fields[0] != "preflight" {
 			trimmed = "preflight " + trimmed
 		}
 

--- a/pkg/preflightfile/preflightfile_test.go
+++ b/pkg/preflightfile/preflightfile_test.go
@@ -226,3 +226,33 @@ func TestFindFile_ReachFilesystemRoot(t *testing.T) {
 		t.Error("expected error when .preflight not found")
 	}
 }
+
+// The file format's contract is that every line runs preflight. The check was
+// HasPrefix, so any token merely starting with "preflight" satisfied it while
+// cmd_run's `parts[0] == "preflight"` substitution did not fire — letting a
+// line like preflight/../evil.sh run an arbitrary binary from the repo.
+func TestParseFile_OnlyExactPreflightTokenCountsAsPrefixed(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want string
+	}{
+		{"bare command gets prefixed", "env HOME", "preflight env HOME"},
+		{"already prefixed is left alone", "preflight env HOME", "preflight env HOME"},
+		{"path that starts with preflight is prefixed", "preflight/../evil.sh", "preflight preflight/../evil.sh"},
+		{"lookalike token is prefixed", "preflightfoo --bar", "preflight preflightfoo --bar"},
+		{"absolute path is prefixed", "/bin/sh -c whoami", "preflight /bin/sh -c whoami"},
+		{"relative path is prefixed", "./evil.sh", "preflight ./evil.sh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), ".preflight")
+			require.NoError(t, os.WriteFile(path, []byte(tt.line+"\n"), 0o600))
+
+			commands, err := ParseFile(path)
+			require.NoError(t, err)
+			require.Equal(t, []string{tt.want}, commands)
+		})
+	}
+}


### PR DESCRIPTION
A `.preflight` file could execute an arbitrary binary, contradicting the documented contract that every line runs `preflight`.

### The mismatch

Two checks disagreed about what "already prefixed" means:

| Location | Test |
|---|---|
| `preflightfile.go:75` | `strings.HasPrefix(trimmed, "preflight")` → don't prepend |
| `cmd_run.go:56` | `parts[0] == "preflight"` → substitute the real binary |

A token that *starts with* `preflight` but isn't equal to it satisfies the first and escapes the second. And because the token contains a slash, `exec.Command` skips `$PATH` and runs it relative to the working directory:

```
.preflight:
    env HOME
    preflight/../evil.sh

$ preflight run
[OK] env: HOME
PWNED: arbitrary code executed
```

`FindFile` discovers `.preflight` by walking up from the working directory, so `git clone && cd repo && preflight run` — or a CI step that does the same — is remote code execution from repo content.

### Fix

- **`ParseFile`** compares the first *token* rather than the prefix, so `preflight/../evil.sh` becomes `preflight preflight/../evil.sh` and resolves as an unknown subcommand.
- **`cmd_run`** substitutes the resolved preflight binary **unconditionally**. `ParseFile` now guarantees the token, so this always fired anyway — making it unconditional means a future parser change can't turn a line back into a path to some other program.

After: `exit=1`, and `PWNED` never appears. Normal files (comments, bare commands, explicitly-prefixed lines) are unchanged.

### Tests

Table written first, confirmed red on the escape cases: paths starting with `preflight`, lookalike tokens like `preflightfoo`, and absolute/relative paths all now get prefixed rather than executed.

### Related, not fixed here

The residual error from the exploit is `unknown command "echo"`, not `unknown command "preflight/../evil.sh"` — because `transformArgsForHashbang` saw an existing file as the first argument and rewrote the invocation to `run --file`, then parsed the payload script *as* a preflight file. Harmless now that lines can only invoke preflight, but it confirms the separate finding that any existing file passed as the first argument is treated as a preflight script, with no executable-bit or shebang check. That's the `knownSubcommands` issue — next PR.