### PR TITLE
Collapse the duplicated retry-failure handling

### DIFF
--- a/pkg/check/helpers.go
+++ b/pkg/check/helpers.go
@@ -3,6 +3,7 @@ package check
 import (
 	"fmt"
 	"regexp"
+	"slices"
 )
 
 // Fail sets the result to failed status with a detail message.
@@ -16,6 +17,19 @@ func (r *Result) Fail(detail string, err error) Result {
 // Failf sets the result to failed status with a formatted detail message.
 func (r *Result) Failf(format string, args ...any) Result {
 	return r.Fail(fmt.Sprintf(format, args...), fmt.Errorf(format, args...))
+}
+
+// FailAfter is Failf for a check that was allowed to retry: it records how many
+// attempts were made, when more than one was.
+//
+// The wording lives here rather than at each call site because it used to be
+// spelled out at eleven of them across two files, where nothing kept the count
+// and the message together — and two had drifted into a different phrasing.
+func (r *Result) FailAfter(attempts int, format string, args ...any) Result {
+	if attempts <= 1 {
+		return r.Failf(format, args...)
+	}
+	return r.Failf(format+" (after %d attempts)", append(slices.Clone(args), attempts)...)
 }
 
 // AddDetail appends a detail line to the result.

--- a/pkg/check/result_test.go
+++ b/pkg/check/result_test.go
@@ -40,3 +40,58 @@ func TestResultOK(t *testing.T) {
 		t.Error("OK() = true, want false for StatusFail")
 	}
 }
+
+// Eleven call sites across httpcheck and promcheck each wrote out the attempt
+// count alongside their own failure message, so the two could drift apart —
+// and two of them worded it differently from the other nine.
+func TestResult_FailAfter(t *testing.T) {
+	t.Run("notes the count when the check retried", func(t *testing.T) {
+		r := &Result{Name: "http: /health"}
+
+		result := r.FailAfter(3, "status %d, expected %d", 503, 200)
+
+		if result.Status != StatusFail {
+			t.Errorf("Status = %v, want %v", result.Status, StatusFail)
+		}
+		want := "status 503, expected 200 (after 3 attempts)"
+		if len(result.Details) != 1 || result.Details[0] != want {
+			t.Errorf("Details = %v, want [%s]", result.Details, want)
+		}
+	})
+
+	// A single attempt is not a retry, and saying "after 1 attempts" would be
+	// noise on every check that never asked for one.
+	t.Run("stays quiet when there was only one attempt", func(t *testing.T) {
+		r := &Result{Name: "http: /health"}
+
+		result := r.FailAfter(1, "status %d, expected %d", 503, 200)
+
+		want := "status 503, expected 200"
+		if len(result.Details) != 1 || result.Details[0] != want {
+			t.Errorf("Details = %v, want [%s]", result.Details, want)
+		}
+	})
+
+	t.Run("works without arguments", func(t *testing.T) {
+		r := &Result{Name: "x"}
+
+		result := r.FailAfter(2, "no data")
+
+		want := "no data (after 2 attempts)"
+		if len(result.Details) != 1 || result.Details[0] != want {
+			t.Errorf("Details = %v, want [%s]", result.Details, want)
+		}
+	})
+
+	t.Run("does not disturb the caller's arguments", func(t *testing.T) {
+		r := &Result{Name: "x"}
+		args := make([]any, 1, 4) // spare capacity an append could scribble on
+		args[0] = "value"
+
+		r.FailAfter(2, "got %v", args...)
+
+		if len(args) != 1 || args[0] != "value" {
+			t.Errorf("args = %v, want [value]", args)
+		}
+	})
+}

