### PR TITLE
Fix --hide-value and --mask-value leaking on failure paths

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -125,6 +125,11 @@ preflight env <variable> [flags]
 | `--hide-value`        | Don't show value in output                             |
 | `--mask-value`        | Show first/last 3 chars only (e.g., `sk-•••xyz`)       |
 
+Both flags apply to failure messages as well as the success line, so a check
+that fails still won't print the value. Neither flag reveals the value's exact
+length: `--min-len 32` on a hidden value reports
+`value length [hidden] < minimum 32`.
+
 ### Examples
 
 ```sh

--- a/pkg/envcheck/check.go
+++ b/pkg/envcheck/check.go
@@ -117,7 +117,7 @@ func (c *Check) Run() check.Result {
 	if c.IsPort {
 		port, err := strconv.Atoi(value)
 		if err != nil || port < 1 || port > 65535 {
-			return result.Fail("value is not a valid port (1-65535)", fmt.Errorf("invalid port: %s", value))
+			return result.Fail("value is not a valid port (1-65535)", fmt.Errorf("invalid port: %s", c.formatValue(value)))
 		}
 	}
 
@@ -125,7 +125,7 @@ func (c *Check) Run() check.Result {
 	if c.IsURL {
 		u, err := url.Parse(value)
 		if err != nil || u.Scheme == "" || u.Host == "" {
-			return result.Fail("value is not a valid URL", fmt.Errorf("invalid URL: %s", value))
+			return result.Fail("value is not a valid URL", fmt.Errorf("invalid URL: %s", c.formatValue(value)))
 		}
 	}
 
@@ -139,7 +139,7 @@ func (c *Check) Run() check.Result {
 	// --is-bool: value must be boolean truthy value
 	if c.IsBool {
 		if !isValidBool(value) {
-			return result.Fail("value is not a valid boolean (true/false/1/0/yes/no/on/off)", fmt.Errorf("invalid boolean: %s", value))
+			return result.Fail("value is not a valid boolean (true/false/1/0/yes/no/on/off)", fmt.Errorf("invalid boolean: %s", c.formatValue(value)))
 		}
 	}
 
@@ -147,10 +147,10 @@ func (c *Check) Run() check.Result {
 	if c.IsFile {
 		info, err := c.Stater.Stat(value)
 		if err != nil {
-			return result.Fail("path does not exist", fmt.Errorf("path does not exist: %s", value))
+			return result.Fail("path does not exist", fmt.Errorf("path does not exist: %s", c.formatValue(value)))
 		}
 		if info.IsDir() {
-			return result.Fail("path is a directory, not a file", fmt.Errorf("path is a directory: %s", value))
+			return result.Fail("path is a directory, not a file", fmt.Errorf("path is a directory: %s", c.formatValue(value)))
 		}
 	}
 
@@ -158,10 +158,10 @@ func (c *Check) Run() check.Result {
 	if c.IsDir {
 		info, err := c.Stater.Stat(value)
 		if err != nil {
-			return result.Fail("path does not exist", fmt.Errorf("path does not exist: %s", value))
+			return result.Fail("path does not exist", fmt.Errorf("path does not exist: %s", c.formatValue(value)))
 		}
 		if !info.IsDir() {
-			return result.Fail("path is a file, not a directory", fmt.Errorf("path is not a directory: %s", value))
+			return result.Fail("path is a file, not a directory", fmt.Errorf("path is not a directory: %s", c.formatValue(value)))
 		}
 	}
 
@@ -172,7 +172,7 @@ func (c *Check) Run() check.Result {
 			return result.Fail("value is not numeric (required for --min-value)", errors.New("not numeric"))
 		}
 		if num < *c.MinValue {
-			return result.Failf("value %v < minimum %v", num, *c.MinValue)
+			return result.Failf("value %s < minimum %v", c.formatValue(value), *c.MinValue)
 		}
 	}
 
@@ -183,18 +183,18 @@ func (c *Check) Run() check.Result {
 			return result.Fail("value is not numeric (required for --max-value)", errors.New("not numeric"))
 		}
 		if num > *c.MaxValue {
-			return result.Failf("value %v > maximum %v", num, *c.MaxValue)
+			return result.Failf("value %s > maximum %v", c.formatValue(value), *c.MaxValue)
 		}
 	}
 
 	// --min-len: minimum string length
 	if c.MinLen > 0 && len(value) < c.MinLen {
-		return result.Failf("value length %d < minimum %d", len(value), c.MinLen)
+		return result.Failf("value length %s < minimum %d", c.formatLength(value), c.MinLen)
 	}
 
 	// --max-len: maximum string length
 	if c.MaxLen > 0 && len(value) > c.MaxLen {
-		return result.Failf("value length %d > maximum %d", len(value), c.MaxLen)
+		return result.Failf("value length %s > maximum %d", c.formatLength(value), c.MaxLen)
 	}
 
 	result.Status = check.StatusOK
@@ -210,6 +210,15 @@ func (c *Check) formatValue(value string) string {
 		return maskValue(value)
 	}
 	return value
+}
+
+// A length is a partial disclosure of the value, so both flags withhold it —
+// masking has no meaningful halfway point for a number.
+func (c *Check) formatLength(value string) string {
+	if c.HideValue || c.MaskValue {
+		return "[hidden]"
+	}
+	return strconv.Itoa(len(value))
 }
 
 func maskValue(value string) string {

--- a/pkg/envcheck/check_test.go
+++ b/pkg/envcheck/check_test.go
@@ -3,10 +3,12 @@ package envcheck
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/vertti/preflight/pkg/check"
 	"github.com/vertti/preflight/pkg/testutil"
@@ -165,5 +167,55 @@ func TestEnvCheck_Run(t *testing.T) {
 				assert.True(t, testutil.ContainsDetail(result.Details, tt.wantDetail), "details %v should contain %q", result.Details, tt.wantDetail)
 			}
 		})
+	}
+}
+
+// --hide-value and --mask-value are what make preflight safe to point at a
+// secret, so a failing check must not disclose the value — or its exact length
+// — on any path, and must not smuggle it out through Err either.
+func TestEnvCheck_HiddenValueNeverLeaks(t *testing.T) {
+	const secret = "pa55w0rd-xyz" // 12 characters, and contains no "12"
+	const numericSecret = "31415"
+
+	noFiles := &mockFileStater{Files: map[string]*mockFileInfo{}}
+
+	tests := []struct {
+		name      string
+		check     Check
+		forbidden string
+	}{
+		{"min-value", Check{Name: "COUNT", MinValue: testutil.Ptr(99999.0), Getter: env(map[string]string{"COUNT": numericSecret})}, numericSecret},
+		{"max-value", Check{Name: "COUNT", MaxValue: testutil.Ptr(1.0), Getter: env(map[string]string{"COUNT": numericSecret})}, numericSecret},
+		{"min-len", Check{Name: "SECRET", MinLen: 40, Getter: env(map[string]string{"SECRET": secret})}, "12"},
+		{"max-len", Check{Name: "SECRET", MaxLen: 3, Getter: env(map[string]string{"SECRET": secret})}, "12"},
+		{"is-port", Check{Name: "SECRET", IsPort: true, Getter: env(map[string]string{"SECRET": secret})}, secret},
+		{"is-url", Check{Name: "SECRET", IsURL: true, Getter: env(map[string]string{"SECRET": secret})}, secret},
+		{"is-bool", Check{Name: "SECRET", IsBool: true, Getter: env(map[string]string{"SECRET": secret})}, secret},
+		{"is-file", Check{Name: "SECRET", IsFile: true, Getter: env(map[string]string{"SECRET": secret}), Stater: noFiles}, secret},
+		{"is-dir", Check{Name: "SECRET", IsDir: true, Getter: env(map[string]string{"SECRET": secret}), Stater: noFiles}, secret},
+	}
+
+	hiders := []struct {
+		flag  string
+		apply func(*Check)
+	}{
+		{"hide-value", func(c *Check) { c.HideValue = true }},
+		{"mask-value", func(c *Check) { c.MaskValue = true }},
+	}
+
+	for _, tt := range tests {
+		for _, hider := range hiders {
+			t.Run(tt.name+" with --"+hider.flag, func(t *testing.T) {
+				c := tt.check
+				hider.apply(&c)
+
+				result := c.Run()
+
+				require.Equal(t, check.StatusFail, result.Status, "the case must fail for the assertion to mean anything")
+				assert.NotContains(t, strings.Join(result.Details, " "), tt.forbidden, "printed details disclosed the value")
+				require.Error(t, result.Err)
+				assert.NotContains(t, result.Err.Error(), tt.forbidden, "Err disclosed the value")
+			})
+		}
 	}
 }


### PR DESCRIPTION
`--hide-value` and `--mask-value` only covered the success line and a few failure messages. Four failure paths formatted the raw value directly:

```
$ SECRET=abcdefgh preflight env SECRET --min-len 32 --hide-value
[FAIL] env: SECRET
       value length 8 < minimum 32
```

`--min-value`/`--max-value` printed the value itself; `--min-len`/`--max-len` printed its exact length. A further five paths (`--is-port`, `--is-url`, `--is-bool`, `--is-file`, `--is-dir`) put the value in `Result.Err` — latent rather than live, since nothing renders `Err` today, but it is meant to become visible.

Every path now goes through `formatValue`, and a new `formatLength` withholds the length under either flag:

```
[FAIL] env: SECRET
       value length [hidden] < minimum 32
```

One incidental improvement: the numeric comparisons formatted the parsed float, so `--min-value` on `8675309` used to report `value 8.675309e+06`. They now use the original string.

Covered by `TestEnvCheck_HiddenValueNeverLeaks` — 9 failure paths × both flags, asserting the value appears in neither the details nor `Err`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hidden and masked value protection in validation errors and success output.
  * Prevented secret values and exact lengths from appearing in numeric, length, format, and filesystem validation messages.
  * Length-related failures now display `[hidden]` when value hiding or masking is enabled.

* **Documentation**
  * Clarified how `--hide-value` and `--mask-value` protect validation output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->