### PR TITLE
Run every check in a .preflight file, not just up to the first failure

### DIFF
--- a/cmd/preflight/cmd_run.go
+++ b/cmd/preflight/cmd_run.go
@@ -66,10 +66,16 @@ func spawn(name string, args []string) error {
 	return cmd.Run()
 }
 
-// runCommands executes each .preflight command, returning the exit code to
+// runCommands executes every .preflight command, returning the exit code to
 // propagate. run is injected so the loop — including the substitution below —
 // can be tested without spawning processes or calling os.Exit.
+//
+// A failing check no longer ends the run. The point of a preflight is a single
+// pass that reports everything wrong with an environment; stopping at the first
+// failure turned that into fix one, rerun, find the next.
 func runCommands(commands []string, executable string, run func(name string, args []string) error) (exitCode int, err error) {
+	ran, failed := 0, 0
+
 	for _, command := range commands {
 		parts := strings.Fields(command)
 		if len(parts) == 0 {
@@ -81,14 +87,24 @@ func runCommands(commands []string, executable string, run func(name string, arg
 		// never turn a .preflight line into a path to some other binary.
 		parts[0] = executable
 
+		ran++
 		if err := run(parts[0], parts[1:]); err != nil {
+			// Failing to spawn is not a check result. The remaining lines would
+			// fail the same way, so stop rather than repeat the same error.
 			var exitError *exec.ExitError
-			if errors.As(err, &exitError) {
-				return exitError.ExitCode(), nil
+			if !errors.As(err, &exitError) {
+				return 0, fmt.Errorf("failed to execute command %q: %w", command, err)
 			}
-			return 0, fmt.Errorf("failed to execute command %q: %w", command, err)
+			failed++
 		}
 		checkRan = true
+	}
+
+	if failed > 0 {
+		fmt.Printf("\n%d of %d checks failed\n", failed, ran)
+		// The child is always preflight itself, which only ever exits 0 or 1,
+		// so there is no other code worth forwarding.
+		return 1, nil
 	}
 
 	return 0, nil

--- a/cmd/preflight/cmd_run_test.go
+++ b/cmd/preflight/cmd_run_test.go
@@ -41,7 +41,7 @@ func TestRunCommands(t *testing.T) {
 		assert.Equal(t, exe, gotName, "a path in the file must not become the program")
 	})
 
-	t.Run("propagates a child's exit code", func(t *testing.T) {
+	t.Run("a failing check exits 1", func(t *testing.T) {
 		failing := exec.Command("sh", "-c", "exit 42")
 		exitErr := failing.Run()
 		require.Error(t, exitErr)
@@ -50,7 +50,9 @@ func TestRunCommands(t *testing.T) {
 			return exitErr
 		})
 		require.NoError(t, err)
-		assert.Equal(t, 42, code)
+		// The child is always preflight itself, which only ever exits 0 or 1,
+		// so there is no other code worth forwarding.
+		assert.Equal(t, 1, code)
 	})
 
 	t.Run("a non-exit failure is an error, not an exit code", func(t *testing.T) {
@@ -62,7 +64,9 @@ func TestRunCommands(t *testing.T) {
 		assert.Contains(t, err.Error(), "preflight env HOME")
 	})
 
-	t.Run("stops at the first failing command", func(t *testing.T) {
+	// The point of a preflight is one pass that reports everything wrong, not a
+	// fix-one-rerun loop, so a failing check must not hide the ones after it.
+	t.Run("runs every command even after one fails", func(t *testing.T) {
 		calls := 0
 		failing := exec.Command("sh", "-c", "exit 3")
 		exitErr := failing.Run()
@@ -76,8 +80,35 @@ func TestRunCommands(t *testing.T) {
 				return nil
 			})
 		require.NoError(t, err)
-		assert.Equal(t, 3, code)
-		assert.Equal(t, 2, calls, "must not keep running after a failure")
+		assert.Equal(t, 1, code)
+		assert.Equal(t, 3, calls, "a failure must not stop the checks after it")
+	})
+
+	t.Run("several failures still run everything and exit 1", func(t *testing.T) {
+		calls := 0
+		exitErr := exec.Command("sh", "-c", "exit 1").Run()
+
+		code, err := runCommands([]string{"preflight env A", "preflight env B", "preflight env C"}, exe,
+			func(string, []string) error {
+				calls++
+				return exitErr
+			})
+		require.NoError(t, err)
+		assert.Equal(t, 1, code)
+		assert.Equal(t, 3, calls)
+	})
+
+	// A failure to spawn is not a check result, so it still stops the run: the
+	// remaining lines would fail the same way and bury the real cause.
+	t.Run("a non-exit failure stops the run", func(t *testing.T) {
+		calls := 0
+		_, err := runCommands([]string{"preflight env A", "preflight env B"}, exe,
+			func(string, []string) error {
+				calls++
+				return errors.New("fork failed")
+			})
+		require.Error(t, err)
+		assert.Equal(t, 1, calls)
 	})
 
 	t.Run("blank commands are skipped without running anything", func(t *testing.T) {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1206,6 +1206,26 @@ preflight tcp localhost:5432
 - Lines without `preflight` prefix are automatically prepended with `preflight`
 - Commands execute sequentially
 
+Every check runs, including the ones after a failure, so a single pass reports
+everything wrong with the environment rather than one problem at a time. A
+summary follows the results, and the exit code is `1` if any check failed:
+
+```
+[OK] cmd: git
+     path: /usr/bin/git
+     version: git version 2.55.0
+[FAIL] cmd: ffmpeg
+       not found in PATH
+[FAIL] env: DATABASE_URL
+       not set
+
+2 of 3 checks failed
+```
+
+A command that cannot be started at all — as opposed to a check that fails — is
+a different problem and does stop the run, since every remaining line would fail
+the same way.
+
 ### File Discovery
 
 When run without `--file`, `preflight run` searches for a `.preflight` file:

--- a/integration_test.go
+++ b/integration_test.go
@@ -735,11 +735,20 @@ func TestIntegration_Run(t *testing.T) {
 		assert.Contains(t, out, "[OK] env: PATH")
 	})
 
-	t.Run("a failing check propagates exit 1 and stops", func(t *testing.T) {
+	t.Run("a failing check exits 1 without hiding the checks after it", func(t *testing.T) {
 		out, code := run(t, "env PREFLIGHT_DEFINITELY_UNSET_XYZ\nenv PATH\n")
 		assert.Equal(t, 1, code)
 		assert.Contains(t, out, "[FAIL]")
-		assert.NotContains(t, out, "[OK] env: PATH", "must stop at the first failure")
+		assert.Contains(t, out, "[OK] env: PATH", "a failure must not stop the checks after it")
+		assert.Contains(t, out, "1 of 2 checks failed")
+	})
+
+	t.Run("every failure is reported, not just the first", func(t *testing.T) {
+		out, code := run(t, "env PREFLIGHT_UNSET_ONE\nenv PATH\nenv PREFLIGHT_UNSET_TWO\n")
+		assert.Equal(t, 1, code)
+		assert.Contains(t, out, "[FAIL] env: PREFLIGHT_UNSET_ONE")
+		assert.Contains(t, out, "[FAIL] env: PREFLIGHT_UNSET_TWO")
+		assert.Contains(t, out, "2 of 3 checks failed")
 	})
 
 	t.Run("a line naming another binary does not run it", func(t *testing.T) {


### PR DESCRIPTION
`runCommands` returned on the first failing check, so a file of ten checks reported one problem and hid the rest:

```
$ cat .preflight
cmd git
cmd definitely-not-real
cmd also-not-real
cmd ls

$ preflight run            # before
[OK] cmd: git
[FAIL] cmd: definitely-not-real
$ echo $?
1                          # checks 3 and 4 never ran
```

That turns a preflight into fix-one, rerun, find-the-next — the opposite of the tool's purpose. The README already advertised it as "Run all checks", and the docs only said commands execute sequentially, so nothing documented the abort either.

Now:

```
[OK] cmd: git
[FAIL] cmd: definitely-not-real
       not found in PATH
[FAIL] cmd: also-not-real
       not found in PATH
[FAIL] cmd: ls
       version command failed: exit status 1

3 of 4 checks failed
```

Exit code is 1 when any check failed. The child process is always preflight itself, which only ever exits 0 or 1, so there was no other exit code worth forwarding — the old code propagated `exitError.ExitCode()` but could never receive anything but 1.

A failure to *spawn* still stops the run. That is not a check result, and every remaining line would fail identically and bury the real cause.

Two existing tests asserted the old behaviour and were rewritten; a third was added for the multi-failure case.