--- a/pkg/httpcheck/check.go
+++ b/pkg/httpcheck/check.go
@@ -2,7 +2,6 @@ package httpcheck
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -104,7 +103,6 @@ func (c *Check) Run() check.Result {
 
 	// Retry loop
 	maxAttempts := c.Retry + 1
-	var lastErr error
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		var bodyReader io.Reader = http.NoBody
@@ -123,15 +121,11 @@ func (c *Check) Run() check.Result {
 
 		resp, err := client.Do(req)
 		if err != nil {
-			lastErr = err
 			if attempt < maxAttempts {
 				time.Sleep(retryDelay)
 				continue
 			}
-			if maxAttempts > 1 {
-				return result.Failf("request failed after %d attempts: %v", maxAttempts, err)
-			}
-			return result.Failf("request failed: %v", err)
+			return result.FailAfter(maxAttempts, "request failed: %v", err)
 		}
 
 		statusCode := resp.StatusCode
@@ -150,28 +144,20 @@ func (c *Check) Run() check.Result {
 		}
 
 		if statusCode != expectedStatus {
-			lastErr = fmt.Errorf("status %d, expected %d", statusCode, expectedStatus)
 			if attempt < maxAttempts {
 				time.Sleep(retryDelay)
 				continue
 			}
-			if maxAttempts > 1 {
-				return result.Failf("status %d, expected %d (after %d attempts)", statusCode, expectedStatus, maxAttempts)
-			}
-			return result.Failf("status %d, expected %d", statusCode, expectedStatus)
+			return result.FailAfter(maxAttempts, "status %d, expected %d", statusCode, expectedStatus)
 		}
 
 		// Check --contains
 		if c.Contains != "" && !strings.Contains(respBody, c.Contains) {
-			lastErr = fmt.Errorf("response body does not contain %q", c.Contains)
 			if attempt < maxAttempts {
 				time.Sleep(retryDelay)
 				continue
 			}
-			if maxAttempts > 1 {
-				return result.Failf("response body does not contain %q (after %d attempts)", c.Contains, maxAttempts)
-			}
-			return result.Failf("response body does not contain %q", c.Contains)
+			return result.FailAfter(maxAttempts, "response body does not contain %q", c.Contains)
 		}
 
 		// Check --json-path
@@ -179,26 +165,18 @@ func (c *Check) Run() check.Result {
 			path, expectedValue, hasExpectedValue := strings.Cut(c.JSONPath, "=")
 			jsonResult := jsonpath.Get(respBody, path)
 			if !jsonResult.Exists() {
-				lastErr = fmt.Errorf("JSON path %q not found", path)
 				if attempt < maxAttempts {
 					time.Sleep(retryDelay)
 					continue
 				}
-				if maxAttempts > 1 {
-					return result.Failf("JSON path %q not found (after %d attempts)", path, maxAttempts)
-				}
-				return result.Failf("JSON path %q not found", path)
+				return result.FailAfter(maxAttempts, "JSON path %q not found", path)
 			}
 			if hasExpectedValue && jsonResult.String() != expectedValue {
-				lastErr = fmt.Errorf("JSON path %q: got %q, expected %q", path, jsonResult.String(), expectedValue)
 				if attempt < maxAttempts {
 					time.Sleep(retryDelay)
 					continue
 				}
-				if maxAttempts > 1 {
-					return result.Failf("JSON path %q: got %q, expected %q (after %d attempts)", path, jsonResult.String(), expectedValue, maxAttempts)
-				}
-				return result.Failf("JSON path %q: got %q, expected %q", path, jsonResult.String(), expectedValue)
+				return result.FailAfter(maxAttempts, "JSON path %q: got %q, expected %q", path, jsonResult.String(), expectedValue)
 			}
 		}
 
@@ -211,6 +189,7 @@ func (c *Check) Run() check.Result {
 		return result
 	}
 
-	// Should not reach here, but handle edge case
-	return result.Failf("unexpected error: %v", lastErr)
+	// Unreachable: every path in the loop returns, or continues only while
+	// tries remain. The compiler cannot see that, so the line has to exist.
+	return result.Failf("check did not complete")
 }

--- a/pkg/promcheck/check.go
+++ b/pkg/promcheck/check.go
@@ -1,7 +1,6 @@
 package promcheck
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -71,7 +70,6 @@ func (c *Check) Run() check.Result {
 
 	// Retry loop
 	maxAttempts := c.Retry + 1
-	var lastErr error
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		req, err := http.NewRequest("GET", queryURL, http.NoBody)
@@ -86,15 +84,11 @@ func (c *Check) Run() check.Result {
 
 		resp, err := client.Do(req)
 		if err != nil {
-			lastErr = err
 			if attempt < maxAttempts {
 				time.Sleep(retryDelay)
 				continue
 			}
-			if maxAttempts > 1 {
-				return result.Failf("request failed after %d attempts: %v", maxAttempts, err)
-			}
-			return result.Failf("request failed: %v", err)
+			return result.FailAfter(maxAttempts, "request failed: %v", err)
 		}
 
 		// Read response body
@@ -106,15 +100,11 @@ func (c *Check) Run() check.Result {
 
 		// Check HTTP status
 		if resp.StatusCode != 200 {
-			lastErr = fmt.Errorf("prometheus returned status %d", resp.StatusCode)
 			if attempt < maxAttempts {
 				time.Sleep(retryDelay)
 				continue
 			}
-			if maxAttempts > 1 {
-				return result.Failf("prometheus returned status %d (after %d attempts)", resp.StatusCode, maxAttempts)
-			}
-			return result.Failf("prometheus returned status %d", resp.StatusCode)
+			return result.FailAfter(maxAttempts, "prometheus returned status %d", resp.StatusCode)
 		}
 
 		// Parse Prometheus response
@@ -136,15 +126,11 @@ func (c *Check) Run() check.Result {
 		case "vector":
 			results := jsonpath.Get(respBody, "data.result")
 			if !results.Exists() || len(results.Array()) == 0 {
-				lastErr = errors.New("query returned no data")
 				if attempt < maxAttempts {
 					time.Sleep(retryDelay)
 					continue
 				}
-				if maxAttempts > 1 {
-					return result.Failf("query %q returned no data (after %d attempts)", c.Query, maxAttempts)
-				}
-				return result.Failf("query %q returned no data", c.Query)
+				return result.FailAfter(maxAttempts, "query %q returned no data", c.Query)
 			}
 			if len(results.Array()) > 1 {
 				return result.Failf("query returned %d results, expected 1 (use a more specific query)", len(results.Array()))
@@ -165,39 +151,27 @@ func (c *Check) Run() check.Result {
 
 		// Validate against thresholds
 		if c.Exact != nil && value != *c.Exact {
-			lastErr = fmt.Errorf("value %v does not equal %v", value, *c.Exact)
 			if attempt < maxAttempts {
 				time.Sleep(retryDelay)
 				continue
 			}
-			if maxAttempts > 1 {
-				return result.Failf("value %v does not equal %v (after %d attempts)", value, *c.Exact, maxAttempts)
-			}
-			return result.Failf("value %v does not equal %v", value, *c.Exact)
+			return result.FailAfter(maxAttempts, "value %v does not equal %v", value, *c.Exact)
 		}
 
 		if c.Min != nil && value < *c.Min {
-			lastErr = fmt.Errorf("value %v < minimum %v", value, *c.Min)
 			if attempt < maxAttempts {
 				time.Sleep(retryDelay)
 				continue
 			}
-			if maxAttempts > 1 {
-				return result.Failf("value %v < minimum %v (after %d attempts)", value, *c.Min, maxAttempts)
-			}
-			return result.Failf("value %v < minimum %v", value, *c.Min)
+			return result.FailAfter(maxAttempts, "value %v < minimum %v", value, *c.Min)
 		}
 
 		if c.Max != nil && value > *c.Max {
-			lastErr = fmt.Errorf("value %v > maximum %v", value, *c.Max)
 			if attempt < maxAttempts {
 				time.Sleep(retryDelay)
 				continue
 			}
-			if maxAttempts > 1 {
-				return result.Failf("value %v > maximum %v (after %d attempts)", value, *c.Max, maxAttempts)
-			}
-			return result.Failf("value %v > maximum %v", value, *c.Max)
+			return result.FailAfter(maxAttempts, "value %v > maximum %v", value, *c.Max)
 		}
 
 		// Success
@@ -213,6 +187,7 @@ func (c *Check) Run() check.Result {
 		return result
 	}
 
-	// Should not reach here, but handle edge case
-	return result.Failf("unexpected error: %v", lastErr)
+	// Unreachable: every path in the loop returns, or continues only while
+	// tries remain. The compiler cannot see that, so the line has to exist.
+	return result.Failf("check did not complete")
 }


### PR DESCRIPTION
Every failure point in `httpcheck` and `promcheck` spelled out the same nine lines:

```go
lastErr = fmt.Errorf("status %d, expected %d", statusCode, expectedStatus)
if attempt < maxAttempts {
    time.Sleep(retryDelay)
    continue
}
if maxAttempts > 1 {
    return result.Failf("status %d, expected %d (after %d attempts)", statusCode, expectedStatus, maxAttempts)
}
return result.Failf("status %d, expected %d", statusCode, expectedStatus)
```

Eleven copies across the two files, each repeating its own message three times. They had already drifted: nine said `… (after 3 attempts)` and two said `request failed after 3 attempts: …`. Drift between these two files is not hypothetical — it is what produced the promcheck credential leak fixed in v0.18.1.

Now:

```go
if attempt < maxAttempts {
    time.Sleep(retryDelay)
    continue
}
return result.FailAfter(maxAttempts, "status %d, expected %d", statusCode, expectedStatus)
```

`Result.FailAfter` holds the wording, so the count and the message cannot separate.

## Also removes lastErr

Every path in both loops returns or continues, and `continue` only runs while tries remain — so on the final attempt the body always returns, and the trailing `return result.Failf("unexpected error: %v", lastErr)` was unreachable. Its eleven assignments were writes nothing could read. The line has to stay because the compiler cannot prove the loop never finishes, so it now says that rather than pretending to handle an edge case.

## One visible change

The two odd-one-out messages are unified:

```
- request failed after 3 attempts: dial tcp …: connection refused
+ request failed: dial tcp …: connection refused (after 3 attempts)
```

Verified against a refused port for both commands, with and without `--retry`; a single attempt still says nothing about attempts. No other behaviour changes — the existing suites pass untouched, which is the point of a refactor this shape.

Net −49 lines of production code.