### PR TITLE
Test the .preflight command loop

### DIFF
--- a/cmd/preflight/cmd_run.go
+++ b/cmd/preflight/cmd_run.go
@@ -47,6 +47,29 @@ func runRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
 
+	exitCode, err := runCommands(commands, executable, spawn)
+	if err != nil {
+		return err
+	}
+	if exitCode != 0 {
+		os.Exit(exitCode)
+	}
+	return nil
+}
+
+// spawn runs one command with the parent's streams attached.
+func spawn(name string, args []string) error {
+	cmd := exec.Command(name, args...) //nolint:gosec // intentional: executing commands from .preflight file
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}
+
+// runCommands executes each .preflight command, returning the exit code to
+// propagate. run is injected so the loop — including the substitution below —
+// can be tested without spawning processes or calling os.Exit.
+func runCommands(commands []string, executable string, run func(name string, args []string) error) (exitCode int, err error) {
 	for _, command := range commands {
 		parts := strings.Fields(command)
 		if len(parts) == 0 {
@@ -58,20 +81,15 @@ func runRun(cmd *cobra.Command, args []string) error {
 		// never turn a .preflight line into a path to some other binary.
 		parts[0] = executable
 
-		execCmd := exec.Command(parts[0], parts[1:]...) //nolint:gosec // intentional: executing commands from .preflight file
-		execCmd.Stdout = os.Stdout
-		execCmd.Stderr = os.Stderr
-		execCmd.Stdin = os.Stdin
-
-		if err := execCmd.Run(); err != nil {
+		if err := run(parts[0], parts[1:]); err != nil {
 			var exitError *exec.ExitError
 			if errors.As(err, &exitError) {
-				os.Exit(exitError.ExitCode())
+				return exitError.ExitCode(), nil
 			}
-			return fmt.Errorf("failed to execute command %q: %w", command, err)
+			return 0, fmt.Errorf("failed to execute command %q: %w", command, err)
 		}
 		checkRan = true
 	}
 
-	return nil
+	return 0, nil
 }

--- a/cmd/preflight/cmd_run_test.go
+++ b/cmd/preflight/cmd_run_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -103,4 +105,28 @@ func TestRunCommands(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, checkRan)
 	})
+}
+
+// Reaches the wiring in runRun that the "nonexistent file" case returns before:
+// discovery, parsing, resolving the executable, and the zero-exit path. An
+// empty file runs no commands, so nothing is spawned.
+func TestRunRun_EmptyFileIsASuccessfulNoOp(t *testing.T) {
+	originalFile, originalRan := runFile, checkRan
+	defer func() { runFile, checkRan = originalFile, originalRan }()
+	runFile, checkRan = "", false
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".preflight"), []byte("# only a comment\n\n"), 0o600))
+	t.Chdir(dir)
+
+	require.NoError(t, runRun(nil, nil))
+	assert.False(t, checkRan, "no check ran, so exec mode must still refuse")
+}
+
+func TestRunRun_ReportsAMissingFile(t *testing.T) {
+	originalFile := runFile
+	defer func() { runFile = originalFile }()
+	runFile = filepath.Join(t.TempDir(), "absent")
+
+	require.Error(t, runRun(nil, nil))
 }

