### PR TITLE
Remove a redundant null branch and a stale gjson comment in jsoncheck

### DIFF
--- a/pkg/jsoncheck/check.go
+++ b/pkg/jsoncheck/check.go
@@ -29,15 +29,15 @@ func (c *Check) Run() check.Result {
 		return result.Failf("failed to read file: %v", err)
 	}
 
-	// Validate JSON syntax using encoding/json for detailed errors
+	// jsonpath.Valid answers yes or no; Unmarshal is what reports where the
+	// document went wrong, which is the only thing worth telling the user.
 	jsonStr := string(content)
 	if !jsonpath.Valid(jsonStr) {
-		// Use encoding/json to get detailed parse error
 		var v any
 		if err := json.Unmarshal(content, &v); err != nil {
 			return result.Failf("invalid JSON: %v", err)
 		}
-		// Fallback if gjson says invalid but encoding/json passes (shouldn't happen)
+		// Both are encoding/json underneath, so disagreeing would be a bug in it.
 		return result.Failf("invalid JSON")
 	}
 
@@ -58,11 +58,7 @@ func (c *Check) Run() check.Result {
 			return result.Failf("key %q not found", c.Key)
 		}
 
-		// Use String() for most values, but handle null specially
 		valueStr := jsonResult.String()
-		if jsonResult.IsNull() {
-			valueStr = "null"
-		}
 
 		// --exact: exact value match
 		if c.Exact != "" && valueStr != c.Exact {


### PR DESCRIPTION
Two small things, no behaviour change.

- `jsonpath.Result.String()` already returns `"null"` for a JSON null, so the `IsNull()` branch that assigned the same value was dead. The existing `key exact null` test covers the path and still passes.
- The comment credited `gjson` with deciding validity. That dependency was replaced by `pkg/jsonpath` some time ago; both calls are `encoding/json` underneath now, which is the actual reason the fallback is unreachable.

`IsNull()` itself stays — it is part of the `jsonpath` API and has its own tests.

## What I did not do

I had listed `check.Result.Err` as part of this cleanup and described it as write-only tidying. That was wrong, so I left it alone:

- `Fail(detail string, err error)` has **37 call sites across 5 packages**, and most build an error solely to hand to it. Removing the field means changing every one.
- Those helpers return `error` purely as control flow (`return err` to abort the check), so it is not a mechanical find-and-replace — it changes how each check signals "stop".
- Three tests read `Err`, including the `--hide-value` disclosure test in `envcheck`. That one also asserts on `Details`, which is what actually gets printed, so the guard would survive — but it is a real assertion, not incidental.

It is still dead in production (nothing outside tests reads it, and `Failf` formats the same string twice to populate it). Worth doing, but as its own deliberate refactor rather than folded into a tidy-up.