### PR TITLE
Fix file size and content checks silently passing on directories

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -203,6 +203,11 @@ preflight file <path> [flags]
 | `--mode-exact <perms>`    | Exact permissions required                           |
 | `--owner <uid>`           | Expected owner UID                                   |
 
+`--not-empty`, `--min-size`, `--max-size`, `--contains`, and `--match` need a
+regular file. Pointing them at a directory fails the check rather than skipping
+it — a size or content constraint that silently evaluated nothing would report
+`[OK]` for something never verified. The remaining flags work on directories.
+
 ### Examples
 
 ```sh

--- a/pkg/filecheck/check.go
+++ b/pkg/filecheck/check.go
@@ -39,6 +39,29 @@ func (c *Check) expectsSymlink() bool {
 	return c.ExpectSymlink || c.SymlinkTarget != ""
 }
 
+// fileOnlyFlags names the requested constraints that need a regular file,
+// in the order they appear in the check, so the failure lists every flag the
+// user has to reconsider rather than only the first.
+func (c *Check) fileOnlyFlags() []string {
+	var set []string
+	if c.NotEmpty {
+		set = append(set, "--not-empty")
+	}
+	if c.MinSize > 0 {
+		set = append(set, "--min-size")
+	}
+	if c.MaxSize > 0 {
+		set = append(set, "--max-size")
+	}
+	if c.Contains != "" {
+		set = append(set, "--contains")
+	}
+	if c.Match != "" {
+		set = append(set, "--match")
+	}
+	return set
+}
+
 // Run executes the file check.
 func (c *Check) Run() check.Result {
 	result := check.Result{
@@ -69,11 +92,15 @@ func (c *Check) Run() check.Result {
 		return result
 	}
 
-	// Size details and checks (only for files)
-	if !info.IsDir() {
-		if err := c.checkSizeConstraints(info, &result); err != nil {
-			return result
+	// Size and content need a file. A directory used to skip those flags and
+	// still report [OK], so `file /etc --min-size 999999999` passed a constraint
+	// nothing had evaluated.
+	if info.IsDir() {
+		if flags := c.fileOnlyFlags(); len(flags) > 0 {
+			return result.Failf("%s cannot be checked on a directory", strings.Join(flags, ", "))
 		}
+	} else if err := c.checkSizeConstraints(info, &result); err != nil {
+		return result
 	}
 
 	// Permission details
@@ -122,8 +149,8 @@ func (c *Check) Run() check.Result {
 		}
 	}
 
-	// Content checks (only for files, not directories)
-	if !info.IsDir() && (c.Contains != "" || c.Match != "") {
+	// Directories were rejected above if they carried either of these.
+	if c.Contains != "" || c.Match != "" {
 		if err := c.checkContent(&result); err != nil {
 			return result
 		}

--- a/pkg/filecheck/check_test.go
+++ b/pkg/filecheck/check_test.go
@@ -119,6 +119,18 @@ func TestCheck_Run(t *testing.T) {
 		{"max size passes", Check{Path: "/data.json", MaxSize: 200, FS: &mockFileSystem{StatFunc: statFile(0o644, 100)}}, check.StatusOK, ""},
 		{"max size fails", Check{Path: "/data.json", MaxSize: 50, FS: &mockFileSystem{StatFunc: statFile(0o644, 100)}}, check.StatusFail, "size 100 > maximum 50"},
 
+		// A directory has no content and no meaningful size, so a constraint that
+		// needs one must fail rather than be skipped: these all reported [OK]
+		// while evaluating nothing.
+		{"min size on directory", Check{Path: "/var/log", MinSize: 999999999, FS: &mockFileSystem{StatFunc: statDir()}}, check.StatusFail, "--min-size cannot be checked on a directory"},
+		{"max size on directory", Check{Path: "/var/log", MaxSize: 10, FS: &mockFileSystem{StatFunc: statDir()}}, check.StatusFail, "--max-size cannot be checked on a directory"},
+		{"not empty on directory", Check{Path: "/var/log", NotEmpty: true, FS: &mockFileSystem{StatFunc: statDir()}}, check.StatusFail, "--not-empty cannot be checked on a directory"},
+		{"contains on directory", Check{Path: "/var/log", Contains: "needle", FS: &mockFileSystem{StatFunc: statDir()}}, check.StatusFail, "--contains cannot be checked on a directory"},
+		{"match on directory", Check{Path: "/var/log", Match: "^needle$", FS: &mockFileSystem{StatFunc: statDir()}}, check.StatusFail, "--match cannot be checked on a directory"},
+		{"several file-only flags on directory", Check{Path: "/var/log", NotEmpty: true, Contains: "needle", FS: &mockFileSystem{StatFunc: statDir()}}, check.StatusFail, "--not-empty, --contains cannot be checked on a directory"},
+		{"explicit dir with file-only flag", Check{Path: "/var/log", ExpectDir: true, MinSize: 10, FS: &mockFileSystem{StatFunc: statDir()}}, check.StatusFail, "--min-size cannot be checked on a directory"},
+		{"directory with no file-only flags still passes", Check{Path: "/var/log", ExpectDir: true, Mode: "0755", FS: &mockFileSystem{StatFunc: statDir()}}, check.StatusOK, "type: directory"},
+
 		// Permissions. These consult the filesystem rather than the mode bits:
 		// a mode with the write bit set may still be unwritable by this process.
 		{"writable passes", Check{Path: "/data.json", Writable: true, FS: &mockFileSystem{StatFunc: statFile(0o644, 100), CanAccessFunc: accessAllowed()}}, check.StatusOK, ""},


### PR DESCRIPTION
`--not-empty`, `--min-size`, `--max-size`, `--contains` and `--match` were gated behind `!info.IsDir()`. Pointing any of them at a directory skipped the constraint and still reported success:

```
$ preflight file /etc --min-size 999999999
[OK] file: /etc
     type: directory
$ echo $?
0
```

All five behaved this way. A verification tool reporting `[OK]` for a constraint it never evaluated is worse than one without the flag at all.

They now fail:

```
$ preflight file /etc --min-size 999999999
[FAIL] file: /etc
       type: directory
       --min-size cannot be checked on a directory
```

The message names every inapplicable flag at once (`--not-empty, --contains cannot be checked on a directory`) rather than surfacing them one per run.

Directory checks that don't involve size or content — `--dir`, `--mode`, `--writable`, `--owner` — are unaffected, as are all file checks.