### PR TITLE
Bound HTTP response body reads

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -370,6 +370,8 @@ preflight prometheus <url> --query '<promql>' [flags]
 | `--insecure`           | Skip TLS certificate verification   |
 | `--header <key:value>` | Custom header (can be repeated)     |
 
+Query responses are read up to 10 MiB, measured after decompression; a larger one fails with `response body too large`. Narrow the query if you hit it — a query answering with that much JSON is returning far more series than a threshold check can use.
+
 ### Examples
 
 ```sh
@@ -684,6 +686,8 @@ preflight http <url> [flags]
 | `--json-path <expr>`   | JSON assertion (`path` or `path=value`) |
 | `--follow-redirects`   | Follow HTTP redirects (3xx)             |
 | `--insecure`           | Skip TLS certificate verification       |
+
+The response body is only read when `--contains` or `--json-path` asks for it, and then only up to 10 MiB — beyond that the check fails with `response body too large` rather than truncating, so a `--contains` miss never means the string was just past the end. The limit is on the body after decompression, which is what actually occupies memory: a gzipped response is far larger unpacked than it is on the wire.
 
 ### Examples
 

--- a/pkg/httpcheck/check.go
+++ b/pkg/httpcheck/check.go
@@ -139,12 +139,12 @@ func (c *Check) Run() check.Result {
 		// Read response body if needed for --contains or --json-path check
 		var respBody string
 		if c.Contains != "" || c.JSONPath != "" {
-			bodyBytes, err := io.ReadAll(resp.Body)
+			body, err := httpclient.ReadBody(resp.Body)
 			_ = resp.Body.Close()
 			if err != nil {
 				return result.Failf("failed to read response body: %v", err)
 			}
-			respBody = string(bodyBytes)
+			respBody = body
 		} else {
 			_ = resp.Body.Close()
 		}

--- a/pkg/httpclient/client.go
+++ b/pkg/httpclient/client.go
@@ -6,6 +6,8 @@ package httpclient
 
 import (
 	"crypto/tls"
+	"fmt"
+	"io"
 	"net/http"
 	"time"
 )
@@ -13,6 +15,29 @@ import (
 // Client abstracts HTTP requests for testability.
 type Client interface {
 	Do(req *http.Request) (*http.Response, error)
+}
+
+// MaxBodySize caps how much of a response body a check will read. Health
+// endpoints and Prometheus queries answer in kilobytes, so this is generous
+// for anything preflight is pointed at on purpose.
+const MaxBodySize = 10 << 20 // 10 MiB
+
+// ReadBody reads a response body, refusing one larger than MaxBodySize.
+//
+// The size of the response on the wire says nothing about the size in memory:
+// Go's transport transparently decompresses gzip, so a 2 MB body can expand to
+// gigabytes. Reading it whole would OOM the memory-limited containers preflight
+// is built to run in. Oversize bodies fail rather than truncate, so a --contains
+// miss is never really a body that ran off the end.
+func ReadBody(r io.Reader) (string, error) {
+	body, err := io.ReadAll(io.LimitReader(r, MaxBodySize+1))
+	if err != nil {
+		return "", err
+	}
+	if len(body) > MaxBodySize {
+		return "", fmt.Errorf("response body too large (over %d bytes)", MaxBodySize)
+	}
+	return string(body), nil
 }
 
 // Real is a Client backed by net/http.

--- a/pkg/httpclient/client_test.go
+++ b/pkg/httpclient/client_test.go
@@ -1,9 +1,12 @@
 package httpclient
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -83,4 +86,56 @@ func TestReal(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 		assert.Equal(t, 200, resp.StatusCode)
 	})
+}
+
+// Go's transport transparently decompresses gzip, so a small response can
+// expand without limit once read. A 2 MB gzip bomb took preflight to 6.5 GB
+// resident, which is an OOM kill on the memory-limited containers it is built
+// to run in.
+func TestReadBody(t *testing.T) {
+	t.Run("reads a body that fits", func(t *testing.T) {
+		body, err := ReadBody(strings.NewReader("hello"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "hello", body)
+	})
+
+	t.Run("reads a body exactly at the limit", func(t *testing.T) {
+		body, err := ReadBody(strings.NewReader(strings.Repeat("x", MaxBodySize)))
+
+		require.NoError(t, err)
+		assert.Len(t, body, MaxBodySize)
+	})
+
+	t.Run("refuses a body over the limit rather than truncating it", func(t *testing.T) {
+		_, err := ReadBody(strings.NewReader(strings.Repeat("x", MaxBodySize+1)))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "too large")
+	})
+
+	// The point is to never hold the whole thing, so an endless body has to stop
+	// the read rather than fill memory first.
+	t.Run("stops on an endless body", func(t *testing.T) {
+		endless := endlessReader{}
+
+		_, err := ReadBody(endless)
+
+		require.Error(t, err)
+	})
+
+	t.Run("surfaces a read failure", func(t *testing.T) {
+		_, err := ReadBody(iotest.ErrReader(errors.New("connection reset")))
+
+		require.ErrorContains(t, err, "connection reset")
+	})
+}
+
+type endlessReader struct{}
+
+func (endlessReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'x'
+	}
+	return len(p), nil
 }

--- a/pkg/promcheck/check.go
+++ b/pkg/promcheck/check.go
@@ -3,7 +3,6 @@ package promcheck
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -99,12 +98,11 @@ func (c *Check) Run() check.Result {
 		}
 
 		// Read response body
-		bodyBytes, err := io.ReadAll(resp.Body)
+		respBody, err := httpclient.ReadBody(resp.Body)
 		_ = resp.Body.Close()
 		if err != nil {
 			return result.Failf("failed to read response body: %v", err)
 		}
-		respBody := string(bodyBytes)
 
 		// Check HTTP status
 		if resp.StatusCode != 200 {


### PR DESCRIPTION
`httpcheck` and `promcheck` both did `io.ReadAll(resp.Body)` with no limit. Go's transport transparently decompresses gzip, so the size on the wire says nothing about the size in memory.

Measured against a server returning a 2 MB gzip bomb (2 GiB of zeros):

| | before | after |
| --- | --- | --- |
| `http … --contains x` | 6.56 GB resident | 39 MB, fails cleanly |
| `prometheus … --query up` | 6.83 GB resident | 39 MB, fails cleanly |

```
[FAIL] http: http://127.0.0.1:18099/health
       failed to read response body: response body too large (over 10485760 bytes)
```

Preflight exists to run inside memory-limited containers, which is precisely where this is an OOM kill rather than a slow check. `promcheck` reads the body unconditionally, so it needs no flag to trigger; `httpcheck` needs `--contains` or `--json-path` (without either it never reads the body and stayed at 12 MB).

## Fix

`httpclient.ReadBody` reads through an `io.LimitReader` capped at 10 MiB — the same package that already holds the client these two share. Health endpoints and Prometheus queries answer in kilobytes, so the cap is generous for anything preflight is pointed at deliberately.

Oversize bodies **fail rather than truncate**. Truncating would make a `--contains` miss ambiguous — the string might simply have been past the cut — and this is a tool whose answers are supposed to mean something.

## Note

There is no flag to raise the cap. I left it out rather than widen the PR, but say the word if an escape hatch is worth having for someone with a legitimately huge body.