### PR TITLE
Fix version extraction picking digits out of program names

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -89,6 +89,18 @@ preflight cmd node --range "^18.0.0"             # Compatible with 18.x
 preflight cmd python3 --range "~3.11.0"          # Patch releases of 3.11
 ```
 
+### Version Detection
+
+Version constraints read the number out of whatever the command prints. Program
+names often contain digits, so the leftmost number is not always the version —
+in `s3cmd version 2.3.0` it is the `3` in the name. Candidates are ranked by how
+many dot-separated components they have, and a number standing on its own beats
+one glued to a name, so `2.3.0` wins. A version attached to its name is still
+found when it is the only candidate, as in `go version go1.25.0`.
+
+Use `--version-regex` when a command's output defeats this, or `--match` to
+assert on the raw text without parsing a version at all.
+
 ---
 
 ## `preflight env`

--- a/pkg/version/parse.go
+++ b/pkg/version/parse.go
@@ -56,13 +56,71 @@ func ParseOptional(s string) (*Version, error) {
 	return &v, nil
 }
 
-// Extract finds and parses the first version number in a string.
+// Extract finds and parses the most version-like number in a string.
+//
+// Taking the leftmost match is not good enough, because program names carry
+// digits: read left to right, "s3cmd version 2.3.0" yields 3.0.0 and
+// "x264 0.164.3108" yields 264.0.0. Every candidate is scored instead, and the
+// best one wins.
 func Extract(s string) (Version, error) {
-	matches := versionRegex.FindStringSubmatch(s)
-	if matches == nil {
+	candidates := versionRegex.FindAllStringSubmatchIndex(s, -1)
+	if candidates == nil {
 		return Version{}, fmt.Errorf("no version found in: %q", s)
 	}
-	return parseMatches(matches), nil
+
+	best := candidates[0]
+	bestScore := score(s, best)
+	for _, c := range candidates[1:] {
+		// Strictly greater keeps the leftmost of equally good candidates.
+		if cScore := score(s, c); cScore > bestScore {
+			best, bestScore = c, cScore
+		}
+	}
+
+	return parseMatches(submatches(s, best)), nil
+}
+
+// score ranks a candidate by how much it looks like a version rather than a
+// number that happens to sit in a name.
+//
+// Both halves are load-bearing. Component count alone cannot separate the "7"
+// from the "23.01" in "7-Zip 23.01", since both start a word. Standing alone,
+// used on its own, would reject every candidate in "go version go1.25.0", where
+// the real version is glued to the name — so it only breaks ties, and a
+// two-component candidate still outranks a lone standalone digit.
+func score(s string, loc []int) int {
+	components := 0
+	for group := 1; group <= 3; group++ {
+		if loc[2*group] >= 0 {
+			components++
+		}
+	}
+
+	standalone := 0
+	if loc[0] == 0 || !isWordByte(s[loc[0]-1]) {
+		standalone = 1
+	}
+
+	return components*2 + standalone
+}
+
+// isWordByte reports whether b would glue a digit to a surrounding name. A
+// multi-byte rune's bytes are all >= 0x80 and so count as a separator, which is
+// what we want: a version after a non-ASCII character stands on its own.
+func isWordByte(b byte) bool {
+	return b >= '0' && b <= '9' || b >= 'a' && b <= 'z' || b >= 'A' && b <= 'Z'
+}
+
+// submatches converts an index pair list from FindAllStringSubmatchIndex into
+// the group strings that parseMatches expects.
+func submatches(s string, loc []int) []string {
+	groups := make([]string, len(loc)/2)
+	for i := range groups {
+		if start := loc[2*i]; start >= 0 {
+			groups[i] = s[start:loc[2*i+1]]
+		}
+	}
+	return groups
 }
 
 func parseMatches(matches []string) Version {

--- a/pkg/version/parse_test.go
+++ b/pkg/version/parse_test.go
@@ -94,6 +94,24 @@ func TestExtract(t *testing.T) {
 		{"Python 3.11.4", Version{3, 11, 4}, false},
 		{"no version here", Version{}, true},
 		{"", Version{}, true},
+
+		// Digits in the program name must not win over the real version.
+		{"s3cmd version 2.3.0", Version{2, 3, 0}, false},
+		{"bzip2, a block-sorting file compressor, version 1.0.8", Version{1, 0, 8}, false},
+		{"log4j 2.17.1", Version{2, 17, 1}, false},
+		{"x264 0.164.3108", Version{0, 164, 3108}, false},
+		{"p7zip Version 16.02", Version{16, 2, 0}, false},
+		{"7-Zip 23.01 (x64)", Version{23, 1, 0}, false},
+		{"libfoo2 3.4.5", Version{3, 4, 5}, false},
+
+		// A version glued to the name is still the only candidate, so it wins.
+		{"go version go1.25.0 darwin/arm64", Version{1, 25, 0}, false},
+		{"python3.12.1", Version{3, 12, 1}, false},
+
+		// Trailing build metadata must not outrank the version itself.
+		{"Docker version 24.0.7, build afdd53b", Version{24, 0, 7}, false},
+		{"git version 2.55.0 (Apple Git-154)", Version{2, 55, 0}, false},
+		{"openjdk version \"21.0.1\" 2023-10-17", Version{21, 0, 1}, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`version.Extract` took the leftmost number in a command's version output. Program names carry digits, so it frequently read the wrong one:

| Version output | Parsed as | Should be |
|---|---|---|
| `s3cmd version 2.3.0` | 3.0.0 | 2.3.0 |
| `bzip2, a block-sorting file compressor, version 1.0.8` | 2.0.0 | 1.0.8 |
| `log4j 2.17.1` | 4.0.0 | 2.17.1 |
| `x264 0.164.3108` | 264.0.0 | 0.164.3108 |
| `p7zip Version 16.02` | 7.0.0 | 16.2.0 |

Every `--min`/`--max`/`--exact`/`--range` check on such a command was answering about the wrong number — producing both false passes and false failures. Verified end to end: `preflight cmd s3cmd --max 3.0.0` against a binary reporting 2.3.0 went from `[FAIL]` to `[OK]`.

## Approach

Candidates are scored rather than taking the first: component count dominates, and standing apart from a name breaks ties.

Both halves are load-bearing. Component count alone cannot separate the `7` from the `23.01` in `7-Zip 23.01`, since both start a word. A word-boundary requirement alone would reject every candidate in `go version go1.25.0`, where the real version is glued to the name — so it only breaks ties, and a two-component candidate still outranks a lone standalone digit.

`Parse` is unchanged; it already required a full-string match and is only used for user-supplied constraint values.

Documented under a new "Version Detection" heading, pointing at `--version-regex` and `--match` as the escape hatches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection to select the most likely version when command output contains multiple numeric values.
  * Avoids mistaking digits in program names or trailing build metadata for the actual version.
  * Supports versions attached directly to names while preserving existing fallback behavior.

* **Documentation**
  * Added guidance on version candidate ranking and handling ambiguous output.
  * Recommends `--version-regex` or `--match` when automatic detection is unclear.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->