--- a/cmd/preflight/cmd_run_test.go
+++ b/cmd/preflight/cmd_run_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The loop that executes .preflight lines was untestable in-process because it
+// called os.Exit directly, so the substitution that keeps a line from naming
+// some other binary had no test at all.
+func TestRunCommands(t *testing.T) {
+	const exe = "/path/to/preflight"
+
+	t.Run("always runs the preflight binary, never a path from the file", func(t *testing.T) {
+		var gotName string
+		var gotArgs []string
+		_, err := runCommands([]string{"preflight env HOME"}, exe, func(name string, args []string) error {
+			gotName, gotArgs = name, args
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, exe, gotName)
+		assert.Equal(t, []string{"env", "HOME"}, gotArgs)
+	})
+
+	t.Run("substitutes even when the first token is a path", func(t *testing.T) {
+		// ParseFile should never produce this, so the assertion is that the
+		// second layer holds independently of the first.
+		var gotName string
+		_, err := runCommands([]string{"preflight/../evil.sh --pwn"}, exe, func(name string, _ []string) error {
+			gotName = name
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, exe, gotName, "a path in the file must not become the program")
+	})
+
+	t.Run("propagates a child's exit code", func(t *testing.T) {
+		failing := exec.Command("sh", "-c", "exit 42")
+		exitErr := failing.Run()
+		require.Error(t, exitErr)
+
+		code, err := runCommands([]string{"preflight env NOPE"}, exe, func(string, []string) error {
+			return exitErr
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 42, code)
+	})
+
+	t.Run("a non-exit failure is an error, not an exit code", func(t *testing.T) {
+		code, err := runCommands([]string{"preflight env HOME"}, exe, func(string, []string) error {
+			return errors.New("fork failed")
+		})
+		require.Error(t, err)
+		assert.Equal(t, 0, code)
+		assert.Contains(t, err.Error(), "preflight env HOME")
+	})
+
+	t.Run("stops at the first failing command", func(t *testing.T) {
+		calls := 0
+		failing := exec.Command("sh", "-c", "exit 3")
+		exitErr := failing.Run()
+
+		code, err := runCommands([]string{"preflight env A", "preflight env B", "preflight env C"}, exe,
+			func(string, []string) error {
+				calls++
+				if calls == 2 {
+					return exitErr
+				}
+				return nil
+			})
+		require.NoError(t, err)
+		assert.Equal(t, 3, code)
+		assert.Equal(t, 2, calls, "must not keep running after a failure")
+	})
+
+	t.Run("blank commands are skipped without running anything", func(t *testing.T) {
+		calls := 0
+		code, err := runCommands([]string{"", "   "}, exe, func(string, []string) error {
+			calls++
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 0, code)
+		assert.Equal(t, 0, calls)
+	})
+
+	t.Run("records that a check ran, but not for an empty file", func(t *testing.T) {
+		original := checkRan
+		defer func() { checkRan = original }()
+
+		checkRan = false
+		_, err := runCommands(nil, exe, func(string, []string) error { return nil })
+		require.NoError(t, err)
+		assert.False(t, checkRan, "an empty .preflight ran no check, so exec must still be refused")
+
+		checkRan = false
+		_, err = runCommands([]string{"preflight env HOME"}, exe, func(string, []string) error { return nil })
+		require.NoError(t, err)
+		assert.True(t, checkRan)
+	})
+}

--- a/cmd/preflight/cmd_run_unix_test.go
+++ b/cmd/preflight/cmd_run_unix_test.go
@@ -1,0 +1,36 @@
+//go:build unix
+
+package main
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runCommands distinguishes "the child failed" from "the child could not be
+// started" by testing for *exec.ExitError, so spawn has to produce that
+// distinction faithfully. Unix-tagged because it needs a real shell.
+func TestSpawn(t *testing.T) {
+	t.Run("a successful command returns nil", func(t *testing.T) {
+		require.NoError(t, spawn("/bin/sh", []string{"-c", "exit 0"}))
+	})
+
+	t.Run("a failing command returns its exit code", func(t *testing.T) {
+		err := spawn("/bin/sh", []string{"-c", "exit 42"})
+
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, err, &exitErr, "runCommands relies on this to propagate the code")
+		assert.Equal(t, 42, exitErr.ExitCode())
+	})
+
+	t.Run("a command that cannot start is not an exit error", func(t *testing.T) {
+		err := spawn("/nonexistent/binary", nil)
+
+		var exitErr *exec.ExitError
+		require.Error(t, err)
+		assert.NotErrorAs(t, err, &exitErr, "must surface as an error, not as exit code 0")
+	})
+}

--- a/cmd/preflight/execute_test.go
+++ b/cmd/preflight/execute_test.go
@@ -342,8 +342,9 @@ func TestGitCommand(t *testing.T) {
 }
 
 func TestRunCommand(t *testing.T) {
-	// Note: Most run command tests are in integration_test.go because
-	// runRun uses exec.Command which is hard to test in unit tests.
+	// The command loop is unit-tested in cmd_run_test.go against an injected
+	// runner; the real spawn and exit-code propagation are covered by
+	// TestIntegration_Run. This file only covers argument handling.
 	t.Run("nonexistent file", func(t *testing.T) {
 		_, err := executeCommand("run", "--file", "/nonexistent/.preflight")
 		assert.Error(t, err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -1,15 +1,20 @@
 package preflight_test
 
 import (
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/vertti/preflight/pkg/check"
 	"github.com/vertti/preflight/pkg/cmdcheck"
@@ -684,5 +689,68 @@ func TestIntegration_ExecMode(t *testing.T) {
 		if !strings.Contains(outputStr, "exec:") {
 			t.Errorf("expected exec error message, got: %s", outputStr)
 		}
+	})
+}
+
+// The unit tests in cmd_run_test.go cover the command loop with an injected
+// runner. This covers what they cannot: the real spawn, and exit-code
+// propagation through os.Exit.
+func TestIntegration_Run(t *testing.T) {
+	binaryPath := filepath.Join(t.TempDir(), "preflight")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, "./cmd/preflight") //nolint:gosec // intentional: building test binary
+	if output, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build preflight: %v\n%s", err, output)
+	}
+
+	run := func(t *testing.T, contents string) (string, int) {
+		t.Helper()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".preflight"), []byte(contents), 0o600))
+
+		cmd := exec.Command(binaryPath, "run")
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "NO_COLOR=1")
+		out, err := cmd.CombinedOutput()
+
+		code := 0
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			code = exitErr.ExitCode()
+		} else if err != nil {
+			t.Fatalf("run failed unexpectedly: %v\n%s", err, out)
+		}
+		return string(out), code
+	}
+
+	t.Run("runs every check in the file", func(t *testing.T) {
+		out, code := run(t, "env PATH\nenv HOME\n")
+		assert.Equal(t, 0, code)
+		assert.Contains(t, out, "[OK] env: PATH")
+		assert.Contains(t, out, "[OK] env: HOME")
+	})
+
+	t.Run("comments and blank lines are skipped", func(t *testing.T) {
+		out, code := run(t, "# a comment\n\nenv PATH\n")
+		assert.Equal(t, 0, code)
+		assert.Contains(t, out, "[OK] env: PATH")
+	})
+
+	t.Run("a failing check propagates exit 1 and stops", func(t *testing.T) {
+		out, code := run(t, "env PREFLIGHT_DEFINITELY_UNSET_XYZ\nenv PATH\n")
+		assert.Equal(t, 1, code)
+		assert.Contains(t, out, "[FAIL]")
+		assert.NotContains(t, out, "[OK] env: PATH", "must stop at the first failure")
+	})
+
+	t.Run("a line naming another binary does not run it", func(t *testing.T) {
+		out, code := run(t, "preflight/../evil.sh\n")
+		assert.NotEqual(t, 0, code)
+		assert.NotContains(t, out, "PWNED")
+	})
+
+	t.Run("explicit preflight prefix is accepted", func(t *testing.T) {
+		out, code := run(t, "preflight env PATH\n")
+		assert.Equal(t, 0, code)
+		assert.Contains(t, out, "[OK] env: PATH")
 	})
 }


