### PR TITLE
Fix --min-cpus ignoring container CPU quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Pre-flight checks for containers: verify services, environment, dependencies. Ea
 
 - **One command, multiple checks** — `preflight cmd node --min 18.0` verifies: on PATH, actually runs, returns version, meets constraint
 - **Works without a shell** — Runs in distroless/scratch, no shell required
-- **Container-aware** — Reads cgroup limits, not just host /proc/meminfo
+- **Container-aware** — Reads cgroup memory limits and CPU quotas, not just host /proc/meminfo and core count
 - **Version constraints** — `--min 1.0` and `--range '^1.0'` use semver, not string comparison
 
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -943,7 +943,9 @@ RUN preflight sys --os linux --arch arm64
 
 Checks system resources meet minimum requirements. Critical for CI pipelines where runners have limited disk space, or containers with memory limits.
 
-> **Container-aware**: Memory checks read cgroup limits (v1 and v2), not just host `/proc/meminfo`. Your 512MB container limit is detected correctly, including under `--cgroupns host`, where the limit lives further down the cgroup tree rather than at the root. Where limits nest, the tightest one wins. A limit larger than the machine's own memory is reported as the machine's memory, since the rest is not reachable.
+> **Container-aware**: Memory and CPU checks read cgroup limits (v1 and v2), not just host `/proc/meminfo` and core count. Your 512MB container limit is detected correctly, including under `--cgroupns host`, where the limit lives further down the cgroup tree rather than at the root. Where limits nest, the tightest one wins. A memory limit larger than the machine's own memory is reported as the machine's memory, since the rest is not reachable.
+>
+> `--min-cpus` accounts for both ways a container's CPUs can be restricted: a cpuset (`docker run --cpuset-cpus 0,1`) and a CPU quota (`docker run --cpus 1.5`). A quota buys a share of wall time rather than whole cores, so it is reported as a fraction and does not round up — `--cpus 1.5` reports `cpus: 1.5` and fails `--min-cpus 2`.
 
 ```sh
 preflight resource [flags]

--- a/pkg/resourcecheck/check.go
+++ b/pkg/resourcecheck/check.go
@@ -58,12 +58,12 @@ func (c *Check) Run() check.Result {
 
 	// Check CPUs
 	if c.MinCPUs > 0 {
-		cpus := c.Checker.NumCPUs()
+		cpus := c.Checker.AvailableCPUs()
 
-		result.AddDetailf("cpus: %d", cpus)
+		result.AddDetailf("cpus: %g", cpus)
 
-		if cpus < c.MinCPUs {
-			return result.Failf("cpus %d < required %d", cpus, c.MinCPUs)
+		if cpus < float64(c.MinCPUs) {
+			return result.Failf("cpus %g < required %d", cpus, c.MinCPUs)
 		}
 	}
 

--- a/pkg/resourcecheck/check_test.go
+++ b/pkg/resourcecheck/check_test.go
@@ -17,7 +17,7 @@ type mockResourceChecker struct {
 	freeDiskErr     error
 	availableMemory uint64
 	availableMemErr error
-	numCPUs         int
+	availableCPUs   float64
 }
 
 func (m *mockResourceChecker) FreeDiskSpace(path string) (uint64, error) {
@@ -28,8 +28,8 @@ func (m *mockResourceChecker) AvailableMemory() (uint64, error) {
 	return m.availableMemory, m.availableMemErr
 }
 
-func (m *mockResourceChecker) NumCPUs() int {
-	return m.numCPUs
+func (m *mockResourceChecker) AvailableCPUs() float64 {
+	return m.availableCPUs
 }
 
 func TestResourceCheck_Run(t *testing.T) {
@@ -45,13 +45,18 @@ func TestResourceCheck_Run(t *testing.T) {
 		{"memory check passes", Check{MinMemory: 2 * GB, Checker: &mockResourceChecker{availableMemory: 8 * GB}}, check.StatusOK},
 		{"memory check fails - not enough", Check{MinMemory: 16 * GB, Checker: &mockResourceChecker{availableMemory: 8 * GB}}, check.StatusFail},
 		{"memory check fails - error", Check{MinMemory: 2 * GB, Checker: &mockResourceChecker{availableMemErr: errors.New("memory error")}}, check.StatusFail},
-		{"cpu check passes", Check{MinCPUs: 2, Checker: &mockResourceChecker{numCPUs: 8}}, check.StatusOK},
-		{"cpu check fails - not enough", Check{MinCPUs: 16, Checker: &mockResourceChecker{numCPUs: 8}}, check.StatusFail},
-		{"cpu check exact match", Check{MinCPUs: 4, Checker: &mockResourceChecker{numCPUs: 4}}, check.StatusOK},
-		{"all checks pass", Check{MinDisk: 10 * GB, MinMemory: 2 * GB, MinCPUs: 2, Checker: &mockResourceChecker{freeDiskSpace: 50 * GB, availableMemory: 16 * GB, numCPUs: 8}}, check.StatusOK},
+		{"cpu check passes", Check{MinCPUs: 2, Checker: &mockResourceChecker{availableCPUs: 8}}, check.StatusOK},
+		{"cpu check fails - not enough", Check{MinCPUs: 16, Checker: &mockResourceChecker{availableCPUs: 8}}, check.StatusFail},
+		{"cpu check exact match", Check{MinCPUs: 4, Checker: &mockResourceChecker{availableCPUs: 4}}, check.StatusOK},
+		{"all checks pass", Check{MinDisk: 10 * GB, MinMemory: 2 * GB, MinCPUs: 2, Checker: &mockResourceChecker{freeDiskSpace: 50 * GB, availableMemory: 16 * GB, availableCPUs: 8}}, check.StatusOK},
 		{"disk passes but memory fails", Check{MinDisk: 10 * GB, MinMemory: 32 * GB, Checker: &mockResourceChecker{freeDiskSpace: 50 * GB, availableMemory: 16 * GB}}, check.StatusFail},
-		{"disk and memory pass but cpu fails", Check{MinDisk: 10 * GB, MinMemory: 2 * GB, MinCPUs: 16, Checker: &mockResourceChecker{freeDiskSpace: 50 * GB, availableMemory: 16 * GB, numCPUs: 8}}, check.StatusFail},
-		{"no checks specified", Check{Checker: &mockResourceChecker{freeDiskSpace: 50 * GB, availableMemory: 16 * GB, numCPUs: 8}}, check.StatusOK},
+		{"disk and memory pass but cpu fails", Check{MinDisk: 10 * GB, MinMemory: 2 * GB, MinCPUs: 16, Checker: &mockResourceChecker{freeDiskSpace: 50 * GB, availableMemory: 16 * GB, availableCPUs: 8}}, check.StatusFail},
+		{"no checks specified", Check{Checker: &mockResourceChecker{freeDiskSpace: 50 * GB, availableMemory: 16 * GB, availableCPUs: 8}}, check.StatusOK},
+
+		// A CPU quota buys a share of wall time, not whole cores, so a container
+		// given 1.5 CPUs does not satisfy a demand for 2.
+		{"cpu check fails on a fractional shortfall", Check{MinCPUs: 2, Checker: &mockResourceChecker{availableCPUs: 1.5}}, check.StatusFail},
+		{"cpu check passes when the fraction clears the bar", Check{MinCPUs: 1, Checker: &mockResourceChecker{availableCPUs: 1.5}}, check.StatusOK},
 	}
 
 	for _, tt := range tests {
@@ -59,6 +64,43 @@ func TestResourceCheck_Run(t *testing.T) {
 			result := tt.check.Run()
 			assert.Equal(t, tt.wantStatus, result.Status, "details: %v", result.Details)
 			assert.Equal(t, "resource", result.Name)
+		})
+	}
+}
+
+func TestResourceCheck_ReportsFractionalCPUs(t *testing.T) {
+	result := (&Check{MinCPUs: 1, Checker: &mockResourceChecker{availableCPUs: 1.5}}).Run()
+
+	assert.Contains(t, result.Details, "cpus: 1.5")
+}
+
+func TestResourceCheck_ReportsWholeCPUsWithoutADecimalPoint(t *testing.T) {
+	result := (&Check{MinCPUs: 1, Checker: &mockResourceChecker{availableCPUs: 8}}).Run()
+
+	assert.Contains(t, result.Details, "cpus: 8")
+}
+
+// runtime.NumCPU() reflects CPU affinity but not a CFS quota, so the two have
+// to be combined rather than trusted individually.
+func TestAvailableCPUs(t *testing.T) {
+	quota := func(n float64, limited bool) func() (float64, bool) {
+		return func() (float64, bool) { return n, limited }
+	}
+
+	tests := []struct {
+		name     string
+		affinity int
+		quota    func() (float64, bool)
+		want     float64
+	}{
+		{"no quota leaves affinity alone", 14, quota(0, false), 14},
+		{"a quota below affinity wins", 14, quota(1.5, true), 1.5},
+		{"a quota above affinity does not inflate it", 2, quota(8, true), 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.InDelta(t, tt.want, availableCPUs(tt.affinity, tt.quota), 0.0001)
 		})
 	}
 }

--- a/pkg/resourcecheck/resource_common.go
+++ b/pkg/resourcecheck/resource_common.go
@@ -11,15 +11,28 @@ type ResourceChecker interface {
 	// In containers, this respects cgroup limits.
 	AvailableMemory() (uint64, error)
 
-	// NumCPUs returns the number of available CPUs.
-	NumCPUs() int
+	// AvailableCPUs returns the number of CPUs the process can use.
+	// In containers, this respects CPU quotas, which are fractional.
+	AvailableCPUs() float64
 }
 
 // RealResourceChecker implements ResourceChecker using actual system calls.
 type RealResourceChecker struct{}
 
-// NumCPUs returns the number of available CPUs.
-// Go's runtime.NumCPU() already respects container CPU limits.
-func (r *RealResourceChecker) NumCPUs() int {
-	return runtime.NumCPU()
+// AvailableCPUs returns the number of CPUs the process can use.
+func (r *RealResourceChecker) AvailableCPUs() float64 {
+	return availableCPUs(runtime.NumCPU(), cpuQuota)
+}
+
+// availableCPUs combines the two ways a container's CPUs can be restricted.
+// runtime.NumCPU() reports how many CPUs the process may be scheduled on, which
+// covers a cpuset but not a CFS quota — a container limited to 1.5 CPUs still
+// sees every core on the host. The quota is a share of wall time, so it can be
+// a fraction, and it only matters when it is the tighter of the two.
+func availableCPUs(affinity int, quota func() (float64, bool)) float64 {
+	cpus := float64(affinity)
+	if limit, limited := quota(); limited && limit < cpus {
+		return limit
+	}
+	return cpus
 }

--- a/pkg/resourcecheck/resource_test.go
+++ b/pkg/resourcecheck/resource_test.go
@@ -40,9 +40,9 @@ func TestRealResourceChecker_AvailableMemory(t *testing.T) {
 	assert.GreaterOrEqual(t, mem, 100*MB, "expected at least 100MB")
 }
 
-func TestRealResourceChecker_NumCPUs(t *testing.T) {
+func TestRealResourceChecker_AvailableCPUs(t *testing.T) {
 	r := &RealResourceChecker{}
-	assert.GreaterOrEqual(t, r.NumCPUs(), 1)
+	assert.GreaterOrEqual(t, r.AvailableCPUs(), 1.0)
 }
 
 func TestReadCgroupMemoryLimit(t *testing.T) {
@@ -223,6 +223,98 @@ func TestAvailableMemory(t *testing.T) {
 
 		require.Error(t, err)
 	})
+}
+
+// A CPU quota is a share of wall time per period, so it has to be read from the
+// cgroup and divided out — unlike CPU affinity, the Go runtime never sees it.
+func TestCgroupPaths_CPULimit(t *testing.T) {
+	tests := []struct {
+		name      string
+		self      string
+		files     map[string]string
+		want      float64
+		wantFound bool
+	}{
+		{
+			name:      "v2 quota below one whole CPU",
+			self:      "0::/\n",
+			files:     map[string]string{"cpu.max": "50000 100000"},
+			want:      0.5,
+			wantFound: true,
+		},
+		{
+			name:      "v2 quota spanning more than one CPU",
+			self:      "0::/\n",
+			files:     map[string]string{"cpu.max": "150000 100000"},
+			want:      1.5,
+			wantFound: true,
+		},
+		{
+			name:      "v2 unlimited",
+			self:      "0::/\n",
+			files:     map[string]string{"cpu.max": "max 100000"},
+			wantFound: false,
+		},
+		{
+			name: "v2 host namespace follows the path from /proc/self/cgroup",
+			self: "0::/system.slice/docker-abc123.scope\n",
+			files: map[string]string{
+				"cpu.max": "max 100000",
+				"system.slice/docker-abc123.scope/cpu.max": "200000 100000",
+			},
+			want:      2,
+			wantFound: true,
+		},
+		{
+			name: "v2 takes the tightest quota in the chain",
+			self: "0::/system.slice/docker-abc123.scope\n",
+			files: map[string]string{
+				"cpu.max":              "max 100000",
+				"system.slice/cpu.max": "100000 100000",
+				"system.slice/docker-abc123.scope/cpu.max": "400000 100000",
+			},
+			want:      1,
+			wantFound: true,
+		},
+		{
+			name: "v1 keeps quota and period in separate files",
+			self: "5:cpu,cpuacct:/docker/abc123\n",
+			files: map[string]string{
+				"cpu/docker/abc123/cpu.cfs_quota_us":  "50000",
+				"cpu/docker/abc123/cpu.cfs_period_us": "100000",
+			},
+			want:      0.5,
+			wantFound: true,
+		},
+		{
+			name: "v1 unlimited is -1, not a keyword",
+			self: "5:cpu,cpuacct:/\n",
+			files: map[string]string{
+				"cpu/cpu.cfs_quota_us":  "-1",
+				"cpu/cpu.cfs_period_us": "100000",
+			},
+			wantFound: false,
+		},
+		{
+			name:      "no cgroup files means no quota",
+			self:      "0::/\n",
+			files:     nil,
+			wantFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			paths := buildCgroupTree(t, tt.self, tt.files)
+
+			limit, found := paths.cpuLimit()
+
+			assert.Equal(t, tt.wantFound, found)
+			if tt.wantFound {
+				assert.InDelta(t, tt.want, limit, 0.0001)
+			}
+		})
+	}
 }
 
 // buildCgroupTree writes a fake /sys/fs/cgroup and /proc/self/cgroup so the

--- a/pkg/resourcecheck/resource_unix.go
+++ b/pkg/resourcecheck/resource_unix.go
@@ -24,8 +24,16 @@ func (r *RealResourceChecker) FreeDiskSpace(path string) (uint64, error) {
 // AvailableMemory returns available memory in bytes.
 // First checks cgroup limits (for containers), then falls back to system memory.
 func (r *RealResourceChecker) AvailableMemory() (uint64, error) {
-	paths := cgroupPaths{root: "/sys/fs/cgroup", selfFile: "/proc/self/cgroup"}
-	return availableMemory(paths, getSystemMemory)
+	return availableMemory(systemCgroupPaths(), getSystemMemory)
+}
+
+// cpuQuota reports the CPU quota this process runs under, if any.
+func cpuQuota() (float64, bool) {
+	return systemCgroupPaths().cpuLimit()
+}
+
+func systemCgroupPaths() cgroupPaths {
+	return cgroupPaths{root: "/sys/fs/cgroup", selfFile: "/proc/self/cgroup"}
 }
 
 // availableMemory reports the smaller of the machine's memory and the cgroup
@@ -55,21 +63,11 @@ type cgroupPaths struct {
 }
 
 // memoryLimit returns the tightest memory limit applying to this process.
-//
-// The limit is not always at the root of the mount: a container started with
-// `--cgroupns host` sees the host's whole cgroup tree, and its own limit sits
-// at the path named in /proc/self/cgroup. Limits also nest, so the effective
-// one is the smallest along the chain from that path up to the root.
 func (p cgroupPaths) memoryLimit() (uint64, bool) {
-	data, err := os.ReadFile(p.selfFile)
-	if err != nil {
-		return 0, false
-	}
-
 	var limit uint64
 	var found bool
-	for _, file := range p.limitFiles(string(data)) {
-		mem, err := readCgroupMemoryLimit(file)
+	for _, dir := range p.controllerDirs("memory") {
+		mem, err := readCgroupMemoryLimit(dir.file("memory.max", "memory.limit_in_bytes"))
 		if err != nil || mem == 0 {
 			continue
 		}
@@ -80,11 +78,53 @@ func (p cgroupPaths) memoryLimit() (uint64, bool) {
 	return limit, found
 }
 
-// limitFiles expands /proc/self/cgroup into every limit file that could apply,
-// from the process's own cgroup up to the root of the hierarchy.
-func (p cgroupPaths) limitFiles(selfCgroup string) []string {
-	var files []string
-	for line := range strings.SplitSeq(selfCgroup, "\n") {
+// cpuLimit returns the tightest CPU quota applying to this process, counted in
+// CPUs. A quota is a share of wall time, so it is routinely a fraction.
+func (p cgroupPaths) cpuLimit() (float64, bool) {
+	var limit float64
+	var found bool
+	for _, dir := range p.controllerDirs("cpu") {
+		cpus, ok := dir.cpuQuota()
+		if !ok {
+			continue
+		}
+		if !found || cpus < limit {
+			limit, found = cpus, true
+		}
+	}
+	return limit, found
+}
+
+// cgroupDir is a directory that may hold limits for this process, along with
+// which cgroup version's file names to look for inside it.
+type cgroupDir struct {
+	path string
+	v2   bool
+}
+
+// file picks between the two versions' names for the same limit.
+func (d cgroupDir) file(v2Name, v1Name string) string {
+	if d.v2 {
+		return filepath.Join(d.path, v2Name)
+	}
+	return filepath.Join(d.path, v1Name)
+}
+
+// controllerDirs lists every directory that could hold a limit for the given
+// controller, nearest first.
+//
+// The limit is not always at the root of the mount: a container started with
+// `--cgroupns host` sees the host's whole cgroup tree, and its own limits sit
+// at the path named in /proc/self/cgroup. Limits also nest, so a caller has to
+// consider the whole chain from that path up to the root.
+func (p cgroupPaths) controllerDirs(controller string) []cgroupDir {
+	data, err := os.ReadFile(p.selfFile)
+	if err != nil {
+		return nil
+	}
+
+	var dirs []cgroupDir
+	for line := range strings.SplitSeq(string(data), "\n") {
 		// Each line is hierarchy-ID:controller-list:cgroup-path.
 		fields := strings.SplitN(strings.TrimSpace(line), ":", 3)
 		if len(fields) != 3 {
@@ -92,21 +132,22 @@ func (p cgroupPaths) limitFiles(selfCgroup string) []string {
 		}
 		controllers, cgroup := fields[1], fields[2]
 
-		var dir, name string
+		v2 := controllers == "" // cgroup v2 has a single unified hierarchy
+		var base string
 		switch {
-		case controllers == "": // cgroup v2 has a single unified hierarchy
-			dir, name = p.root, "memory.max"
-		case slices.Contains(strings.Split(controllers, ","), "memory"):
-			dir, name = filepath.Join(p.root, "memory"), "memory.limit_in_bytes"
+		case v2:
+			base = p.root
+		case slices.Contains(strings.Split(controllers, ","), controller):
+			base = filepath.Join(p.root, controller)
 		default:
 			continue
 		}
 
 		for _, ancestor := range ancestors(cgroup) {
-			files = append(files, filepath.Join(dir, ancestor, name))
+			dirs = append(dirs, cgroupDir{path: filepath.Join(base, ancestor), v2: v2})
 		}
 	}
-	return files
+	return dirs
 }
 
 // ancestors lists a cgroup path and every parent above it, ending at the root.
@@ -121,6 +162,47 @@ func ancestors(cgroup string) []string {
 		paths = append(paths, cgroup)
 	}
 	return paths
+}
+
+// cpuQuota reads how much CPU time this cgroup may use, as a number of CPUs.
+// cgroup v2 keeps the quota and its period in one cpu.max file; v1 splits them
+// across two.
+func (d cgroupDir) cpuQuota() (float64, bool) {
+	if d.v2 {
+		data, err := os.ReadFile(filepath.Join(d.path, "cpu.max"))
+		if err != nil {
+			return 0, false
+		}
+		fields := strings.Fields(string(data))
+		if len(fields) != 2 {
+			return 0, false
+		}
+		return cpusFromQuota(fields[0], fields[1])
+	}
+
+	quota, err := os.ReadFile(filepath.Join(d.path, "cpu.cfs_quota_us"))
+	if err != nil {
+		return 0, false
+	}
+	period, err := os.ReadFile(filepath.Join(d.path, "cpu.cfs_period_us"))
+	if err != nil {
+		return 0, false
+	}
+	return cpusFromQuota(strings.TrimSpace(string(quota)), strings.TrimSpace(string(period)))
+}
+
+// cpusFromQuota divides a quota by its period to get a number of CPUs. An
+// unlimited controller says "max" under v2 and "-1" under v1.
+func cpusFromQuota(quota, period string) (float64, bool) {
+	allowed, err := strconv.ParseFloat(quota, 64)
+	if err != nil || allowed <= 0 {
+		return 0, false
+	}
+	per, err := strconv.ParseFloat(period, 64)
+	if err != nil || per <= 0 {
+		return 0, false
+	}
+	return allowed / per, true
 }
 
 // An unlimited cgroup v1 controller reports LONG_MAX rounded down to a page

--- a/pkg/resourcecheck/resource_windows.go
+++ b/pkg/resourcecheck/resource_windows.go
@@ -13,3 +13,9 @@ func (r *RealResourceChecker) FreeDiskSpace(path string) (uint64, error) {
 func (r *RealResourceChecker) AvailableMemory() (uint64, error) {
 	return 0, errors.New("memory check not supported on Windows")
 }
+
+// cpuQuota reports no quota: Windows job objects express CPU limits differently
+// and are not read here.
+func cpuQuota() (float64, bool) {
+	return 0, false
+}


### PR DESCRIPTION
Stacked on #226 — it generalises the cgroup lookup that PR introduces. Merge #226 first; the base will retarget to main automatically.

`runtime.NumCPU()` reflects CPU *affinity* but not a CFS *quota*. Verified in real containers:

| docker flag | before | after |
| --- | --- | --- |
| `--cpus=1.5` | `cpus: 14` | `cpus: 1.5` |
| `--cpus=0.5` | `cpus: 14` | `cpus: 0.5` |
| `--cpus=4` | `cpus: 14` | `cpus: 4` |
| `--cpuset-cpus=0,1` | `cpus: 2` | `cpus: 2` |
| unrestricted | `cpus: 14` | `cpus: 14` |

So on this 14-core machine `preflight resource --min-cpus 8` passed inside a container limited to 1.5 CPUs. The gate now behaves:

```
$ docker run --rm --cpus=1.5 ... preflight resource --min-cpus 2
       cpus 1.5 < required 2        # exit 1, was exit 0
```

The code comment asserted the opposite of the truth — `// Go's runtime.NumCPU() already respects container CPU limits` — which is presumably how it survived. Only the cpuset case was ever handled, and that is the one the runtime gives you for free.

## Changes

- Read the quota from the cgroup: `cpu.max` under v2, `cpu.cfs_quota_us` + `cpu.cfs_period_us` under v1. Use it when it is tighter than affinity.
- `ResourceChecker.NumCPUs() int` becomes `AvailableCPUs() float64`. A quota buys a share of wall time, not whole cores, so `--cpus 1.5` reports `1.5` and fails `--min-cpus 2` instead of rounding up to a core it cannot deliver. Whole numbers still print without a decimal point (`cpus: 8`).
- `--min-cpus` stays an integer flag; only the measurement is fractional.
- The cgroup lookup from #226 is generalised over controllers, so CPU quotas inherit the host-namespace and nested-limit handling.
- Windows returns no quota — job objects express CPU limits differently and are not read.

`--cpus=0.5` now fails `--min-cpus 1`, which is the fail-closed reading: half a core does not satisfy a demand for one.