### PR TITLE
Make --exact "" assert an empty value in env and json checks

### DIFF
--- a/cmd/preflight/cmd_env.go
+++ b/cmd/preflight/cmd_env.go
@@ -70,7 +70,6 @@ func runEnvCheck(cmd *cobra.Command, args []string) error {
 		NotSet:     envNotSet,
 		AllowEmpty: envAllowEmpty,
 		Match:      envMatch,
-		Exact:      envExact,
 		OneOf:      envOneOf,
 		HideValue:  envHideValue,
 		MaskValue:  envMaskValue,
@@ -90,7 +89,11 @@ func runEnvCheck(cmd *cobra.Command, args []string) error {
 		Stater:     &envcheck.RealFileStater{},
 	}
 
-	// Only set MinValue/MaxValue if the flags were explicitly provided
+	// Only set these if the flags were explicitly provided. For --exact that is
+	// what makes `--exact ""` mean "must be empty" rather than "not given".
+	if cmd.Flags().Changed("exact") {
+		c.Exact = &envExact
+	}
 	if cmd.Flags().Changed("min-value") {
 		c.MinValue = &envMinValue
 	}

--- a/cmd/preflight/cmd_json.go
+++ b/cmd/preflight/cmd_json.go
@@ -30,11 +30,12 @@ func init() {
 	rootCmd.AddCommand(jsonCmd)
 }
 
-func runJSONCheck(_ *cobra.Command, args []string) error {
+func runJSONCheck(cmd *cobra.Command, args []string) error {
 	file := args[0]
 
 	// Validate flag combinations
-	if (jsonExact != "" || jsonMatch != "") && jsonKey == "" {
+	exactGiven := cmd.Flags().Changed("exact")
+	if (exactGiven || jsonMatch != "") && jsonKey == "" {
 		return errors.New("--exact and --match require --key to be set")
 	}
 
@@ -42,9 +43,14 @@ func runJSONCheck(_ *cobra.Command, args []string) error {
 		File:   file,
 		HasKey: jsonHasKey,
 		Key:    jsonKey,
-		Exact:  jsonExact,
 		Match:  jsonMatch,
 		FS:     &jsoncheck.RealFileSystem{},
+	}
+
+	// Only set if given, so `--exact ""` asserts the value is the empty string
+	// rather than reading as "no --exact".
+	if exactGiven {
+		c.Exact = &jsonExact
 	}
 
 	return runCheck(c)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -146,6 +146,13 @@ that fails still won't print the value. Neither flag reveals the value's exact
 length: `--min-len 32` on a hidden value reports
 `value length [hidden] < minimum 32`.
 
+`--exact ""` asserts the variable is empty, which needs `--allow-empty` too
+since an empty value fails by default:
+
+```sh
+preflight env OPTIONAL_OVERRIDE --allow-empty --exact ""
+```
+
 > **Values are printed by default.** `preflight env DATABASE_URL` reports
 > `value: postgres://user:password@host/db`. That is what you want for a
 > `MODEL_PATH` and not what you want for a credential, and the places preflight
@@ -286,6 +293,9 @@ preflight json <file> [flags]
 | `--key <path>`      | Key to check value of (dot notation for nested keys) |
 | `--exact <value>`   | Exact value required (requires `--key`)              |
 | `--match <pattern>` | Regex pattern for value (requires `--key`)           |
+
+`--exact ""` asserts the key's value is the empty string, as distinct from not
+passing `--exact` at all.
 
 ### Examples
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/vertti/preflight/pkg/resourcecheck"
 	"github.com/vertti/preflight/pkg/syscheck"
 	"github.com/vertti/preflight/pkg/tcpcheck"
+	"github.com/vertti/preflight/pkg/testutil"
 	"github.com/vertti/preflight/pkg/usercheck"
 )
 
@@ -295,7 +296,7 @@ func TestIntegration_JSON(t *testing.T) {
 	c = jsoncheck.Check{
 		File:  tmpFile.Name(),
 		Key:   "version",
-		Exact: "1.2.3",
+		Exact: testutil.Ptr("1.2.3"),
 		FS:    &jsoncheck.RealFileSystem{},
 	}
 

--- a/pkg/envcheck/check.go
+++ b/pkg/envcheck/check.go
@@ -18,7 +18,7 @@ type Check struct {
 	NotSet     bool       // --not-set: verify variable is NOT defined
 	AllowEmpty bool       // --allow-empty: pass if defined but empty
 	Match      string     // --match: regex pattern
-	Exact      string     // --exact: exact value
+	Exact      *string    // --exact: exact value (nil = flag not given, so "" is assertable)
 	OneOf      []string   // --one-of: value must be one of these
 	HideValue  bool       // --hide-value: don't show value in output
 	MaskValue  bool       // --mask-value: show first/last 3 chars
@@ -80,8 +80,8 @@ func (c *Check) Run() check.Result {
 	}
 
 	// --exact: exact value match
-	if c.Exact != "" && value != c.Exact {
-		return result.Failf("%q does not equal %q", c.formatValue(value), c.Exact)
+	if c.Exact != nil && value != *c.Exact {
+		return result.Failf("%q does not equal %q", c.formatValue(value), *c.Exact)
 	}
 
 	// --one-of: value must be one of the allowed values

--- a/pkg/envcheck/check_test.go
+++ b/pkg/envcheck/check_test.go
@@ -62,8 +62,14 @@ func TestEnvCheck_Run(t *testing.T) {
 		{"match pattern fails", Check{Name: "DATABASE_URL", Match: `^postgres://`, Getter: env(map[string]string{"DATABASE_URL": "mysql://localhost:3306/db"})}, check.StatusFail, `does not match pattern`},
 
 		// --exact
-		{"exact value passes", Check{Name: "NODE_ENV", Exact: "production", Getter: env(map[string]string{"NODE_ENV": "production"})}, check.StatusOK, ""},
-		{"exact value fails", Check{Name: "NODE_ENV", Exact: "production", Getter: env(map[string]string{"NODE_ENV": "development"})}, check.StatusFail, `does not equal "production"`},
+		{"exact value passes", Check{Name: "NODE_ENV", Exact: testutil.Ptr("production"), Getter: env(map[string]string{"NODE_ENV": "production"})}, check.StatusOK, ""},
+		{"exact value fails", Check{Name: "NODE_ENV", Exact: testutil.Ptr("production"), Getter: env(map[string]string{"NODE_ENV": "development"})}, check.StatusFail, `does not equal "production"`},
+
+		// Empty is a value like any other. It used to be indistinguishable from
+		// "--exact was not given", so asserting a variable is empty was impossible.
+		{"exact empty passes", Check{Name: "OPT", AllowEmpty: true, Exact: testutil.Ptr(""), Getter: env(map[string]string{"OPT": ""})}, check.StatusOK, ""},
+		{"exact empty fails on a set value", Check{Name: "OPT", AllowEmpty: true, Exact: testutil.Ptr(""), Getter: env(map[string]string{"OPT": "value"})}, check.StatusFail, `does not equal ""`},
+		{"no exact given checks nothing", Check{Name: "OPT", Getter: env(map[string]string{"OPT": "anything"})}, check.StatusOK, ""},
 
 		// --one-of
 		{"one-of passes", Check{Name: "NODE_ENV", OneOf: []string{"dev", "staging", "production"}, Getter: env(map[string]string{"NODE_ENV": "production"})}, check.StatusOK, ""},

--- a/pkg/jsoncheck/check.go
+++ b/pkg/jsoncheck/check.go
@@ -12,7 +12,7 @@ type Check struct {
 	File   string     // path to JSON file
 	HasKey string     // --has-key: check key exists (dot notation)
 	Key    string     // --key: key to check value of
-	Exact  string     // --exact: expected exact value (requires --key)
+	Exact  *string    // --exact: expected exact value (nil = flag not given, so "" is assertable)
 	Match  string     // --match: regex pattern for value (requires --key)
 	FS     FileSystem // injected for testing
 }
@@ -65,8 +65,8 @@ func (c *Check) Run() check.Result {
 		}
 
 		// --exact: exact value match
-		if c.Exact != "" && valueStr != c.Exact {
-			return result.Failf("value %q does not equal %q", valueStr, c.Exact)
+		if c.Exact != nil && valueStr != *c.Exact {
+			return result.Failf("value %q does not equal %q", valueStr, *c.Exact)
 		}
 
 		// --match: regex pattern

--- a/pkg/jsoncheck/check_test.go
+++ b/pkg/jsoncheck/check_test.go
@@ -44,10 +44,10 @@ func TestJSONCheck_Run(t *testing.T) {
 		{"has-key on non-object", Check{File: "f.json", HasKey: "name.nested", FS: fs(`{"name": "test"}`)}, check.StatusFail, `key "name.nested" not found`},
 
 		// --key + --exact
-		{"key exact match", Check{File: "f.json", Key: "env", Exact: "production", FS: fs(`{"env": "production"}`)}, check.StatusOK, "key env: production"},
-		{"key exact mismatch", Check{File: "f.json", Key: "env", Exact: "production", FS: fs(`{"env": "development"}`)}, check.StatusFail, `value "development" does not equal "production"`},
-		{"key exact nested", Check{File: "f.json", Key: "db.host", Exact: "localhost", FS: fs(`{"db": {"host": "localhost"}}`)}, check.StatusOK, "key db.host: localhost"},
-		{"key not found", Check{File: "f.json", Key: "missing", Exact: "value", FS: fs(`{"name": "test"}`)}, check.StatusFail, `key "missing" not found`},
+		{"key exact match", Check{File: "f.json", Key: "env", Exact: testutil.Ptr("production"), FS: fs(`{"env": "production"}`)}, check.StatusOK, "key env: production"},
+		{"key exact mismatch", Check{File: "f.json", Key: "env", Exact: testutil.Ptr("production"), FS: fs(`{"env": "development"}`)}, check.StatusFail, `value "development" does not equal "production"`},
+		{"key exact nested", Check{File: "f.json", Key: "db.host", Exact: testutil.Ptr("localhost"), FS: fs(`{"db": {"host": "localhost"}}`)}, check.StatusOK, "key db.host: localhost"},
+		{"key not found", Check{File: "f.json", Key: "missing", Exact: testutil.Ptr("value"), FS: fs(`{"name": "test"}`)}, check.StatusFail, `key "missing" not found`},
 
 		// --key + --match
 		{"key match pattern", Check{File: "f.json", Key: "version", Match: `^1\.`, FS: fs(`{"version": "1.2.3"}`)}, check.StatusOK, "key version: 1.2.3"},
@@ -55,9 +55,14 @@ func TestJSONCheck_Run(t *testing.T) {
 		{"key match invalid regex", Check{File: "f.json", Key: "version", Match: `[invalid`, FS: fs(`{"version": "1.0.0"}`)}, check.StatusFail, "invalid regex pattern"},
 
 		// Non-string value coercion
-		{"key exact number", Check{File: "f.json", Key: "port", Exact: "8080", FS: fs(`{"port": 8080}`)}, check.StatusOK, "key port: 8080"},
-		{"key exact boolean", Check{File: "f.json", Key: "enabled", Exact: "true", FS: fs(`{"enabled": true}`)}, check.StatusOK, "key enabled: true"},
-		{"key exact null", Check{File: "f.json", Key: "value", Exact: "null", FS: fs(`{"value": null}`)}, check.StatusOK, "key value: null"},
+		{"key exact number", Check{File: "f.json", Key: "port", Exact: testutil.Ptr("8080"), FS: fs(`{"port": 8080}`)}, check.StatusOK, "key port: 8080"},
+		{"key exact boolean", Check{File: "f.json", Key: "enabled", Exact: testutil.Ptr("true"), FS: fs(`{"enabled": true}`)}, check.StatusOK, "key enabled: true"},
+		{"key exact null", Check{File: "f.json", Key: "value", Exact: testutil.Ptr("null"), FS: fs(`{"value": null}`)}, check.StatusOK, "key value: null"},
+
+		// Empty is a value like any other. It used to be indistinguishable from
+		// "--exact was not given", so asserting a key is "" was impossible.
+		{"key exact empty string", Check{File: "f.json", Key: "name", Exact: testutil.Ptr(""), FS: fs(`{"name": ""}`)}, check.StatusOK, "key name: "},
+		{"key exact empty fails on a set value", Check{File: "f.json", Key: "name", Exact: testutil.Ptr(""), FS: fs(`{"name": "x"}`)}, check.StatusFail, `does not equal ""`},
 		{"key match float", Check{File: "f.json", Key: "rate", Match: `^0\.5`, FS: fs(`{"rate": 0.5}`)}, check.StatusOK, "key rate: 0.5"},
 	}
 


### PR DESCRIPTION
`Exact` was a `string` where `""` doubled as "flag not given", so asserting that a value *is* empty was impossible — `--exact ""` was silently ignored and the check passed regardless of the value.

It is now `*string`, set only when cobra reports the flag as `Changed`. That is the pattern `--min-value` and `--max-value` already used in the same command.

```sh
$ EMPTYVAR= preflight env EMPTYVAR --allow-empty --exact ""
[OK] env: EMPTYVAR
     value:

$ SETVAR=x preflight env SETVAR --allow-empty --exact ""
[FAIL] env: SETVAR
       "x" does not equal ""

$ preflight json config.json --key name --exact ""    # {"name": ""}
[OK] json: config.json
     syntax: valid
     key name:
```

In `env` this pairs with `--allow-empty`, since an empty value fails before the `--exact` comparison is reached otherwise. Documented that way.

## Also fixed by the same change

`cmd_json.go` validated `(jsonExact != "" || jsonMatch != "") && jsonKey == ""` — the same sentinel — so `--exact ""` without `--key` slipped past the requirement instead of being rejected. It now uses `Changed` and errors correctly.

Omitting `--exact` still checks nothing, verified explicitly.