### PR DESCRIPTION
`runRun` sat at **17.9%** coverage. The consequence wasn't abstract: the substitution that keeps a `.preflight` line from naming another binary — the second half of the fix in #220 — had **no test at all**. I verified it by running the exploit by hand, which is not the same thing, and then merged past `codecov/patch` flagging exactly that.

### Why it was untestable

The loop called `os.Exit(exitError.ExitCode())` inline, which cannot run in-process.

### Change

The loop moves to `runCommands`, which returns the exit code rather than calling `os.Exit`, and takes the spawn function as a parameter:

```go
func runCommands(commands []string, executable string, run func(name string, args []string) error) (exitCode int, err error)
```

`runRun` now does discovery, parsing, and `os.Exit`; `runCommands` does the logic.

| | before | after |
|---|---|---|
| `runCommands` (the logic) | — | **100%** |
| `runRun` | 17.9% | 27.8% — remainder is `os.Getwd`, `os.Executable`, `os.Exit` |
| total | 94.6% | 94.8% |

### Tests

Written first, confirmed red (`undefined: runCommands`). Seven cases, the first two being the ones that were missing:

- the preflight binary is always the program, never a path from the file
- **substitution holds even when the first token is a path** — so the second layer is verified independently of `ParseFile`
- a child's exit code propagates
- a non-exit failure is an error, not an exit code
- execution stops at the first failing command
- blank lines run nothing
- `checkRan` stays false for an empty file, so exec is still refused

`TestIntegration_Run` covers what unit tests can't — the real spawn and the exit code leaving the process — including that a line naming another binary doesn't run it, end to end against the built binary.

### A comment that was false

`execute_test.go` said *"Most run command tests are in integration_test.go"*. There were **zero** `preflight run` tests there — that's how the gap survived. It now describes where the tests actually are.

Also drops a `//nolint:gosec` that `nolintlint` flagged as unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `preflight run` handling of command failures and exit codes.
  * Execution stops after a failed check while preserving the correct failure status.
  * Blank lines and comments are ignored, and only intended executables are run.
  * Explicit command prefixes are supported consistently.
  * Empty configuration files complete successfully, while missing files report errors.

* **Tests**
  * Added coverage for command execution, failure handling, filtering, empty files, and end-to-end behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->