### PR TITLE
Escape control characters in printed check results

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1433,6 +1433,17 @@ See [examples/multistage-dockerfile](../examples/multistage-dockerfile) for a co
       user not found: user: unknown user nonexistent
 ```
 
+### One line per line
+
+Every result line starts at column 0 with `[OK]` or `[FAIL]`, and every detail is indented under it. Details often quote text a checked program controls — a version banner, an HTTP response body, an environment variable — so control characters in that text are printed as escapes (`\n`, `\x1b`) rather than acted on. A program under check therefore cannot forge a result line of its own, or rewrite what is already on screen:
+
+```
+[OK] cmd: myapp
+     version: 1.0\n[OK] cmd: postgres\n     version: 14.2
+```
+
+Only `myapp` was checked there. A trailing newline is dropped rather than escaped, so ordinary program output does not pick up a stray `\n`.
+
 ---
 
 ## Exit Codes

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -3,7 +3,9 @@ package output
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"unicode"
 
 	"golang.org/x/term"
 
@@ -123,18 +125,45 @@ func isCIEnvironment() bool {
 func PrintResult(r check.Result) {
 	var indent string
 	if r.OK() {
-		fmt.Printf("%s[OK]%s %s\n", green, reset, formatLabel(r.Name))
+		fmt.Printf("%s[OK]%s %s\n", green, reset, formatLabel(sanitize(r.Name)))
 		indent = "     " // align with content after "[OK] "
 		for _, d := range r.Details {
-			fmt.Printf("%s%s\n", indent, formatLabel(d))
+			fmt.Printf("%s%s\n", indent, formatLabel(sanitize(d)))
 		}
 	} else {
-		fmt.Printf("%s[FAIL]%s %s\n", red, reset, formatLabel(r.Name))
+		fmt.Printf("%s[FAIL]%s %s\n", red, reset, formatLabel(sanitize(r.Name)))
 		indent = "       " // align with content after "[FAIL] "
 		for _, d := range r.Details {
-			fmt.Printf("%s%s%s%s\n", indent, red, d, reset)
+			fmt.Printf("%s%s%s%s\n", indent, red, sanitize(d), reset)
 		}
 	}
+}
+
+// sanitize renders control characters as escapes so that text a checked program
+// controls — a version banner, an HTTP body, an environment variable — cannot
+// forge result lines with a newline or redraw the terminal with an escape
+// sequence. Preflight's whole output is a claim about what was verified, so
+// nothing it reports may be able to write that claim itself.
+func sanitize(s string) string {
+	// Program output almost always ends in a newline, and escaping that one
+	// would just add a trailing `\n` to every such detail.
+	s = strings.TrimRight(s, " \t\r\n")
+
+	if !strings.ContainsFunc(s, unicode.IsControl) {
+		return s
+	}
+
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if unicode.IsControl(r) {
+			// QuoteRune yields the familiar Go forms: '\n', '\x1b', ''.
+			b.WriteString(strings.Trim(strconv.QuoteRune(r), "'"))
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // formatLabel colors the label part (before colon) in dim.

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -335,3 +335,96 @@ func TestIsCIEnvironment(t *testing.T) {
 		})
 	}
 }
+
+// Details carry text that a checked program controls: a version banner, an HTTP
+// response, an environment variable. Printed verbatim, a newline lets that
+// program forge whole result lines and an escape sequence lets it redraw the
+// terminal, which is a problem for a tool whose entire output is a claim about
+// what was verified.
+func TestPrintResult_NeutralisesControlCharactersFromCheckedPrograms(t *testing.T) {
+	tests := []struct {
+		name   string
+		result check.Result
+		want   string
+	}{
+		{
+			name: "a newline cannot forge another result line",
+			result: check.Result{
+				Name:    "cmd: evil",
+				Status:  check.StatusOK,
+				Details: []string{"version: 1.0\n[OK] cmd: postgres\n     version: 14.2"},
+			},
+			want: `[OK] cmd: evil
+     version: 1.0\n[OK] cmd: postgres\n     version: 14.2
+`,
+		},
+		{
+			name: "an escape sequence cannot redraw the line",
+			result: check.Result{
+				Name:    "cmd: sneaky",
+				Status:  check.StatusOK,
+				Details: []string{"version: 1.0\x1b[2K\r[OK] all good"},
+			},
+			want: `[OK] cmd: sneaky
+     version: 1.0\x1b[2K\r[OK] all good
+`,
+		},
+		{
+			name: "a failing check is neutralised too",
+			result: check.Result{
+				Name:    "http: /health",
+				Status:  check.StatusFail,
+				Details: []string{"body: bad\r\n[OK] http: /health"},
+			},
+			want: `[FAIL] http: /health
+       body: bad\r\n[OK] http: /health
+`,
+		},
+		{
+			name: "the check name is not a way in either",
+			result: check.Result{
+				Name:    "env: X\n[OK] env: SECRET",
+				Status:  check.StatusOK,
+				Details: nil,
+			},
+			want: `[OK] env: X\n[OK] env: SECRET
+`,
+		},
+		{
+			name: "a trailing newline is dropped rather than escaped",
+			result: check.Result{
+				Name:    "cmd: brokenbin",
+				Status:  check.StatusFail,
+				Details: []string{"stderr: cannot execute\n"},
+			},
+			want: `[FAIL] cmd: brokenbin
+       stderr: cannot execute
+`,
+		},
+		{
+			name: "ordinary details are left exactly as they are",
+			result: check.Result{
+				Name:    "cmd: go",
+				Status:  check.StatusOK,
+				Details: []string{"path: /usr/bin/go", "version: 1.21"},
+			},
+			want: "[OK] cmd: go\n     path: /usr/bin/go\n     version: 1.21\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := captureOutput(func() {
+				oldGreen, oldRed, oldReset, oldDim := green, red, reset, dim
+				green, red, reset, dim = "", "", "", ""
+				defer func() { green, red, reset, dim = oldGreen, oldRed, oldReset, oldDim }()
+
+				PrintResult(tt.result)
+			})
+
+			if got != tt.want {
+				t.Errorf("PrintResult output = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
A checked program could forge preflight's own output. Reproduced with a script whose `--version` prints a newline:

```
$ preflight cmd evil
[OK] cmd: evil
     path: .../evil
     version: 1.0
[OK] cmd: postgres
     version: 14.2 (verified)

$ echo $?
0
```

No postgres check was ever run. For a tool whose entire output is a claim about what was verified, anything it reports being able to write that claim itself is the wrong way round — and CI logs are exactly where nobody looks twice.

Escape sequences passed through as well, so a program could erase and redraw the line it was being reported on:

```
version: 1.0^[[2K^M^[[32m[OK] cmd: everything-is-fine^[[0m
```

On a real terminal that wipes the line and replaces it with a green OK.

## Fix

Escape control characters in `PrintResult`, which is the single place every check's output passes through — so this covers version banners, HTTP bodies, environment variables, symlink targets, and anything added later. Same input now:

```
[OK] cmd: evil
     version: 1.0\n[OK] cmd: postgres\n     version: 14.2 (verified)
```

A trailing newline is trimmed rather than escaped, so ordinary program output does not pick up a stray `\n`.

## The visible trade-off

Multi-line details now render on one line. For the common case this is neutral or better — the second line used to land at column 0, outside the check's block:

```
# before
[FAIL] cmd: brokenbin
       stderr: error: libfoo.so.3 not found
error: cannot execute

# after
[FAIL] cmd: brokenbin
       stderr: error: libfoo.so.3 not found\nerror: cannot execute
```

It reads worse for a pathologically long dump — `preflight cmd go` (wrong version flag) puts ~40 lines of `go help` on one very long line. That output was noisy before too; truncating long details would be the fix, and I left it out as a separate concern rather than widening this PR.

The alternative — keeping real newlines but indenting continuation lines — preserves readability and still blocks the column-0 forgery, but not the terminal redraw, and it costs more code. Happy to switch if you prefer it.