### PR TITLE
Add quoting to .preflight files so arguments can contain spaces

### DIFF
--- a/cmd/preflight/cmd_run.go
+++ b/cmd/preflight/cmd_run.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -77,7 +76,12 @@ func runCommands(commands []string, executable string, run func(name string, arg
 	ran, failed := 0, 0
 
 	for _, command := range commands {
-		parts := strings.Fields(command)
+		// Quote-aware, so an argument may contain a space. ParseFile has already
+		// accepted these lines, so a failure here means the two disagree.
+		parts, err := preflightfile.Fields(command)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse command %q: %w", command, err)
+		}
 		if len(parts) == 0 {
 			continue
 		}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1206,6 +1206,29 @@ preflight tcp localhost:5432
 - Lines without `preflight` prefix are automatically prepended with `preflight`
 - Commands execute sequentially
 
+### Quoting
+
+An argument containing a space must be quoted, and either quote works:
+
+```sh
+env GREETING --exact "hello world"
+env GREETING --contains 'lo wo'
+```
+
+Single quotes are literal throughout, which is what a regex or a JSON document
+usually wants:
+
+```sh
+cmd myapp --match '^v2\.'
+json config.json --key name --exact '{"a": 1}'
+```
+
+Double quotes recognise `\"` and `\\` and leave every other backslash alone, so
+`"^v2\."` still means what it looks like. There is no variable expansion or
+command substitution — a line is a list of arguments, not a shell command. An
+unclosed quote is reported with its line number rather than silently
+mis-splitting the line.
+
 Every check runs, including the ones after a failure, so a single pass reports
 everything wrong with the environment rather than one problem at a time. A
 summary follows the results, and the exit code is `1` if any check failed:

--- a/integration_test.go
+++ b/integration_test.go
@@ -751,6 +751,28 @@ func TestIntegration_Run(t *testing.T) {
 		assert.Contains(t, out, "2 of 3 checks failed")
 	})
 
+	// strings.Fields split on every space, so a value containing one reached
+	// cobra as several arguments and the line failed with a usage dump.
+	t.Run("an argument may contain spaces", func(t *testing.T) {
+		t.Setenv("PREFLIGHT_SPACED", "hello world")
+		out, code := run(t, "env PREFLIGHT_SPACED --exact \"hello world\"\n")
+		assert.Equal(t, 0, code, out)
+		assert.Contains(t, out, "[OK] env: PREFLIGHT_SPACED")
+	})
+
+	t.Run("single quotes keep a regex intact", func(t *testing.T) {
+		t.Setenv("PREFLIGHT_SPACED", "hello world")
+		out, code := run(t, "env PREFLIGHT_SPACED --match '^hello\\s'\n")
+		assert.Equal(t, 0, code, out)
+		assert.Contains(t, out, "[OK] env: PREFLIGHT_SPACED")
+	})
+
+	t.Run("an unterminated quote is reported with its line number", func(t *testing.T) {
+		out, code := run(t, "env PATH\nenv HOME --exact \"unclosed\n")
+		assert.NotEqual(t, 0, code)
+		assert.Contains(t, out, "line 2")
+	})
+
 	t.Run("a line naming another binary does not run it", func(t *testing.T) {
 		out, code := run(t, "preflight/../evil.sh\n")
 		assert.NotEqual(t, 0, code)

--- a/pkg/preflightfile/fields.go
+++ b/pkg/preflightfile/fields.go
@@ -1,0 +1,96 @@
+package preflightfile
+
+import (
+	"errors"
+	"strings"
+)
+
+// Fields splits a .preflight line into arguments, honouring single quotes,
+// double quotes and backslash escapes the way a shell does for simple words.
+//
+// strings.Fields split on every space, so an argument containing one could not
+// be written at all: `env GREETING --exact "hello world"` arrived as four
+// arguments and cobra rejected the line with "accepts 1 arg(s), received 4"
+// and a usage dump.
+//
+// Quoting rules are deliberately the small POSIX subset that argument values
+// need. Single quotes are literal throughout, so a regex or a JSON document can
+// be pasted in unchanged. Double quotes recognise \" and \\ and leave every
+// other backslash alone, which keeps `"^v2\."` meaning what it looks like.
+// There is no variable expansion, command substitution or globbing: a line is a
+// list of arguments, not a shell command.
+func Fields(line string) ([]string, error) {
+	var (
+		fields  []string
+		current strings.Builder
+		quote   byte // 0, '\'' or '"'
+		started bool // a quote can produce an argument with no characters in it
+	)
+
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+
+		switch {
+		case quote == '\'':
+			if c == '\'' {
+				quote = 0
+				continue
+			}
+			current.WriteByte(c)
+
+		case quote == '"':
+			// Only these two escapes are consumed. Anything else keeps its
+			// backslash, so a regex does not need doubling.
+			if c == '\\' && i+1 < len(line) && (line[i+1] == '"' || line[i+1] == '\\') {
+				i++
+				current.WriteByte(line[i])
+				continue
+			}
+			if c == '"' {
+				quote = 0
+				continue
+			}
+			current.WriteByte(c)
+
+		case c == '\'' || c == '"':
+			quote = c
+			started = true
+
+		case c == '\\':
+			if i+1 >= len(line) {
+				return nil, errors.New("line ends with a trailing backslash")
+			}
+			i++
+			current.WriteByte(line[i])
+			started = true
+
+		case c == ' ' || c == '\t':
+			if started || current.Len() > 0 {
+				fields = append(fields, current.String())
+				current.Reset()
+				started = false
+			}
+
+		default:
+			current.WriteByte(c)
+			started = true
+		}
+	}
+
+	if quote != 0 {
+		return nil, errors.New("unterminated " + quoteName(quote) + " quote")
+	}
+
+	if started || current.Len() > 0 {
+		fields = append(fields, current.String())
+	}
+
+	return fields, nil
+}
+
+func quoteName(quote byte) string {
+	if quote == '\'' {
+		return "single"
+	}
+	return "double"
+}

--- a/pkg/preflightfile/fields_test.go
+++ b/pkg/preflightfile/fields_test.go
@@ -1,0 +1,64 @@
+package preflightfile
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFields(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{"empty", "", nil},
+		{"only spaces", "   \t ", nil},
+		{"plain words", "env HOME", []string{"env", "HOME"}},
+		{"collapses runs of whitespace", "env \t  HOME", []string{"env", "HOME"}},
+
+		// The reason this exists: an argument containing a space could not be
+		// written at all, because every space split it into another argument.
+		{"double quoted argument", `env GREETING --exact "hello world"`, []string{"env", "GREETING", "--exact", "hello world"}},
+		{"single quoted argument", `env GREETING --exact 'hello world'`, []string{"env", "GREETING", "--exact", "hello world"}},
+		{"quotes join to adjacent text", `env X --exact pre"fix suffix"`, []string{"env", "X", "--exact", "prefix suffix"}},
+		{"empty quoted argument stays an argument", `env X --exact ""`, []string{"env", "X", "--exact", ""}},
+
+		// Regexes and JSON are ordinary arguments here, so quoting has to leave
+		// their contents alone.
+		{"single quotes keep backslashes literal", `cmd myapp --match '^v2\.'`, []string{"cmd", "myapp", "--match", `^v2\.`}},
+		{"single quotes keep double quotes literal", `json f --exact '{"a": 1}'`, []string{"json", "f", "--exact", `{"a": 1}`}},
+		{"double quotes keep single quotes literal", `env X --exact "it's"`, []string{"env", "X", "--exact", "it's"}},
+		{"escaped double quote inside double quotes", `env X --exact "say \"hi\""`, []string{"env", "X", "--exact", `say "hi"`}},
+		{"escaped backslash inside double quotes", `env X --exact "a\\b"`, []string{"env", "X", "--exact", `a\b`}},
+		{"unknown escape is left alone inside double quotes", `env X --match "^v2\."`, []string{"env", "X", "--match", `^v2\.`}},
+		{"backslash escapes a space outside quotes", `env X --exact hello\ world`, []string{"env", "X", "--exact", "hello world"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Fields(tt.line)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFields_UnterminatedQuote(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		{"unterminated double quote", `env X --exact "hello`},
+		{"unterminated single quote", `env X --exact 'hello`},
+		{"trailing backslash", `env X --exact hello\`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Fields(tt.line)
+			require.Error(t, err, "an unclosed quote must be reported, not silently accepted")
+		})
+	}
+}

--- a/pkg/preflightfile/preflightfile.go
+++ b/pkg/preflightfile/preflightfile.go
@@ -61,7 +61,7 @@ func ParseFile(path string) ([]string, error) {
 	lines := strings.Split(string(data), "\n")
 	commands := []string{}
 
-	for _, line := range lines {
+	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
 
 		if trimmed == "" {
@@ -76,7 +76,11 @@ func ParseFile(path string) ([]string, error) {
 		// beginning with "preflight" — including preflight/../evil.sh, a path
 		// that cmd_run then executed directly because its substitution tests
 		// for the exact token.
-		if fields := strings.Fields(trimmed); len(fields) == 0 || fields[0] != "preflight" {
+		fields, err := Fields(trimmed)
+		if err != nil {
+			return nil, fmt.Errorf("line %d: %w", i+1, err)
+		}
+		if len(fields) == 0 || fields[0] != "preflight" {
 			trimmed = "preflight " + trimmed
 		}
 


### PR DESCRIPTION
Lines were split with `strings.Fields`, so every space started a new argument and a value containing one could not be written at all:

```
# .preflight
env GREETING --exact "hello world"
```
```
Error: accepts 1 arg(s), received 4
Usage:
  preflight env <variable> [flags]
... 20 more lines of usage
```

## Rules

`Fields` honours single quotes, double quotes and backslash escapes — the small POSIX subset argument values actually need:

- **Single quotes** are literal throughout, so a regex or JSON document pastes in unchanged: `--match '^v2\.'`
- **Double quotes** consume only `\"` and `\\`, leaving every other backslash alone, so `"^v2\."` still means what it looks like
- **No expansion or substitution.** A line is a list of arguments, not a shell command — no variables, no globbing, no subshells.

Verified end to end; all four of these now pass where the first two previously could not be expressed:

```
env GREETING --exact "hello world"
env GREETING --contains 'lo wo'
env GREETING --match '^hello\s'
cmd git
```

## Notes

`ParseFile` and `runCommands` share the tokenizer, so the security property added earlier — that the first token is exactly `preflight` before substitution — is still checked against the same parse that produces the arguments, not a second, differently-behaving split.

An unterminated quote is reported with its line number (`Error: line 2: unterminated double quote`) rather than silently mis-splitting the line.