### PR TITLE
Derive the subcommand list from cobra

### DIFF
--- a/cmd/preflight/main.go
+++ b/cmd/preflight/main.go
@@ -16,8 +16,26 @@ import (
 // Version is set at build time via ldflags
 var Version = "dev"
 
-// knownSubcommands lists all valid preflight subcommands
-var knownSubcommands = []string{"cmd", "env", "file", "git", "hash", "http", "json", "prometheus", "resource", "sys", "tcp", "user", "run", "version", "help", "--help", "-h"}
+// isKnownSubcommand reports whether name is one of preflight's own commands.
+// Derived from cobra rather than a hand-kept list: the list had drifted (it
+// named "version", which is not a command), and adding a command without
+// updating it meant a file of that name in the working directory would be
+// mistaken for a hashbang script.
+func isKnownSubcommand(name string) bool {
+	switch name {
+	case "help", "--help", "-h":
+		return true
+	}
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Name() == name {
+			return true
+		}
+		if slices.Contains(cmd.Aliases, name) {
+			return true
+		}
+	}
+	return false
+}
 
 // fileChecker abstracts file existence checks for testing
 type fileChecker func(path string) (isFile bool)
@@ -45,7 +63,7 @@ func transformArgsForHashbang(args []string, checkFile fileChecker) (newArgs []s
 	}
 
 	// Skip if it's a known subcommand
-	if slices.Contains(knownSubcommands, firstArg) {
+	if isKnownSubcommand(firstArg) {
 		return args, ""
 	}
 

--- a/cmd/preflight/main_test.go
+++ b/cmd/preflight/main_test.go
@@ -279,6 +279,46 @@ func TestRunExec(t *testing.T) {
 	})
 }
 
+// The set of subcommands must come from cobra rather than a hand-kept list.
+// The list had already drifted: it named "version", which is not a command, and
+// a command added without updating it would be mistaken for a script path
+// whenever a file of that name sat in the working directory.
+func TestKnownSubcommandsMatchesCobra(t *testing.T) {
+	for _, cmd := range rootCmd.Commands() {
+		name := cmd.Name()
+		t.Run(name, func(t *testing.T) {
+			if !isKnownSubcommand(name) {
+				t.Errorf("%q is a registered command but not recognized; a file named %q would hijack it", name, name)
+			}
+		})
+	}
+
+	t.Run("does not claim commands that do not exist", func(t *testing.T) {
+		registered := map[string]bool{}
+		for _, cmd := range rootCmd.Commands() {
+			registered[cmd.Name()] = true
+		}
+		// "version" was listed by hand but has never been a subcommand.
+		if isKnownSubcommand("version") && !registered["version"] {
+			t.Error(`"version" is recognized as a subcommand but is not registered with cobra`)
+		}
+	})
+
+	t.Run("help and flags still recognized", func(t *testing.T) {
+		for _, name := range []string{"help", "--help", "-h"} {
+			if !isKnownSubcommand(name) {
+				t.Errorf("%q should be recognized", name)
+			}
+		}
+	})
+
+	t.Run("an arbitrary word is not a subcommand", func(t *testing.T) {
+		if isKnownSubcommand("notes.txt") {
+			t.Error("notes.txt should not be treated as a subcommand")
+		}
+	})
+}
+
 func TestReportExecuteError(t *testing.T) {
 	newCmd := func() *cobra.Command {
 		return &cobra.Command{Use: "demo", Short: "a demo", Run: func(*cobra.Command, []string) {}}


### PR DESCRIPTION
`knownSubcommands` was a hand-maintained duplicate of cobra's command registry, consulted by `transformArgsForHashbang` to decide whether `argv[1]` is a command or a script path. It had already drifted:

```go
var knownSubcommands = []string{..., "run", "version", "help", "--help", "-h"}

$ preflight version
Error: unknown command "version" for "preflight"
```

### Why it matters

The failure mode is quiet. A contributor follows all five documented steps in CLAUDE.md for adding a command, misses this list (nothing points at it), and the new command is treated as a **script path** whenever a file of that name happens to sit in the working directory. The result is a parse error about the wrong thing rather than the check running.

The same shape bites typos today:

```
$ ls
fil                       # a file that happens to be named this
$ preflight fil /etc/hosts
Error: unknown command "/etc/hosts" for "preflight run"
```

The user typo'd `file`, and the message names neither their typo nor the file.

### Fix

`isKnownSubcommand` reads `rootCmd.Commands()`, so the two cannot disagree. Aliases are covered for free — the previous list had no way to express them.

A test iterates every registered command and asserts it's recognized, so replacing the derivation with a literal list again fails CI. Verified end-to-end: with a same-named file present for all 13 commands, each still dispatches to its command.

`"version"` is correctly no longer claimed as a subcommand, since it isn't one — `--version` is a root flag and still works.

### Deliberately not included

`transformArgsForHashbang` still treats **any** existing file as a preflight script, with no executable-bit or shebang check — so `preflight notes.txt` parses `notes.txt` as a check file. With #220 merged, a `.preflight` line can only ever invoke preflight itself, so this is no longer an execution risk, just a surprising behavior.

Requiring a `#!` first line would match the documented hashbang usage exactly (`docs/usage.md` shows `#!/usr/bin/env preflight` plus `chmod +x`, invoked as `./.preflight`). But `preflight <file>` is an undocumented path that currently works, so tightening it is a user-visible behavior change I'd rather you decide on than make silently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command recognition so newly available commands and aliases are handled automatically.
  * Preserved support for help flags while rejecting invalid words as commands.
* **Tests**
  * Added coverage to verify command recognition stays synchronized with the available command set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->