### PR TITLE
Fix memory limit detection under host cgroup namespaces and cgroup v1

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -943,7 +943,7 @@ RUN preflight sys --os linux --arch arm64
 
 Checks system resources meet minimum requirements. Critical for CI pipelines where runners have limited disk space, or containers with memory limits.
 
-> **Container-aware**: Memory checks read cgroup limits (v1 and v2), not just host `/proc/meminfo`. Your 512MB container limit is detected correctly.
+> **Container-aware**: Memory checks read cgroup limits (v1 and v2), not just host `/proc/meminfo`. Your 512MB container limit is detected correctly, including under `--cgroupns host`, where the limit lives further down the cgroup tree rather than at the root. Where limits nest, the tightest one wins. A limit larger than the machine's own memory is reported as the machine's memory, since the rest is not reachable.
 
 ```sh
 preflight resource [flags]

--- a/pkg/resourcecheck/resource_test.go
+++ b/pkg/resourcecheck/resource_test.go
@@ -3,7 +3,9 @@
 package resourcecheck
 
 import (
+	"errors"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,6 +69,182 @@ func TestReadCgroupMemoryLimit(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, uint64(4294967296), mem)
 	})
+
+	// cgroup v1 has no "max" keyword: an unlimited controller reports LONG_MAX
+	// rounded down to a page boundary, which is not a memory size anybody has.
+	t.Run("cgroup v1 unlimited sentinel is not a limit", func(t *testing.T) {
+		for _, sentinel := range []string{
+			"9223372036854771712", // 4 KiB pages
+			"9223372036854710272", // 64 KiB pages
+		} {
+			tmpFile := writeTempFile(t, sentinel)
+			mem, err := readCgroupMemoryLimit(tmpFile)
+			require.NoError(t, err)
+			assert.Equal(t, uint64(0), mem, "sentinel %s should read as unlimited", sentinel)
+		}
+	})
+}
+
+// Where a container's memory limit lives depends on its cgroup namespace: with
+// a private one it is at the root of /sys/fs/cgroup, but under `--cgroupns
+// host` the root belongs to the host and the container's own limit sits
+// further down the tree at the path named in /proc/self/cgroup.
+func TestCgroupPaths_MemoryLimit(t *testing.T) {
+	const gib = 1 << 30
+
+	tests := []struct {
+		name      string
+		self      string
+		files     map[string]string
+		want      uint64
+		wantFound bool
+	}{
+		{
+			name:      "v2 private namespace reads the root",
+			self:      "0::/\n",
+			files:     map[string]string{"memory.max": "2147483648"},
+			want:      2 * gib,
+			wantFound: true,
+		},
+		{
+			name: "v2 host namespace follows the path from /proc/self/cgroup",
+			self: "0::/system.slice/docker-abc123.scope\n",
+			files: map[string]string{
+				"memory.max": "max",
+				"system.slice/docker-abc123.scope/memory.max": "1073741824",
+			},
+			want:      gib,
+			wantFound: true,
+		},
+		{
+			name: "v2 takes the tightest limit in the chain",
+			self: "0::/system.slice/docker-abc123.scope\n",
+			files: map[string]string{
+				"memory.max":              "max",
+				"system.slice/memory.max": "1073741824",
+				"system.slice/docker-abc123.scope/memory.max": "4294967296",
+			},
+			want:      gib,
+			wantFound: true,
+		},
+		{
+			name: "v1 reads under the memory controller",
+			self: "9:memory:/docker/abc123\n8:cpu,cpuacct:/docker/abc123\n",
+			files: map[string]string{
+				"memory/docker/abc123/memory.limit_in_bytes": "536870912",
+			},
+			want:      536870912,
+			wantFound: true,
+		},
+		{
+			name: "v1 unlimited is not a limit",
+			self: "9:memory:/\n",
+			files: map[string]string{
+				"memory/memory.limit_in_bytes": "9223372036854771712",
+			},
+			wantFound: false,
+		},
+		{
+			name:      "no cgroup files means no limit",
+			self:      "0::/\n",
+			files:     nil,
+			wantFound: false,
+		},
+		{
+			name:      "an unreadable /proc/self/cgroup means no limit",
+			self:      "",
+			files:     map[string]string{"memory.max": "2147483648"},
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := buildCgroupTree(t, tt.self, tt.files)
+
+			limit, found := paths.memoryLimit()
+
+			assert.Equal(t, tt.wantFound, found)
+			if tt.wantFound {
+				assert.Equal(t, tt.want, limit)
+			}
+		})
+	}
+}
+
+func TestAvailableMemory(t *testing.T) {
+	const gib = 1 << 30
+	system := func(n uint64, err error) func() (uint64, error) {
+		return func() (uint64, error) { return n, err }
+	}
+
+	t.Run("reports the cgroup limit when it is the binding one", func(t *testing.T) {
+		paths := buildCgroupTree(t, "0::/\n", map[string]string{"memory.max": "1073741824"})
+
+		mem, err := availableMemory(paths, system(64*gib, nil))
+
+		require.NoError(t, err)
+		assert.Equal(t, uint64(gib), mem)
+	})
+
+	// A limit above the machine's own memory cannot be reached, so reporting it
+	// would overstate what is actually available.
+	t.Run("reports system memory when the cgroup limit exceeds it", func(t *testing.T) {
+		paths := buildCgroupTree(t, "0::/\n", map[string]string{"memory.max": "137438953472"})
+
+		mem, err := availableMemory(paths, system(64*gib, nil))
+
+		require.NoError(t, err)
+		assert.Equal(t, uint64(64*gib), mem)
+	})
+
+	t.Run("falls back to system memory when there is no cgroup", func(t *testing.T) {
+		paths := buildCgroupTree(t, "", nil)
+
+		mem, err := availableMemory(paths, system(64*gib, nil))
+
+		require.NoError(t, err)
+		assert.Equal(t, uint64(64*gib), mem)
+	})
+
+	t.Run("uses the cgroup limit when system memory is unavailable", func(t *testing.T) {
+		paths := buildCgroupTree(t, "0::/\n", map[string]string{"memory.max": "1073741824"})
+
+		mem, err := availableMemory(paths, system(0, errors.New("sysinfo failed")))
+
+		require.NoError(t, err)
+		assert.Equal(t, uint64(gib), mem)
+	})
+
+	t.Run("surfaces the error when neither source works", func(t *testing.T) {
+		paths := buildCgroupTree(t, "", nil)
+
+		_, err := availableMemory(paths, system(0, errors.New("sysinfo failed")))
+
+		require.Error(t, err)
+	})
+}
+
+// buildCgroupTree writes a fake /sys/fs/cgroup and /proc/self/cgroup so the
+// lookup can be exercised without a container. An empty self makes
+// /proc/self/cgroup unreadable.
+func buildCgroupTree(t *testing.T, self string, files map[string]string) cgroupPaths {
+	t.Helper()
+
+	dir := t.TempDir()
+	root := filepath.Join(dir, "cgroup")
+	for name, content := range files {
+		full := filepath.Join(root, name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o750))
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	}
+
+	selfFile := filepath.Join(dir, "self-cgroup")
+	if self != "" {
+		require.NoError(t, os.WriteFile(selfFile, []byte(self), 0o600))
+	}
+
+	return cgroupPaths{root: root, selfFile: selfFile}
 }
 
 func writeTempFile(t *testing.T, content string) string {

--- a/pkg/resourcecheck/resource_unix.go
+++ b/pkg/resourcecheck/resource_unix.go
@@ -4,6 +4,8 @@ package resourcecheck
 
 import (
 	"os"
+	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -22,21 +24,112 @@ func (r *RealResourceChecker) FreeDiskSpace(path string) (uint64, error) {
 // AvailableMemory returns available memory in bytes.
 // First checks cgroup limits (for containers), then falls back to system memory.
 func (r *RealResourceChecker) AvailableMemory() (uint64, error) {
-	// Try cgroup v2 first
-	if mem, err := readCgroupMemoryLimit("/sys/fs/cgroup/memory.max"); err == nil && mem > 0 {
-		return mem, nil
-	}
-
-	// Try cgroup v1
-	if mem, err := readCgroupMemoryLimit("/sys/fs/cgroup/memory/memory.limit_in_bytes"); err == nil && mem > 0 {
-		return mem, nil
-	}
-
-	// Fall back to system memory
-	return getSystemMemory()
+	paths := cgroupPaths{root: "/sys/fs/cgroup", selfFile: "/proc/self/cgroup"}
+	return availableMemory(paths, getSystemMemory)
 }
 
+// availableMemory reports the smaller of the machine's memory and the cgroup
+// limit the process runs under. A limit larger than the machine's memory is not
+// reachable, so it would overstate what a container can actually use.
+func availableMemory(paths cgroupPaths, systemMemory func() (uint64, error)) (uint64, error) {
+	system, err := systemMemory()
+
+	limit, limited := paths.memoryLimit()
+	switch {
+	case !limited:
+		return system, err
+	case err != nil || limit < system:
+		//nolint:nilerr // a cgroup limit answers the question on its own, so an
+		// unreadable system memory is not worth failing over
+		return limit, nil
+	default:
+		return system, nil
+	}
+}
+
+// cgroupPaths locates the cgroup filesystem and the process's own membership in
+// it. The fields exist so tests can point at a fixture tree.
+type cgroupPaths struct {
+	root     string // cgroup mount point, normally /sys/fs/cgroup
+	selfFile string // normally /proc/self/cgroup
+}
+
+// memoryLimit returns the tightest memory limit applying to this process.
+//
+// The limit is not always at the root of the mount: a container started with
+// `--cgroupns host` sees the host's whole cgroup tree, and its own limit sits
+// at the path named in /proc/self/cgroup. Limits also nest, so the effective
+// one is the smallest along the chain from that path up to the root.
+func (p cgroupPaths) memoryLimit() (uint64, bool) {
+	data, err := os.ReadFile(p.selfFile)
+	if err != nil {
+		return 0, false
+	}
+
+	var limit uint64
+	var found bool
+	for _, file := range p.limitFiles(string(data)) {
+		mem, err := readCgroupMemoryLimit(file)
+		if err != nil || mem == 0 {
+			continue
+		}
+		if !found || mem < limit {
+			limit, found = mem, true
+		}
+	}
+	return limit, found
+}
+
+// limitFiles expands /proc/self/cgroup into every limit file that could apply,
+// from the process's own cgroup up to the root of the hierarchy.
+func (p cgroupPaths) limitFiles(selfCgroup string) []string {
+	var files []string
+	for line := range strings.SplitSeq(selfCgroup, "\n") {
+		// Each line is hierarchy-ID:controller-list:cgroup-path.
+		fields := strings.SplitN(strings.TrimSpace(line), ":", 3)
+		if len(fields) != 3 {
+			continue
+		}
+		controllers, cgroup := fields[1], fields[2]
+
+		var dir, name string
+		switch {
+		case controllers == "": // cgroup v2 has a single unified hierarchy
+			dir, name = p.root, "memory.max"
+		case slices.Contains(strings.Split(controllers, ","), "memory"):
+			dir, name = filepath.Join(p.root, "memory"), "memory.limit_in_bytes"
+		default:
+			continue
+		}
+
+		for _, ancestor := range ancestors(cgroup) {
+			files = append(files, filepath.Join(dir, ancestor, name))
+		}
+	}
+	return files
+}
+
+// ancestors lists a cgroup path and every parent above it, ending at the root.
+func ancestors(cgroup string) []string {
+	if !strings.HasPrefix(cgroup, "/") {
+		cgroup = "/" + cgroup
+	}
+
+	paths := []string{cgroup}
+	for cgroup != "/" {
+		cgroup = filepath.Dir(cgroup)
+		paths = append(paths, cgroup)
+	}
+	return paths
+}
+
+// An unlimited cgroup v1 controller reports LONG_MAX rounded down to a page
+// boundary rather than a keyword, and the exact figure depends on the page
+// size. Anything in that neighbourhood is a sentinel, not a memory size.
+const unlimitedMemory = 1 << 62
+
 // readCgroupMemoryLimit reads memory limit from a cgroup file.
+// A zero result means the file says the memory is unlimited.
 func readCgroupMemoryLimit(path string) (uint64, error) {
 	data, err := os.ReadFile(path) //nolint:gosec // intentional: reading cgroup files
 	if err != nil {
@@ -50,5 +143,12 @@ func readCgroupMemoryLimit(path string) (uint64, error) {
 		return 0, nil
 	}
 
-	return strconv.ParseUint(content, 10, 64)
+	limit, err := strconv.ParseUint(content, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if limit >= unlimitedMemory {
+		return 0, nil
+	}
+	return limit, nil
 }


### PR DESCRIPTION
`AvailableMemory` read only `/sys/fs/cgroup/memory.max` and `/sys/fs/cgroup/memory/memory.limit_in_bytes` — the root of the mount. That is the right place only when the container has a private cgroup namespace.

Verified against real containers, before and after:

```
$ docker run --rm --memory 512m --cgroupns private ... preflight resource --min-memory 1MB
     memory: 512.0MB      # before and after

$ docker run --rm --memory 512m --cgroupns host ... preflight resource --min-memory 1MB
     memory: 22.9GB       # before — the host's memory
     memory: 512.0MB      # after
```

Under `--cgroupns host` the container sees the host's whole cgroup tree; the root cgroup is unlimited and the container's own limit sits at the path named in `/proc/self/cgroup`. So `preflight resource --min-memory 8GB` passed inside a 512MB container — a fail-open on the check's whole purpose.

## Changes

- Derive the cgroup path from `/proc/self/cgroup` (both the v2 `0::<path>` form and the v1 `<id>:<controllers>:<path>` form) instead of assuming the root.
- Walk from that path up to the root and take the tightest limit, since limits nest and a parent slice can be the binding one.
- Treat cgroup v1's unlimited sentinel as no limit. v1 has no `max` keyword — it reports LONG_MAX rounded down to a page boundary (`9223372036854771712` with 4 KiB pages, `9223372036854710272` with 64 KiB), which was being returned as if it were 8 exabytes of available memory.
- Clamp the result to the machine's own memory, so a limit set above physical RAM does not overstate what is reachable.

## Verification

The namespace fix is confirmed end-to-end in containers as shown above; unlimited containers still report host memory, unchanged. The v1 sentinel path is covered by unit tests only — Docker Desktop is cgroup v2, so I had no v1 host to exercise it on.

Cgroup lookup is now injectable (`cgroupPaths`), so `TestCgroupPaths_MemoryLimit` builds fixture trees for the private-namespace, host-namespace, nested-limit, v1, and sentinel cases.