### PR TITLE
Stop recommending that secrets be echoed into build logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 COPY --from=ghcr.io/vertti/preflight:latest /preflight /usr/local/bin/preflight
 
 RUN preflight cmd node --min 18.0        # verify binary + version
-RUN preflight env DATABASE_URL           # env var exists
+RUN preflight env DATABASE_URL --hide-value  # env var exists, value stays out of the build log
 RUN preflight file /app/config.yaml      # file exists
 RUN preflight tcp postgres:5432 --timeout 5s  # reachable?
 
@@ -134,7 +134,7 @@ preflight cmd ffmpeg --version-cmd -version   # custom version flag
 ### Check environment variables
 
 ```sh
-preflight env DATABASE_URL                       # exists and non-empty
+preflight env DATABASE_URL --hide-value          # exists and non-empty, value not printed
 preflight env MODEL_PATH --match '^/models/'     # matches pattern
 preflight env APP_ENV --one-of dev,staging,prod  # allowed values
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -130,6 +130,12 @@ that fails still won't print the value. Neither flag reveals the value's exact
 length: `--min-len 32` on a hidden value reports
 `value length [hidden] < minimum 32`.
 
+> **Values are printed by default.** `preflight env DATABASE_URL` reports
+> `value: postgres://user:password@host/db`. That is what you want for a
+> `MODEL_PATH` and not what you want for a credential, and the places preflight
+> runs — Docker build logs, CI output — are places that keep what they are told.
+> Reach for `--hide-value` on anything secret.
+
 ### Examples
 
 ```sh
@@ -1285,7 +1291,7 @@ Run preflight checks at container startup before your app starts:
 set -e
 
 preflight tcp postgres:5432 --timeout 30s
-preflight env DATABASE_URL
+preflight env DATABASE_URL --hide-value
 preflight file /app/config.yaml --not-empty
 
 exec "$@"
@@ -1343,7 +1349,7 @@ This works with any preflight command:
 preflight tcp postgres:5432 --timeout 10s -- ./myapp
 
 # Check environment then start
-preflight env DATABASE_URL -- ./myapp
+preflight env DATABASE_URL --hide-value -- ./myapp
 
 # HTTP health check then start
 preflight http http://api:8080/ready --retry 5 -- ./myapp


### PR DESCRIPTION
`preflight env DATABASE_URL` prints the value:

```
[OK] env: DATABASE_URL
     value: postgres://user:password@host/db
```

Every documented `DATABASE_URL` example did exactly that, including the README's quick start, where it sits inside a `RUN` in a Dockerfile — so following the front page of the docs writes a password into an image build log. The same example appears in the entrypoint-script and exec-mode sections.

Adds `--hide-value` to the four examples that name a credential, and states in the env docs that values are printed by default, with the reasoning: it is what you want for a `MODEL_PATH` and not what you want for a secret.

Docs only — no behaviour change. Whether the default itself should change (say, auto-hiding names that look like secrets) is a separate question I have not touched.