### PR TITLE
Fix --match silently disabling version constraints in cmd check

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,6 +57,10 @@ preflight cmd <command> [flags]
 | `--version-cmd <arg>`   | Override the default `--version` argument       |
 | `--timeout <duration>`  | Timeout for version command (default: 30s)      |
 
+These flags combine, and every one given must hold. `--match` asserts on the raw
+version output while `--min`, `--max`, `--exact` and `--range` assert on the
+version parsed out of it, so using them together checks both.
+
 ### Examples
 
 ```sh

--- a/pkg/cmdcheck/check.go
+++ b/pkg/cmdcheck/check.go
@@ -70,18 +70,28 @@ func (c *Check) Run() check.Result {
 		versionOutput = stderr
 	}
 
-	switch {
-	case c.MatchPattern != "":
+	hasVersionConstraint := c.MinVersion != nil || c.MaxVersion != nil || c.ExactVersion != nil ||
+		c.VersionPattern != "" || c.VersionRange != ""
+
+	// Without a version constraint there is no parsed version to report, so the
+	// raw output stands in for one.
+	if !hasVersionConstraint && versionOutput != "" {
+		result.AddDetailf("version: %s", versionOutput)
+	}
+
+	// --match and a version constraint are independent assertions and both have
+	// to hold. These used to be arms of one switch, where --match won and left
+	// the version constraint unevaluated: `cmd git --match 'git version' --min 99`
+	// reported [OK] while `--min 99` alone correctly failed.
+	if c.MatchPattern != "" {
 		if err := c.checkMatchPattern(versionOutput, &result); err != nil {
 			return result
 		}
-	case c.MinVersion != nil || c.MaxVersion != nil || c.ExactVersion != nil || c.VersionPattern != "" || c.VersionRange != "":
+	}
+
+	if hasVersionConstraint {
 		if err := c.checkVersionConstraints(versionOutput, &result); err != nil {
 			return result
-		}
-	default:
-		if versionOutput != "" {
-			result.AddDetailf("version: %s", versionOutput)
 		}
 	}
 
@@ -100,7 +110,6 @@ func (c *Check) checkMatchPattern(output string, result *check.Result) error {
 		result.Fail(fmt.Sprintf("version output %q does not match pattern %q", output, c.MatchPattern), err)
 		return err
 	}
-	result.AddDetailf("version: %s", output)
 	return nil
 }
 

--- a/pkg/cmdcheck/check_test.go
+++ b/pkg/cmdcheck/check_test.go
@@ -61,6 +61,16 @@ func TestCommandCheck_Run(t *testing.T) {
 		{"match fails", Check{Name: "n", MatchPattern: `^v18\.`, Runner: &mockCmdRunner{LookPathFunc: found, RunCommandContextFunc: run("v16.0.0")}}, check.StatusFail},
 		{"match invalid regex", Check{Name: "n", MatchPattern: `[invalid`, Runner: &mockCmdRunner{LookPathFunc: found, RunCommandContextFunc: run("v18.0.0")}}, check.StatusFail},
 
+		// --match combined with a version constraint. Both are assertions the
+		// user made, so both have to hold: --match used to win the switch and
+		// leave the version constraint unevaluated.
+		{"match passes but min fails", Check{Name: "n", MatchPattern: `^v18\.`, MinVersion: v(99, 0, 0), Runner: &mockCmdRunner{LookPathFunc: found, RunCommandContextFunc: run("v18.17.0")}}, check.StatusFail},
+		{"match passes but max fails", Check{Name: "n", MatchPattern: `^v18\.`, MaxVersion: v(1, 0, 0), Runner: &mockCmdRunner{LookPathFunc: found, RunCommandContextFunc: run("v18.17.0")}}, check.StatusFail},
+		{"match passes but exact fails", Check{Name: "n", MatchPattern: `^v18\.`, ExactVersion: v(1, 0, 0), Runner: &mockCmdRunner{LookPathFunc: found, RunCommandContextFunc: run("v18.17.0")}}, check.StatusFail},
+		{"match passes but range fails", Check{Name: "n", MatchPattern: `^v18\.`, VersionRange: ">=99.0.0", Runner: &mockCmdRunner{LookPathFunc: found, RunCommandContextFunc: run("v18.17.0")}}, check.StatusFail},
+		{"match fails but min passes", Check{Name: "n", MatchPattern: `^v99\.`, MinVersion: v(1, 0, 0), Runner: &mockCmdRunner{LookPathFunc: found, RunCommandContextFunc: run("v18.17.0")}}, check.StatusFail},
+		{"match and min both pass", Check{Name: "n", MatchPattern: `^v18\.`, MinVersion: v(18, 0, 0), Runner: &mockCmdRunner{LookPathFunc: found, RunCommandContextFunc: run("v18.17.0")}}, check.StatusOK},
+
 		// Parse failures
 		{"version parse fails", Check{Name: "n", MinVersion: v(1, 0, 0), Runner: &mockCmdRunner{LookPathFunc: found, RunCommandContextFunc: run("no version")}}, check.StatusFail},
 		{"version from stderr", Check{Name: "java", Runner: &mockCmdRunner{LookPathFunc: found, RunCommandContextFunc: runStderr("openjdk 17.0.1")}}, check.StatusOK},


### PR DESCRIPTION
`--match` and the version constraints were arms of a single `switch`, so `--match` won and the version constraint was never evaluated:

```
$ preflight cmd git --min 99                        -> [FAIL] version 2.55.0 < minimum 99.0.0
$ preflight cmd git --match 'git version' --min 99  -> [OK]
```

Both are assertions the user made, so both now have to hold. The switch was also inconsistent with the command's own behaviour — `--exact` and `--range` already combined correctly with each other, and every other command (`env`, `file`) evaluates its flags in sequence.

## Output

The raw-output detail moves ahead of the checks and is emitted only when no version constraint will report a parsed version. That keeps `--match` alone byte-identical to before, and avoids two `version:` lines when both are used:

```
$ preflight cmd git --match 'git version'            # unchanged
[OK] cmd: git
     path: /opt/homebrew/bin/git
     version: git version 2.55.0

$ preflight cmd git --match 'git version' --min 99   # now fails
[FAIL] cmd: git
       path: /opt/homebrew/bin/git
       version: 2.55.0
       version 2.55.0 < minimum 99.0.0
```