### PR TITLE
Add a CA bundle to the released image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,14 +188,19 @@ jobs:
           # This runs a check, then execs into preflight --version
           docker run --rm --entrypoint /preflight preflight-distroless env PATH -- /preflight --version
 
-      - name: Test in scratch
+      # Builds the Dockerfile that actually ships, rather than an inline copy of
+      # it: the released image shipped for months without a CA bundle because
+      # nothing here ever exercised the real one.
+      - name: Test the released image
         run: |
-          echo 'FROM scratch
-          COPY preflight /preflight
-          ENTRYPOINT ["/preflight"]' > Dockerfile.scratch
-          docker build -f Dockerfile.scratch -t preflight-scratch .
+          mkdir -p dist && cp preflight dist/preflight-linux-amd64
+          docker build --build-arg TARGETARCH=amd64 -t preflight-release .
 
-          docker run --rm preflight-scratch --version
+          docker run --rm preflight-release --version
 
-          # Test exec mode in scratch too
-          docker run --rm --entrypoint /preflight preflight-scratch env PATH -- /preflight --version
+          # Exec mode: the point of a shell-less image
+          docker run --rm --entrypoint /preflight preflight-release env PATH -- /preflight --version
+
+          # HTTPS needs a CA bundle, which a scratch image does not have by default
+          docker run --rm preflight-release file /etc/ssl/certs/ca-certificates.crt --not-empty
+          docker run --rm preflight-release http https://example.com

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ bin/
 
 # Claude local settings
 .claude/settings.local.json
+
+# Release build output (also produced by the Dockerfile CI test)
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
+# A scratch image has no CA bundle, and Go's TLS verification has nowhere else
+# to look, so every `preflight http https://...` fails with "certificate signed
+# by unknown authority". Alpine's bundle is ~220KB and is already a maintained
+# artifact, so take it rather than shipping certificates from this repo.
+FROM alpine:3.21 AS certs
+
 FROM scratch
 ARG TARGETARCH
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY dist/preflight-linux-${TARGETARCH} /preflight
 ENTRYPOINT ["/preflight"]

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,6 +12,17 @@ curl -fsSL https://raw.githubusercontent.com/vertti/preflight/main/install.sh | 
 COPY --from=ghcr.io/vertti/preflight:latest /preflight /usr/local/bin/preflight
 ```
 
+Copying only `/preflight` gives you the binary, and it uses whatever CA bundle the
+destination image has. If that image is `scratch` or `distroless/base` and you
+need `preflight http https://...`, copy a bundle across as well:
+
+```dockerfile
+COPY --from=ghcr.io/vertti/preflight:latest /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+```
+
+Running the preflight image directly (`docker run ghcr.io/vertti/preflight …`)
+needs nothing extra — the bundle ships in it.
+
 ## Manual Download
 
 Download the binary for your platform from [GitHub Releases](https://github.com/vertti/preflight/releases):


### PR DESCRIPTION
Every HTTPS check fails in the image we publish:

```
$ docker run --rm ghcr.io/vertti/preflight:latest http https://example.com
[FAIL] http: https://example.com
       request failed: Get "https://example.com": tls: failed to verify certificate:
       x509: certificate signed by unknown authority
```

The image is `FROM scratch`, which has no CA certificates, and Go's TLS verification has nowhere else to look. `preflight http` against an HTTPS URL is a headline feature, and it has never worked in the container — plain TCP and everything non-TLS were fine, which is presumably why it went unnoticed.

## Why CI missed it

The "Test in scratch" step wrote its own inline Dockerfile instead of building the repo's. The real `Dockerfile` was never exercised by anything, and neither variant made an HTTPS request.

That step now builds the actual `Dockerfile` and asserts both that the bundle is there and that a real HTTPS request succeeds. Testing the artifact we ship seemed more to the point than testing a lookalike.

## Cost

Alpine's bundle, copied in at 238 kB uncompressed. I took a maintained bundle rather than committing certificates to this repo.

After:

```
[OK] http: https://example.com
     status 200
[OK] file: /etc/ssl/certs/ca-certificates.crt
     size: 217769
```

Also documents that `COPY --from=…/preflight /preflight` alone inherits the destination image's CA bundle — so a scratch or distroless-base target needs the certs copied across too — and adds `dist/` to `.gitignore`, since both the release build and the new CI step produce it.