### PR TITLE
Print multi-line check details as indented lines, not escaped newlines

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1511,14 +1511,25 @@ See [examples/multistage-dockerfile](../examples/multistage-dockerfile) for a co
 
 ### One line per line
 
-Every result line starts at column 0 with `[OK]` or `[FAIL]`, and every detail is indented under it. Details often quote text a checked program controls — a version banner, an HTTP response body, an environment variable — so control characters in that text are printed as escapes (`\n`, `\x1b`) rather than acted on. A program under check therefore cannot forge a result line of its own, or rewrite what is already on screen:
+Every result line starts at column 0 with `[OK]` or `[FAIL]`, and **every** line of every detail is indented under it — including the second and later lines of multi-line output. That indentation is the guarantee: a checked program controls the text in a version banner, an HTTP response body or an environment variable, but nothing it emits can reach column 0, so it cannot forge a result of its own:
 
 ```
 [OK] cmd: myapp
-     version: 1.0\n[OK] cmd: postgres\n     version: 14.2
+     version: 1.0
+     [OK] cmd: postgres
+          version: 14.2
 ```
 
-Only `myapp` was checked there. A trailing newline is dropped rather than escaped, so ordinary program output does not pick up a stray `\n`.
+Only `myapp` was checked there. The `[OK] cmd: postgres` line came from `myapp`, and its indentation is what says so.
+
+Line breaks and tabs in program output are kept, since neither can reach column 0. Every other control character is printed as an escape rather than acted on, so a carriage return or an ANSI sequence cannot overwrite what is already on screen:
+
+```
+[OK] cmd: myapp
+     version: 1.0\x1b[2K\r[OK] all good
+```
+
+A trailing newline is dropped, so ordinary program output does not gain a blank line.
 
 ---
 

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -123,40 +123,80 @@ func isCIEnvironment() bool {
 
 // PrintResult outputs a check result with colored status.
 func PrintResult(r check.Result) {
-	var indent string
 	if r.OK() {
-		fmt.Printf("%s[OK]%s %s\n", green, reset, formatLabel(sanitize(r.Name)))
-		indent = "     " // align with content after "[OK] "
-		for _, d := range r.Details {
-			fmt.Printf("%s%s\n", indent, formatLabel(sanitize(d)))
-		}
-	} else {
-		fmt.Printf("%s[FAIL]%s %s\n", red, reset, formatLabel(sanitize(r.Name)))
-		indent = "       " // align with content after "[FAIL] "
-		for _, d := range r.Details {
-			fmt.Printf("%s%s%s%s\n", indent, red, sanitize(d), reset)
+		fmt.Printf("%s[OK]%s %s\n", green, reset, formatLabel(sanitizeInline(r.Name)))
+		// Align with content after "[OK] ".
+		printDetails(r.Details, "     ", true)
+		return
+	}
+
+	fmt.Printf("%s[FAIL]%s %s\n", red, reset, formatLabel(sanitizeInline(r.Name)))
+	// Align with content after "[FAIL] ".
+	printDetails(r.Details, "       ", false)
+}
+
+// printDetails writes each detail under the result line, indenting every line of
+// it. A detail routinely spans several lines — a version banner, a stderr dump,
+// an HTTP body — and indenting the continuation lines is what keeps a checked
+// program from forging a result of its own: those start at column 0.
+//
+// Blank lines are left blank rather than indented, so no line carries trailing
+// whitespace.
+func printDetails(details []string, indent string, ok bool) {
+	for _, d := range details {
+		for i, line := range strings.Split(sanitizeBlock(d), "\n") {
+			switch {
+			case line == "":
+				fmt.Println()
+			case !ok:
+				fmt.Printf("%s%s%s%s\n", indent, red, line, reset)
+			case i == 0:
+				// Only the opening line carries the "label:" that dimming applies to.
+				fmt.Printf("%s%s\n", indent, formatLabel(line))
+			default:
+				fmt.Printf("%s%s\n", indent, line)
+			}
 		}
 	}
 }
 
-// sanitize renders control characters as escapes so that text a checked program
-// controls — a version banner, an HTTP body, an environment variable — cannot
-// forge result lines with a newline or redraw the terminal with an escape
-// sequence. Preflight's whole output is a claim about what was verified, so
-// nothing it reports may be able to write that claim itself.
-func sanitize(s string) string {
-	// Program output almost always ends in a newline, and escaping that one
-	// would just add a trailing `\n` to every such detail.
+// sanitizeInline renders every control character as an escape, newlines
+// included. It is for text that has to stay on one line: a result's name shares
+// its line with the [OK] marker, so a newline there would put whatever followed
+// at column 0, which is exactly what a forged result line looks like.
+func sanitizeInline(s string) string {
+	return escapeControl(s, func(r rune) bool { return r == '\t' })
+}
+
+// sanitizeBlock keeps newlines for the caller to indent, and escapes every other
+// control character. A carriage return still has to go: it returns to column 0
+// and overwrites what is already there, so it could rewrite a real result line.
+func sanitizeBlock(s string) string {
+	return escapeControl(s, func(r rune) bool { return r == '\t' || r == '\n' })
+}
+
+// escapeControl renders control characters as escapes, except the ones keep
+// accepts. Text a checked program controls — a version banner, an HTTP body, an
+// environment variable — must not be able to redraw the terminal or write
+// preflight's own claims about what was verified.
+//
+// Tabs are kept throughout: they only ever move right, so they cannot reach
+// column 0, and escaping them mangled the tab-aligned help text programs print
+// when a version flag is wrong.
+func escapeControl(s string, keep func(rune) bool) string {
+	// Program output almost always ends in a newline, and keeping that one would
+	// add a blank line under every such detail.
 	s = strings.TrimRight(s, " \t\r\n")
 
-	if !strings.ContainsFunc(s, unicode.IsControl) {
+	escaped := func(r rune) bool { return unicode.IsControl(r) && !keep(r) }
+	if !strings.ContainsFunc(s, escaped) {
 		return s
 	}
 
 	var b strings.Builder
 	b.Grow(len(s))
 	for _, r := range s {
-		if unicode.IsControl(r) {
+		if escaped(r) {
 			// QuoteRune yields the familiar Go forms: '\n', '\x1b', ''.
 			b.WriteString(strings.Trim(strconv.QuoteRune(r), "'"))
 			continue

--- a/pkg/output/output_test.go
+++ b/pkg/output/output_test.go
@@ -337,10 +337,14 @@ func TestIsCIEnvironment(t *testing.T) {
 }
 
 // Details carry text that a checked program controls: a version banner, an HTTP
-// response, an environment variable. Printed verbatim, a newline lets that
-// program forge whole result lines and an escape sequence lets it redraw the
-// terminal, which is a problem for a tool whose entire output is a claim about
-// what was verified.
+// response, an environment variable. Printed verbatim, an escape sequence lets
+// that program redraw the terminal, which is a problem for a tool whose entire
+// output is a claim about what was verified.
+//
+// A newline is different. Escaping it made a program's own line breaks unreadable
+// — 40 lines of `go help` arrived as one line of literal \n — when indenting the
+// continuation lines gives the same guarantee: result lines start at column 0,
+// and nothing a checked program emits ever does.
 func TestPrintResult_NeutralisesControlCharactersFromCheckedPrograms(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -355,7 +359,23 @@ func TestPrintResult_NeutralisesControlCharactersFromCheckedPrograms(t *testing.
 				Details: []string{"version: 1.0\n[OK] cmd: postgres\n     version: 14.2"},
 			},
 			want: `[OK] cmd: evil
-     version: 1.0\n[OK] cmd: postgres\n     version: 14.2
+     version: 1.0
+     [OK] cmd: postgres
+          version: 14.2
+`,
+		},
+		{
+			name: "multi-line output keeps its line breaks",
+			result: check.Result{
+				Name:    "cmd: go",
+				Status:  check.StatusFail,
+				Details: []string{"stderr: usage: go <command>\n\nThe commands are:\n\tbuild\tcompile packages"},
+			},
+			want: `[FAIL] cmd: go
+       stderr: usage: go <command>
+
+       The commands are:
+       	build	compile packages
 `,
 		},
 		{
@@ -370,18 +390,19 @@ func TestPrintResult_NeutralisesControlCharactersFromCheckedPrograms(t *testing.
 `,
 		},
 		{
-			name: "a failing check is neutralised too",
+			name: "a carriage return is still escaped, so it cannot return to column 0",
 			result: check.Result{
 				Name:    "http: /health",
 				Status:  check.StatusFail,
 				Details: []string{"body: bad\r\n[OK] http: /health"},
 			},
 			want: `[FAIL] http: /health
-       body: bad\r\n[OK] http: /health
+       body: bad\r
+       [OK] http: /health
 `,
 		},
 		{
-			name: "the check name is not a way in either",
+			name: "the name stays on one line, because it shares one with the marker",
 			result: check.Result{
 				Name:    "env: X\n[OK] env: SECRET",
 				Status:  check.StatusOK,
@@ -391,7 +412,7 @@ func TestPrintResult_NeutralisesControlCharactersFromCheckedPrograms(t *testing.
 `,
 		},
 		{
-			name: "a trailing newline is dropped rather than escaped",
+			name: "a trailing newline is dropped rather than printed as a blank line",
 			result: check.Result{
 				Name:    "cmd: brokenbin",
 				Status:  check.StatusFail,


### PR DESCRIPTION
In #228 I made `sanitize` escape every control character uniformly, because that was the simplest way to stop a checked program forging an `[OK]` line. Newlines got swept up in that, and they didn't need to be. The result was that real multi-line output became unreadable — `preflight cmd go` with a wrong version flag printed 40 lines of help as one line of literal `\n` and `\t`.

Truncating that output would have left it garbled and merely shorter. This fixes the cause instead.

## The actual guarantee

A program can't forge a result line because **result lines start at column 0 and details are indented** — already the documented contract. Indenting the continuation lines of a multi-line detail satisfies it just as well as escaping the newline did:

```
[OK] cmd: forger
     path: /tmp/bin/forger
     version: 1.0
     [OK] cmd: postgres
          version: 14.2
```

The forged line sits at column 5. Verified: `grep -c '^\[OK\]'` returns 1.

## What changed

- **Newlines and tabs are kept.** Neither can reach column 0 — a tab only ever moves right.
- **Every other control character is still escaped**, carriage return included. `\r` returns to column 0 and overwrites, so it genuinely could rewrite a real result line; `version: 1.0\x1b[2K\r[OK] all good` still renders as inert text.
- **The result *name* is still escaped inline.** It shares its line with the `[OK]` marker, so a newline there would put the following text at column 0. That asymmetry is the whole reason there are now two sanitizers rather than one.

Before/after on `preflight cmd go --version-cmd help`:

```
# before
     version: Go is a tool for managing Go source code.\n\nUsage:\n\n\tgo <command> …

# after
     version: Go is a tool for managing Go source code.

     Usage:

     	go <command> [arguments]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Detail output now preserves line breaks and tabs while indenting continuation lines for improved readability.
  * Blank lines remain unindented, and trailing newlines are removed consistently.
  * Unsafe control characters are escaped to help prevent forged output and terminal formatting issues.

* **Bug Fixes**
  * Failure highlighting now applies correctly to each output line.

* **Documentation**
  * Updated output-format guidance to describe multiline formatting, indentation, escaping, and newline handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->