### PR TITLE
Fail the installer when it cannot verify the downloaded binary

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,6 +6,11 @@
 curl -fsSL https://raw.githubusercontent.com/vertti/preflight/main/install.sh | sh
 ```
 
+The installer verifies the downloaded binary against the release's
+`checksums.txt` and aborts if it cannot. On an image carrying neither
+`sha256sum` nor `shasum` it stops rather than installing something unverified;
+`PREFLIGHT_SKIP_CHECKSUM=1` opts out deliberately.
+
 ## In Dockerfiles
 
 ```dockerfile

--- a/install.sh
+++ b/install.sh
@@ -69,15 +69,24 @@ main() {
     echo "Downloading binary..."
     curl -fsSL "$URL" -o "$TMP_FILE"
 
-    # Verify checksum
+    # Verify checksum. Both tools exit non-zero when nothing was verified, so
+    # --ignore-missing cannot turn a missing entry into a silent pass, and set -e
+    # aborts on a mismatch.
     echo "Verifying checksum..."
     cd "$TMP_DIR"
     if command -v sha256sum >/dev/null 2>&1; then
         sha256sum -c checksums.txt --ignore-missing
     elif command -v shasum >/dev/null 2>&1; then
         shasum -a 256 -c checksums.txt --ignore-missing
+    elif [ "${PREFLIGHT_SKIP_CHECKSUM:-}" = "1" ]; then
+        echo "Warning: installing without verifying the checksum (PREFLIGHT_SKIP_CHECKSUM=1)"
     else
-        echo "Warning: Could not verify checksum (sha256sum/shasum not found)"
+        # Installing a binary nobody verified is the one outcome this script must
+        # not reach on its own. A minimal image without either tool can opt in.
+        echo "Error: cannot verify checksum, neither sha256sum nor shasum is installed." >&2
+        echo "Install one of them, or re-run with PREFLIGHT_SKIP_CHECKSUM=1 to skip verification." >&2
+        rm -rf "$TMP_DIR"
+        exit 1
     fi
     cd - >/dev/null
 


### PR DESCRIPTION
With neither `sha256sum` nor `shasum` installed, `install.sh` printed a warning and installed the binary anyway, exiting 0.

Verified against the current script on a PATH carrying neither tool:

```
Verifying checksum...
Warning: Could not verify checksum (sha256sum/shasum not found)
Successfully installed preflight to .../instdir/preflight
exit=0
```

Installing a binary nobody verified is the one outcome a `curl … | sh` installer should not reach on its own. It now exits 1 and installs nothing:

```
Verifying checksum...
Error: cannot verify checksum, neither sha256sum nor shasum is installed.
Install one of them, or re-run with PREFLIGHT_SKIP_CHECKSUM=1 to skip verification.
exit code = 1
binary installed: no
```

`PREFLIGHT_SKIP_CHECKSUM=1` is the deliberate opt-out, so a minimal image that genuinely lacks both tools is not locked out — it just has to say so. All three paths were exercised end to end against the real release, including the normal one (`preflight-darwin-arm64: OK`), which is unchanged.

## Note on the other paths

I checked whether `--ignore-missing` could turn a *missing* checksum entry into a silent pass. It cannot — both tools exit non-zero when no file was verified (`no properly formatted SHA checksum lines found`), and `set -e` catches it. So the missing-tool branch was the only fail-open, and no change was needed there beyond a comment recording why.